### PR TITLE
Added restart policy to `compose.yml`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,3 +6,5 @@ services:
       - "3000:3000"
     volumes:
       - ./node_modules:/app/node_modules
+    restart: always
+    


### PR DESCRIPTION
## Problem
If the host server reboots, the compose.yml file is not currently configured to restart the container once it comes back up.

## Solution
A restart policy of 'always' has been added to `compose.yml`