### PR TITLE
Playtest Server Link & Expanded Blurb

### DIFF
--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -4,10 +4,19 @@ import React from 'react';
 const Blurb: React.FC = () => (
     <Box sx={{ flexGrow: 1, p: 2 }}>
         <Typography variant="body1" gutterBottom>
-        Welcome to the Dan&apos;s Plugins Community website!
+            Welcome to the Dan&apos;s Plugins Community website!
         </Typography>
         <Typography variant="body1" gutterBottom>
-        This website is a hub for all of the plugins that are maintained by the community. If you&apos;d like to contribute, please visit the relevant GitHub repository.
+            This website is a hub for all of the plugins that are maintained by or related to the community.
+        </Typography>
+        <Typography>
+            To contribute to a project, click on the relevant `GitHub` link below. If there is a CONTRIBUTING.md for the project, be sure to read it.
+        </Typography>
+        <Typography>
+            To download a plugin, click on the relevant `SpigotMC` link below. The Spigot page will have a download button.
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+            To join the playtest server, open a Minecraft client and enter `dansplugins.com` as the IP address for the server you want to connect to.
         </Typography>
     </Box>
 )

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -22,9 +22,10 @@ const TopBar: React.FC = () => {
           </Typography>
           <Button color="inherit" href="/">Home</Button>
           <Button color="inherit" href="/guides">Guides</Button>
-          <Button color="inherit" href="https://github.com/Dans-Plugins">GitHub</Button>
-          <Button color="inherit" href="https://discord.gg/xXtuAQ2">Discord</Button>
-          <Button color="inherit" href="https://www.linkedin.com/company/dansplugins">LinkedIn</Button>
+          <Button color="inherit" href="https://github.com/Dans-Plugins">GitHub*</Button>
+          <Button color="inherit" href="https://discord.gg/xXtuAQ2">Discord*</Button>
+          <Button color="inherit" href="https://www.planetminecraft.com/server/dan-s-plugins-community-playtest-server/">Playtest Server*</Button>
+          <Button color="inherit" href="https://www.linkedin.com/company/dansplugins">LinkedIn*</Button>
         </Box>
         <Box sx={{ flexGrow: 0 }}>
           <ColorModeToggleSwitch


### PR DESCRIPTION
## Problem
The website does not provide much guidance in general, and there is no mention of the playtest server.

## Solution
A link to the PMC page for the playtest server has been added and some guidance has been added to the Blurb.

## Testing
This was tested locally using docker compose & Docker Desktop.

## Additional Changes
- Added '*' to external links