### PR TITLE
docs: document monorepo layout and dpc-api CORS configuration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,13 +6,27 @@ making any changes.
 
 ## Technology Stack
 
+This repository is a monorepo containing a frontend and a backend.
+
+### Frontend (repository root)
+
 - Language: TypeScript
 - Framework: Next.js (React)
 - Build tool: npm
 - Styling: MUI (Material UI) with Emotion
 - Target platform: Node.js web server (Next.js server via `next start`)
 
+### Backend (`dpc-api/`)
+
+- Language: Java
+- Framework: Spring Boot (Spring Web, Spring Data JPA, Spring Security)
+- Build tool: Maven (`./mvnw`)
+- Database: PostgreSQL with Flyway migrations
+- Target platform: JVM service (exposes the DPC community data REST API, e.g. faction sync)
+
 ## Project Structure
+
+### Frontend (repository root)
 
 - `pages/` – Next.js pages (each file is a route)
 - `components/` – Reusable React components
@@ -21,12 +35,28 @@ making any changes.
 - `utils/` – Shared utility functions
 - `services/` – Data-fetching or business-logic services
 
+### Backend
+
+- `dpc-api/` – Spring Boot REST API (Java + Maven). See `dpc-api/README.md`
+  for backend setup, endpoints, and configuration. Changes that touch the API
+  contract, sync logic, or backend configuration live here.
+
 ## Coding Conventions
+
+Frontend (repository root):
 
 - Use TypeScript for all new files.
 - Follow the existing component structure when adding new pages or components.
 - Use MUI components for UI elements to stay consistent with the existing design.
 - Keep user-facing text in components readable and consistent with the site's tone.
+
+Backend (`dpc-api/`):
+
+- Follow the existing Spring Boot package layout (controllers, services, config, filters).
+- Document backend configuration in `dpc-api/README.md`.
+
+All code:
+
 - Do not hard-code environment-specific values; use environment variables instead.
 
 ## Contribution Workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Documented the `dpc-api` backend's `DPC_CORS_ALLOWED_ORIGINS` configuration variable (CORS allowed origins, default `*`) in `dpc-api/README.md`, and wired it explicitly in `application.yml` to match the existing `DPC_SYNC_*` configuration pattern.
+
+### Changed
+
+- Updated `.github/copilot-instructions.md` to describe the monorepo layout: the Next.js/TypeScript frontend at the repository root and the Spring Boot/Java backend under `dpc-api/`.
+
 ## [0.9.0] – 2022-07-01
 
 ### Added

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -62,6 +62,7 @@ Configuration is managed via environment variables:
 | `DB_PASSWORD` | *(required)* | Database password |
 | `JWT_SECRET` | *(required)* | Secret key for JWT signing (min 32 bytes) |
 | `JWT_EXPIRATION` | `24h` | JWT token expiration duration |
+| `DPC_CORS_ALLOWED_ORIGINS` | `*` | Comma-separated list of origins allowed to call the API (CORS). The `*` default allows **all** origins; set this explicitly to the site origin(s) in production (e.g. `https://dansplugins.com`). |
 | `DPC_SYNC_MIN_INCOMING` | `2` | Minimum batch size eligible to deactivate factions (see [Sync safety guards](#sync-safety-guards)) |
 | `DPC_SYNC_MAX_DEACTIVATION_RATIO` | `0.5` | Fraction cap on factions one sync may deactivate |
 | `DPC_SYNC_MAX_DEACTIVATIONS` | `1000` | Absolute cap on factions one sync may deactivate (`0` disables) |

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -22,6 +22,11 @@ dpc:
   jwt:
     secret: ${JWT_SECRET}
     expiration: ${JWT_EXPIRATION:24h}
+  cors:
+    # Comma-separated list of origins allowed to call the API (CORS).
+    # The `*` default allows all origins; set this explicitly to the site
+    # origin(s) in production, e.g. https://dansplugins.com
+    allowed-origins: ${DPC_CORS_ALLOWED_ORIGINS:*}
   sync:
     safety:
       # Smallest incoming batch that may deactivate factions. Smaller batches


### PR DESCRIPTION
## Summary

Closes two documentation-drift gaps left behind when the `dpc-api` Spring Boot backend was added to this repository (PR #110).

- **Monorepo layout (`#112`):** `.github/copilot-instructions.md` described a frontend-only project. It now documents both halves of the monorepo — the Next.js/TypeScript frontend at the repo root and the Spring Boot/Java/Maven backend under `dpc-api/` — across the Technology Stack, Project Structure, and Coding Conventions sections, and points at `dpc-api/README.md` for backend details.
- **CORS configuration (`#113`):** the API reads `dpc.cors.allowed-origins` with a wildcard (`*`) default in `SecurityConfig`, but it was documented nowhere. Added a Configuration-table row for `DPC_CORS_ALLOWED_ORIGINS` in `dpc-api/README.md`, and wired the property explicitly in `application.yml` (`allowed-origins: ${DPC_CORS_ALLOWED_ORIGINS:*}`) so it matches the existing `DPC_SYNC_*` env-var pattern. Behavior is unchanged — the default remains `*`.

## Test plan

- [x] `npm run lint` — no ESLint warnings or errors
- [x] `npm run build` — compiled successfully (5/5 pages generated)
- [x] Confirmed `application.yml`'s new `dpc.cors.allowed-origins` key matches the `@Value("${dpc.cors.allowed-origins:*}")` placeholder in `SecurityConfig.java` (default `*` preserved — behavior-neutral)
- [x] Verified every claim in both issues against source before editing (localization check)

This PR is documentation/config-only; no frontend TypeScript and no faction-sync logic is touched.

## Issues skipped this cycle (deferred, not value judgments)

- `#114`, `#115` — visit-storage robustness **bugs**; deferred to a focused visit-counter hardening cycle so the fixes and a regression trace land together.
- `#116` — frontend **test harness**; large enhancement, out of scope for a docs batch.
- `#117` — VisitCounter **dead-code removal**; a separate small refactor, kept out to keep this PR docs-coherent.
- `#23`, `#24`, `#40`, `#57`, `#73`, `#87`, `#106` — larger **feature requests**; too large for this cycle.

Closes #112
Closes #113

---

_drafted by Claude on behalf of Daniel Stephenson_
