### PR TITLE
Move GitHub & PMC Links to Blurb Components; Add SpigotMC Link to Download Blurb

### DIFF
--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -14,9 +14,25 @@ import {
     infoCardIconSizeStyle
 } from '../styles/styles';
 
-const InfoCard: React.FC<{ icon: React.ReactNode; title: string; content: string }> = ({icon, title, content}) => (
+const InfoCard: React.FC<{
+    icon: React.ReactNode;
+    title: string;
+    content: string;
+    href?: string
+}> = ({icon, title, content, href}) => (
     <Grid item xs={12} md={4}>
-        <Paper elevation={3} sx={(theme) => infoCardStyle(theme)}>
+        <Paper
+            elevation={3}
+            sx={(theme) => ({
+                ...infoCardStyle(theme),
+                cursor: href ? 'pointer' : 'default',
+                '&:hover': href ? {
+                    transform: 'scale(1.02)',
+                    transition: 'transform 0.2s ease-in-out'
+                } : {}
+            })}
+            onClick={() => href && window.open(href, '_blank')}
+        >
             <Box sx={(theme) => infoCardIconStyle(theme)}>
                 {icon}
             </Box>
@@ -43,16 +59,19 @@ const Blurb: React.FC = () => (
                 icon={<GitHubIcon sx={infoCardIconSizeStyle}/>}
                 title="Contribute"
                 content="Join our open-source community on GitHub. Check out the CONTRIBUTING.md in each project to get started."
+                href="https://github.com/Dans-Plugins"
             />
             <InfoCard
                 icon={<DownloadIcon sx={infoCardIconSizeStyle}/>}
                 title="Download"
                 content="Get our plugins from SpigotMC. Each plugin page contains detailed installation instructions and documentation."
+                href="https://www.spigotmc.org/resources/authors/danthetechman.659208/"
             />
             <InfoCard
                 icon={<GamesIcon sx={infoCardIconSizeStyle}/>}
                 title="Try it Out"
                 content="Join our playtest server at dansplugins.com to experience our plugins in action!"
+                href="https://www.planetminecraft.com/server/dan-s-plugins-community-playtest-server/"
             />
         </Grid>
     </Box>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -3,7 +3,6 @@ import React, {useContext} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
 
-// Import styles
 import {
     appBarStyle,
     navButtonStyle,
@@ -13,7 +12,6 @@ import {
     flexContainerStyle
 } from '../styles/styles';
 
-// Enhanced button component with hover effects
 const NavButton: React.FC<{ href: string; children: React.ReactNode }> = ({href, children}) => (
     <Button
         color="inherit"
@@ -24,7 +22,6 @@ const NavButton: React.FC<{ href: string; children: React.ReactNode }> = ({href,
     </Button>
 );
 
-// Component for the brand name
 const BrandName: React.FC = () => (
     <Typography
         variant="h6"
@@ -52,12 +49,7 @@ const TopBar: React.FC = () => {
                     <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
                         <NavButton href="/">Home</NavButton>
                         <NavButton href="/guides">Guides</NavButton>
-                        <NavButton href="https://github.com/Dans-Plugins">GitHub</NavButton>
                         <NavButton href="https://discord.gg/xXtuAQ2">Discord</NavButton>
-                        <NavButton
-                            href="https://www.planetminecraft.com/server/dan-s-plugins-community-playtest-server/">
-                            Playtest Server
-                        </NavButton>
                         <NavButton href="https://www.patreon.com/danspluginscommunity">Patreon</NavButton>
                         <NavButton href="https://www.linkedin.com/company/dansplugins">LinkedIn</NavButton>
                         <NavButton href="https://github.com/RP-Kit/RPKit">RPKit</NavButton>


### PR DESCRIPTION
## Problem  
The TopBar UI is too cluttered, and the Blurb components lack interactivity.

## Solution  
- Moved the GitHub and PMC (Planet Minecraft) links from the TopBar into their respective Blurb components.  
- Made the "Download" Blurb component link directly to the SpigotMC page.

## Testing  
Tested locally in Docker; all links function as expected and the UI appears cleaner.
