### PR TITLE
Display Server Count, closes #22

### DIFF
--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -62,7 +62,7 @@ const PluginCard: React.FC<PluginCardProps> = ({ title, description, githubLink,
   return (
     <Card
       sx={{
-        height: '15rem',
+        height: '18rem',
         display: 'flex',
         flexDirection: 'column',
       }}

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -6,39 +6,98 @@ interface PluginCardProps {
     description: string
     githubLink: string
     spigotmcLink?: string
+    bStatsId?: string
 }
 
-const PluginCard: React.FC<PluginCardProps> = ({ title, description, githubLink, spigotmcLink }) => (
-  <Card
-    sx={{
-      height: '15rem',
-      display: 'flex',
-      flexDirection: 'column',
-    }}
-  >
-    <CardContent
+async function getServerCount(bStatsId: string) {
+  var functionName = 'getServerCount()'
+  var response = await fetch('https://bstats.org/api/v1/plugins/' + bStatsId + '/charts/servers/data?maxElements=1')
+  var data = await response.json()
+  // verify we have a list
+  if (!Array.isArray(data)) {
+    console.log(functionName + ' returned data that is not an array')
+
+    return
+  }
+  // verify that the list has at least one element
+  if (data.length < 1) {
+    console.log(functionName + ' returned data that has less than one element')
+    return
+  }
+  var firstElement = data[0]
+  // verify that the first element is an array
+  if (!Array.isArray(firstElement)) {
+    console.log(functionName + ' returned data that has a first element that is not an array')
+    return
+  }
+  // verify that the first element has at least 2 element
+  if (firstElement.length < 2) {
+    console.log(functionName + ' returned data that has a first element that has less than 2 elements')
+    return
+  }
+  var secondElementOfFirstElement = firstElement[1]
+  // verify that the second element of the first element is a number
+  if (typeof secondElementOfFirstElement !== 'number') {
+    console.log(functionName + ' returned data that has a first element that has a second element that is not a number')
+    return
+  }
+  var serverCount = secondElementOfFirstElement
+  return serverCount
+}
+
+const PluginCard: React.FC<PluginCardProps> = ({ title, description, githubLink, spigotmcLink, bStatsId }) => {
+  const [serverCount, setServerCount] = React.useState<number | undefined>(undefined);
+  
+  React.useEffect(() => {
+    if (!bStatsId) {
+      return
+    }
+    const fetchServerCount = async () => {
+      var serverCount = await getServerCount(bStatsId)
+      setServerCount(serverCount)
+    };
+
+    fetchServerCount();
+  } , []);
+  return (
+    <Card
       sx={{
-        flexGrow: 1
+        height: '15rem',
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
-      <Typography gutterBottom variant="h5" component="div">
-        {title}
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        {description}
-      </Typography>
-    </CardContent>
-    <CardActions
-      sx={{
-        flexGrow: 0
-      }}
-    >
-      <Button variant="contained" size="small" component={Link} href={githubLink}>GitHub</Button>
-      {
-        spigotmcLink ? <Button variant="contained" size="small" component={Link} href={spigotmcLink}>SpigotMC</Button> : null
-      }
-    </CardActions>
-  </Card>
-)
+      <CardContent
+        sx={{
+          flexGrow: 1
+        }}
+      >
+        <Typography gutterBottom variant="h5" component="div">
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {description}
+        </Typography>
+        {
+          // if serverCount is defined and greater than 0, display it
+          serverCount && serverCount > 0 ? <Typography variant="body2" color="text.secondary">
+            <br />
+            {serverCount} servers running
+          </Typography> : null
+        }
+      </CardContent>
+      <CardActions
+        sx={{
+          flexGrow: 0
+        }}
+      >
+        <Button variant="contained" size="small" component={Link} href={githubLink}>GitHub</Button>
+        {
+          spigotmcLink ? <Button variant="contained" size="small" component={Link} href={spigotmcLink}>SpigotMC</Button> : null
+        }
+      </CardActions>
+    </Card>
+  )
+}
 
 export default PluginCard;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ const ActivityTracker: React.FC = () => (
     description="Tracks the activity of players."
     githubLink="https://github.com/Dans-Plugins/Activity-Tracker"
     spigotmcLink="https://www.spigotmc.org/resources/activity-tracker.96724/"
+    bStatsId="12983"
   />
 )
 
@@ -25,6 +26,7 @@ const AlternateAccountFinder: React.FC = () => (
     description="Identifies accounts that have used the same IP address."
     githubLink="https://github.com/Dans-Plugins/AlternateAccountFinder"
     spigotmcLink="https://www.spigotmc.org/resources/alternate-account-finder.83290/"
+    bStatsId="9834"
   />
 )
 
@@ -34,6 +36,7 @@ const ConquestRecipes: React.FC = () => (
     description="Adds recipes for the many item textures that the Conquest Resource Pack adds to the game."
     githubLink="https://github.com/Dans-Plugins/Conquest-Recipes"
     spigotmcLink="https://www.spigotmc.org/resources/conquest-recipes.83594/"
+    // no bStats ID yet
   />
 )
 
@@ -43,6 +46,7 @@ const Currencies: React.FC = () => (
     description="An expansion for Medieval Factions that allows faction owners to create and mint local currencies."
     githubLink="https://github.com/Dans-Plugins/Currencies"
     spigotmcLink="https://www.spigotmc.org/resources/currencies.96381/"
+    bStatsId="12810"
   />
 )
 
@@ -52,6 +56,7 @@ const DansEssentials: React.FC = () => (
     description="Provides miscellaneous commands."
     githubLink="https://github.com/Dans-Plugins/Dans-Essentials"
     spigotmcLink="https://www.spigotmc.org/resources/dans-essentials.80513/"
+    bStatsId="9527"
   />
 )
 
@@ -61,6 +66,7 @@ const DansPluginManager: React.FC = () => (
     description="Allows operators to easily download the community's plugins in-game or through a server console."
     githubLink="https://github.com/Dans-Plugins/Dans-Plugin-Manager"
     spigotmcLink="https://www.spigotmc.org/resources/dans-plugin-manager-early-access.100279/"
+    // no bStats ID yet
   />
 )
 
@@ -70,6 +76,7 @@ const DansSetHome: React.FC = () => (
     description="Allows players to set and teleport to home locations."
     githubLink="https://github.com/Dans-Plugins/Dans-Set-Home"
     spigotmcLink="https://www.spigotmc.org/resources/dans-set-home.79986/"
+    bStatsId="12126"
   />
 )
 
@@ -79,6 +86,7 @@ const DansSpawnSystem: React.FC = () => (
     description="Allows players to use signs to select a custom spawn in their world."
     githubLink="https://github.com/Dans-Plugins/Dans-Spawn-System"
     spigotmcLink="https://www.spigotmc.org/resources/dans-spawn-system.82697/"
+    bStatsId="12161"
   />
 )
 
@@ -88,6 +96,7 @@ const Democracy: React.FC = () => (
     description="An expansion for MF that aims to allow nations to be democratic."
     githubLink="https://github.com/Dans-Plugins/Democracy"
     // no spigotmc link yet
+    // no bStats ID yet
   />
 )
 
@@ -97,6 +106,7 @@ const EasyLinks: React.FC = () => (
     description="Allows players to view relevant links with simple commands."
     githubLink="https://github.com/Dans-Plugins/Easy-Links"
     spigotmcLink="https://www.spigotmc.org/resources/easylinks-early-access.98040/"
+    // no bStats ID yet
   />
 )
 
@@ -106,6 +116,7 @@ const Fiefs: React.FC = () => (
     description="Allows players to create fiefs and manage them."
     githubLink="https://github.com/Dans-Plugins/Fiefs"
     spigotmcLink="https://www.spigotmc.org/resources/fiefs-early-access.98559/"
+    bStatsId="12743"
   />
 )
 
@@ -115,6 +126,7 @@ const FoodSpoilage: React.FC = () => (
     description="Makes food items turn into rotten flesh after a certain period of time."
     githubLink="https://github.com/Dans-Plugins/FoodSpoilage"
     spigotmcLink="https://www.spigotmc.org/resources/food-spoilage.81507/"
+    bStatsId="8992"
   />
 )
 
@@ -124,6 +136,7 @@ const KDRTracker: React.FC = () => (
     description="Keeps track of players' kill/death ratios."
     githubLink="https://github.com/Dans-Plugins/KDRTracker"
     // no spigotmc link yet
+    // no bStats ID yet
   />
 )
 
@@ -133,6 +146,7 @@ const Mailboxes: React.FC = () => (
     description="Allows players and plugins to send persistent messages to players."
     githubLink="https://github.com/Dans-Plugins/Mailboxes"
     spigotmcLink="https://www.spigotmc.org/resources/mailboxes.96611/"
+    bStatsId="12902"
   />
 )
 
@@ -142,6 +156,7 @@ const MedievalCookery: React.FC = () => (
     description="Allows server owners to add cooking recipes for an enhanced roleplay experience."
     githubLink="https://github.com/Dans-Plugins/Medieval-Cookery"
     // no spigotmc link yet
+    // no bStats ID yet
   />
 )
 
@@ -151,6 +166,7 @@ const MedievalEconomy: React.FC = () => (
     description="Provides a virtual coinpurse and a physical currency item for the purpose of simulating an economy."
     githubLink="https://github.com/Dans-Plugins/Medieval-Economy"
     spigotmcLink="https://www.spigotmc.org/resources/medieval-economy.81836/"
+    bStatsId="8998"
   />
 )
 
@@ -160,6 +176,7 @@ const MedievalFactions: React.FC = () => (
     description="Allows players to organize themselves into feudal, diplomatic, lawful groups akin to nations."
     githubLink="https://github.com/Dans-Plugins/Medieval-Factions"
     spigotmcLink="https://www.spigotmc.org/resources/medieval-factions.79941/"
+    bStatsId="8929"
   />
 )
 
@@ -169,6 +186,7 @@ const MedievalRoleplayEngine: React.FC = () => (
     description="Facilitates roleplay between players."
     githubLink="https://github.com/Dans-Plugins/Medieval-Roleplay-Engine"
     spigotmcLink="https://www.spigotmc.org/resources/medieval-roleplay-engine.79993/"
+    bStatsId="8996"
   />
 )
 
@@ -178,6 +196,7 @@ const MiniFactions: React.FC = () => (
     description="Aims to introduce factions into the game in a simple, easy to use, expandable way."
     githubLink="https://github.com/Dans-Plugins/MiniFactions"
     // no spigotmc link yet
+    // no bStats ID yet
   />
 )
 
@@ -187,6 +206,7 @@ const MoreRecipes: React.FC = () => (
     description="Adds static recipes for items that are not craftable in vanilla."
     githubLink="https://github.com/Dans-Plugins/More-Recipes"
     spigotmcLink="https://www.spigotmc.org/resources/more-recipes.81832/"
+    bStatsId="12140"
   />
 )
 
@@ -196,6 +216,7 @@ const NetherAccessController: React.FC = () => (
     description="Allows operators to control who has access to the nether."
     githubLink="https://github.com/Dans-Plugins/Nether-Access-Controller"
     spigotmcLink="https://www.spigotmc.org/resources/nether-access-controller.95905/"
+    bStatsId="12673"
   />
 )
 
@@ -205,6 +226,7 @@ const NoMoreCreepers: React.FC = () => (
     description="Prevents creepers from spawning."
     githubLink="https://github.com/Dans-Plugins/NoMoreCreepers"
     spigotmcLink="https://www.spigotmc.org/resources/nomorecreepers.97946/"
+    bStatsId="13432"
   />
 )
 
@@ -214,6 +236,7 @@ const PlayerLore: React.FC = () => (
     description="Aims to allow players to add lore to their items in Minecraft."
     githubLink="https://github.com/Dans-Plugins/PlayerLore"
     spigotmcLink="https://www.spigotmc.org/resources/playerlore.98602/"
+    bStatsId="17025"
   />
 )
 
@@ -223,6 +246,7 @@ const SimpleSkills: React.FC = () => (
     description="Introduces skills into the game in a systematic, easy to use, expandable way."
     githubLink="https://github.com/Dans-Plugins/SimpleSkills"
     spigotmcLink="https://www.spigotmc.org/resources/simpleskills.98039/"
+    bStatsId="13470"
   />
 )
 
@@ -232,6 +256,7 @@ const WildPets: React.FC = () => (
     description="Allows players to tame any entity and keep them as a pet."
     githubLink="https://github.com/Dans-Plugins/Wild-Pets"
     spigotmcLink="https://www.spigotmc.org/resources/wild-pets.95800/"
+    bStatsId="12332"
   />
 )
 
@@ -355,17 +380,17 @@ const AllPlugins: React.FC = () => (
 )
 
 const Home: NextPage = () => (
-    <Box sx={{ flexGrow: 1 }}>
-      <TopBar />
-      <Container maxWidth="xl">
-        <Blurb />
-        <br />
-        <MostPopularPlugins />
-        <br />
-        <AllPlugins />
-      </Container>
-      <BottomBar version={version}/>
-    </Box>
+  <Box sx={{ flexGrow: 1 }}>
+    <TopBar />
+    <Container maxWidth="xl">
+      <Blurb />
+      <br />
+      <MostPopularPlugins />
+      <br />
+      <AllPlugins />
+    </Container>
+    <BottomBar version={version}/>
+  </Box>
 )
 
 export default Home


### PR DESCRIPTION
The server count now gets displayed in plugin cards for plugins with bStats support.

![image](https://github.com/Dans-Plugins/dpc-website/assets/21204351/1e67424a-e1b3-4fbd-8a43-01fecc65ef13)

![image](https://github.com/Dans-Plugins/dpc-website/assets/21204351/d2298293-ad42-41f2-a329-7c6f1c7f17b3)

