### PR TITLE
docs: document NEXT_PUBLIC_BASE_URL in CONFIG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Documented the `dpc-api` backend's `DPC_CORS_ALLOWED_ORIGINS` configuration variable (CORS allowed origins, default `*`) in `dpc-api/README.md`, and wired it explicitly in `application.yml` to match the existing `DPC_SYNC_*` configuration pattern.
+- Documented the `NEXT_PUBLIC_BASE_URL` environment variable (read by `services/visitService.ts`, default `http://localhost:3000`) in `CONFIG.md`.
 
 ### Changed
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -30,6 +30,18 @@ NEXT_PUBLIC_SITE_URL=https://dansplugins.com
 NEXT_PUBLIC_API_URL=https://api.dansplugins.com
 ```
 
+### `NEXT_PUBLIC_BASE_URL`
+
+**Type:** string  
+**Default:** `http://localhost:3000`  
+**Description:** The site's own base URL, used by the frontend for calls to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`). Set this to the site's public origin when deploying so server-side rendering can reach its own API routes. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend.
+
+**Example:**
+
+```env
+NEXT_PUBLIC_BASE_URL=https://dansplugins.com
+```
+
 ## Docker Compose Configuration
 
 When running the site with Docker Compose, environment variables can be placed in a `.env.local` file in the project root. Files matching the `.env*.local` pattern are excluded from version control via `.gitignore`.


### PR DESCRIPTION
## Summary

`services/visitService.ts` reads `NEXT_PUBLIC_BASE_URL` (default `http://localhost:3000`) for its internal Next.js API calls, but the variable was missing from `CONFIG.md`. This adds an Environment Variables entry documenting its purpose, default, and how it differs from `NEXT_PUBLIC_API_URL` (which targets the separate DPC API backend).

## Test plan

- [x] `npm run lint` — no ESLint warnings or errors
- [x] Confirmed the variable is read at `services/visitService.ts:6` and was absent from `CONFIG.md` before this change
- [x] Documentation-only; no code paths affected

Closes #120

_drafted by Claude on behalf of Daniel Stephenson_