### PR TITLE
feat: add About Us, Road Map, and Commissions pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added an **About Us** page (`/about`) introducing the community, with links to GitHub, Discord, and Patreon.
+- Added a **Road Map** page (`/roadmap`) that lists planned, in-progress, and completed work, driven by an editable `pages/data/roadmap.json`.
+- Added a **Commissions** page (`/commissions`) with a pricing table, what's-included list, availability status, and a link to the commissions Discord, driven by an editable `pages/data/commissions.json`.
+- Added **About**, **Road Map**, and **Commissions** links to the top navigation bar.
 - Added a frontend test harness (Vitest) with a `npm test` script, an initial suite covering `utils/bstats.ts`, `utils/visitStorage.ts`, and the `pages/api/visits.ts` handler, and a `Test` step in the CI workflow.
 - Documented the `dpc-api` backend's `DPC_CORS_ALLOWED_ORIGINS` configuration variable (CORS allowed origins, default `*`) in `dpc-api/README.md`, and wired it explicitly in `application.yml` to match the existing `DPC_SYNC_*` configuration pattern.
 - Documented the `NEXT_PUBLIC_BASE_URL` environment variable (read by `services/visitService.ts`, default `http://localhost:3000`) in `CONFIG.md`.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -20,6 +20,24 @@ No special software is required to use the website. Simply visit [https://danspl
 2. Browse the plugin cards displayed on the page.
 3. Click a plugin card to open its details or external page.
 
+### Learning About the Community
+
+1. Click **About** in the top navigation bar (or visit `/about`).
+2. Read the overview of Dan's Plugins Community.
+3. Use the GitHub, Discord, or Patreon links to get involved.
+
+### Viewing the Road Map
+
+1. Click **Road Map** in the top navigation bar (or visit `/roadmap`).
+2. Review the planned, in-progress, and completed work.
+3. Follow the linked GitHub issue tracker for day-to-day detail.
+
+### Requesting a Commission
+
+1. Click **Commissions** in the top navigation bar (or visit `/commissions`).
+2. Review the pricing options, what's included, and the current availability status.
+3. Click **Join the Commissions Discord** to discuss your project.
+
 ### Getting Support
 
 If you need help with any DPC plugin, join the community Discord:

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -50,6 +50,9 @@ const TopBar: React.FC = () => {
                         <NavButton href="/">Home</NavButton>
                         <NavButton href="/guides">Guides</NavButton>
                         <NavButton href="/leaderboard">Leaderboard</NavButton>
+                        <NavButton href="/about">About</NavButton>
+                        <NavButton href="/roadmap">Road Map</NavButton>
+                        <NavButton href="/commissions">Commissions</NavButton>
                         <NavButton href="/account">Account</NavButton>
                         <NavButton href="https://discord.gg/xXtuAQ2">Discord</NavButton>
                         <NavButton href="https://www.patreon.com/danspluginscommunity">Patreon</NavButton>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,65 @@
+import {Box, Button, Container, Typography} from '@mui/material';
+import type {NextPage} from 'next';
+import TopBar from '../components/TopBar';
+import React from 'react';
+import BottomBar from '../components/BottomBar';
+
+// Import styles
+import {pageStyle, sectionHeaderStyle, pluginsBoxStyle, containerPaddingStyle} from '../styles/styles';
+
+// Pull version from package.json
+const version = require('../package.json').version;
+
+const About: NextPage = () => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <TopBar/>
+        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                About Us
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+                Dan&apos;s Plugins Community (DPC) is an open-source community that builds plugins for
+                Minecraft servers. It is best known for Medieval Factions and a catalogue of
+                complementary plugins, all developed in the open and free to use.
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+                Our goal is to give server owners and players reliable, well-documented plugins, and to
+                grow a welcoming community around them. Every project is open source, so anyone can
+                read the code, report issues, or contribute improvements.
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+                Want to get involved? Join the conversation on Discord, support development on Patreon,
+                or browse the source on GitHub.
+            </Typography>
+            <Box sx={pluginsBoxStyle}>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    href="https://github.com/Dans-Plugins"
+                    sx={{mr: 1, mb: 1}}
+                >
+                    GitHub
+                </Button>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    href="https://discord.gg/xXtuAQ2"
+                    sx={{mr: 1, mb: 1}}
+                >
+                    Discord
+                </Button>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    href="https://www.patreon.com/danspluginscommunity"
+                    sx={{mr: 1, mb: 1}}
+                >
+                    Patreon
+                </Button>
+            </Box>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default About;

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -1,0 +1,126 @@
+import {
+    Box,
+    Button,
+    Chip,
+    Container,
+    List,
+    ListItem,
+    ListItemText,
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography
+} from '@mui/material';
+import type {NextPage} from 'next';
+import TopBar from '../components/TopBar';
+import React from 'react';
+import BottomBar from '../components/BottomBar';
+
+// Import styles
+import {pageStyle, sectionHeaderStyle, pluginsBoxStyle, containerPaddingStyle} from '../styles/styles';
+
+// Pull version from package.json
+const version = require('../package.json').version;
+
+interface CommissionTier {
+    name: string;
+    description: string;
+    oneTime: string;
+    retainer: string;
+    adHoc: string;
+}
+
+interface CommissionsData {
+    availability: 'open' | 'closed';
+    discordInvite: string;
+    tiers: CommissionTier[];
+    included: string[];
+}
+
+const commissionsData = require('./data/commissions.json') as CommissionsData;
+
+const Commissions: NextPage = () => {
+    const isOpen = commissionsData.availability === 'open';
+
+    return (
+        <Box sx={(theme) => pageStyle(theme)}>
+            <TopBar/>
+            <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+                <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>
+                    <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                        Commissions
+                    </Typography>
+                    <Chip
+                        label={isOpen ? 'Open for commissions' : 'Currently closed'}
+                        color={isOpen ? 'success' : 'default'}
+                    />
+                </Box>
+                <Typography variant="body1" gutterBottom>
+                    Custom Minecraft plugin development by the creator of the Dan&apos;s Plugins Community
+                    catalogue. Whether you need an existing plugin fixed and extended or a brand-new plugin
+                    built to your specification, the pricing options below cover one-time projects, monthly
+                    retainers, and ad-hoc hourly work.
+                </Typography>
+
+                <TableContainer component={Paper} sx={{mt: 3, mb: 3}}>
+                    <Table aria-label="commission pricing">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Service</TableCell>
+                                <TableCell>One-time</TableCell>
+                                <TableCell>Monthly retainer</TableCell>
+                                <TableCell>Ad hoc</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {commissionsData.tiers.map((tier) => (
+                                <TableRow key={tier.name}>
+                                    <TableCell>
+                                        <Typography variant="subtitle1">{tier.name}</Typography>
+                                        <Typography variant="body2" color="text.secondary">
+                                            {tier.description}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>{tier.oneTime}</TableCell>
+                                    <TableCell>{tier.retainer}</TableCell>
+                                    <TableCell>{tier.adHoc}</TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+
+                <Typography variant="h5" gutterBottom>What&apos;s included</Typography>
+                <List dense>
+                    {commissionsData.included.map((item) => (
+                        <ListItem key={item} sx={{display: 'list-item', listStyleType: 'disc', ml: 3, py: 0}}>
+                            <ListItemText primary={item}/>
+                        </ListItem>
+                    ))}
+                </List>
+
+                <Typography variant="body1" sx={{mt: 2}} gutterBottom>
+                    To discuss a commission, join the commissions Discord server:
+                </Typography>
+                <Box sx={pluginsBoxStyle}>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        href={commissionsData.discordInvite}
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        Join the Commissions Discord
+                    </Button>
+                </Box>
+            </Container>
+            <BottomBar version={version}/>
+        </Box>
+    );
+};
+
+export default Commissions;

--- a/pages/data/commissions.json
+++ b/pages/data/commissions.json
@@ -1,0 +1,25 @@
+{
+  "availability": "open",
+  "discordInvite": "https://discord.gg/VSe2cpfj5",
+  "tiers": [
+    {
+      "name": "Fork & Repair",
+      "description": "Fix, update, or extend an existing plugin (yours or an abandoned open-source one).",
+      "oneTime": "$200 – $400",
+      "retainer": "$75 / mo",
+      "adHoc": "$45 / hr"
+    },
+    {
+      "name": "Custom Plugin",
+      "description": "A new plugin built to your specification from the ground up.",
+      "oneTime": "$800 – $1,500",
+      "retainer": "$100 / mo",
+      "adHoc": "$45 / hr"
+    }
+  ],
+  "included": [
+    "Full source code ownership",
+    "Documentation for the delivered work",
+    "30-day bug-fix guarantee after delivery"
+  ]
+}

--- a/pages/data/roadmap.json
+++ b/pages/data/roadmap.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "Single source of truth for the DPC website/plugin road map. Edit the items below to keep it current; each item has a title, description, and status of 'Completed', 'In Progress', or 'Planned'. The live issue tracker linked on the page holds the day-to-day detail.",
+  "items": [
+    {
+      "title": "Community Data API",
+      "description": "A backend API (dpc-api) that lets Medieval Factions servers publish faction data to a shared community registry.",
+      "status": "Completed"
+    },
+    {
+      "title": "Factions Leaderboard",
+      "description": "A public leaderboard on the website showing community factions synced from participating servers.",
+      "status": "Completed"
+    },
+    {
+      "title": "Account Management & API Keys",
+      "description": "Register an account and manage API keys used by plugins to sync data.",
+      "status": "Completed"
+    },
+    {
+      "title": "Visit-Counter Reliability",
+      "description": "Crash-tolerant visit storage and a home page that degrades gracefully when the counter is unavailable.",
+      "status": "Completed"
+    },
+    {
+      "title": "Automated Test Harness",
+      "description": "A Vitest test suite, run in CI, covering the site's highest-value logic.",
+      "status": "Completed"
+    },
+    {
+      "title": "About, Road Map & Commissions Pages",
+      "description": "Informational pages introducing the community, its plans, and custom-development availability.",
+      "status": "In Progress"
+    },
+    {
+      "title": "News Page",
+      "description": "A news page surfacing community announcements, including posts pulled from the Discord server.",
+      "status": "Planned"
+    },
+    {
+      "title": "Editable Plugin Catalogue",
+      "description": "Allow the plugin cards data to be edited from the website instead of by hand.",
+      "status": "Planned"
+    },
+    {
+      "title": "TLS via Reverse Proxy",
+      "description": "An nginx reverse proxy in the Docker Compose setup to enable HTTPS.",
+      "status": "Planned"
+    }
+  ]
+}

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -1,0 +1,75 @@
+import {Box, Chip, Container, Link, Paper, Typography} from '@mui/material';
+import type {NextPage} from 'next';
+import TopBar from '../components/TopBar';
+import React from 'react';
+import BottomBar from '../components/BottomBar';
+
+// Import styles
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
+
+// Pull version from package.json
+const version = require('../package.json').version;
+
+interface RoadmapItem {
+    title: string;
+    description: string;
+    status: 'Completed' | 'In Progress' | 'Planned';
+}
+
+interface RoadmapData {
+    items: RoadmapItem[];
+}
+
+const roadmapData = require('./data/roadmap.json') as RoadmapData;
+
+// Display order and the MUI Chip colour used for each status.
+const STATUS_ORDER: { status: RoadmapItem['status']; color: 'success' | 'warning' | 'info' }[] = [
+    {status: 'In Progress', color: 'warning'},
+    {status: 'Planned', color: 'info'},
+    {status: 'Completed', color: 'success'}
+];
+
+const RoadmapCard: React.FC<{ item: RoadmapItem; color: 'success' | 'warning' | 'info' }> = ({item, color}) => (
+    <Paper elevation={3} sx={{p: 2, mb: 2}}>
+        <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
+            <Typography variant="h6">{item.title}</Typography>
+            <Chip label={item.status} color={color} size="small"/>
+        </Box>
+        <Typography variant="body2" sx={{mt: 1}}>{item.description}</Typography>
+    </Paper>
+);
+
+const Roadmap: NextPage = () => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <TopBar/>
+        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                Road Map
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+                This page tracks where Dan&apos;s Plugins Community is headed. For the day-to-day detail,
+                see the{' '}
+                <Link href="https://github.com/Dans-Plugins/dansplugins-dot-com/issues" target="_blank" rel="noopener">
+                    issue tracker on GitHub
+                </Link>.
+            </Typography>
+            {STATUS_ORDER.map(({status, color}) => {
+                const items = roadmapData.items.filter((item) => item.status === status);
+                if (items.length === 0) {
+                    return null;
+                }
+                return (
+                    <Box key={status} sx={{mt: 4}}>
+                        <Typography variant="h5" gutterBottom>{status}</Typography>
+                        {items.map((item) => (
+                            <RoadmapCard key={item.title} item={item} color={color}/>
+                        ))}
+                    </Box>
+                );
+            })}
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default Roadmap;


### PR DESCRIPTION
## Summary

Adds the three community content pages and wires them into the top navigation. Each page matches the existing `guides.tsx` page structure and uses MUI components only. Content for the Road Map and Commissions pages lives in editable JSON data files so it can be updated without touching the components.

### Pages
- **About Us** (`/about`) — overview of Dan's Plugins Community with GitHub, Discord, and Patreon links. (#73)
- **Road Map** (`/roadmap`) — work grouped into **In Progress / Planned / Completed**, rendered from `pages/data/roadmap.json`, with a link to the GitHub issue tracker as the live source of day-to-day detail. (#40)
- **Commissions** (`/commissions`) — pricing table (Fork & Repair / Custom Plugin × one-time / retainer / ad-hoc), a what's-included list, an availability status chip, and a prominent link to the commissions Discord, rendered from `pages/data/commissions.json`. Content matches the spec in #106. (#106)

### Navigation
Added **About**, **Road Map**, and **Commissions** links to `TopBar`, grouped with the other internal site pages.

## Content you should review / can edit
- **Commissions** (`pages/data/commissions.json`) — pricing, inclusions, Discord invite, and `availability` (`open`/`closed`) come straight from #106; flip `availability` to `closed` anytime to update the status chip.
- **Road Map** (`pages/data/roadmap.json`) — seeded from the repo's actual shipped and open work as a starting point; please curate the items/wording to match your real plans (it's a plain JSON list).
- **About** (`pages/about.tsx`) — copy is grounded in the existing site blurb/README; adjust the wording/voice as you see fit.

## Test plan
- [x] `npm run lint` — no ESLint warnings or errors
- [x] `npm run build` — compiled successfully; `/about`, `/roadmap`, `/commissions` generated as static routes
- [x] `npm test` — 16/16 (no regressions)
- [x] Served the production build and confirmed each route returns **200** with its expected content: About shows the GitHub/Discord/Patreon links; Road Map shows all three status groups and the issue-tracker link; Commissions shows the pricing tiers, the 30-day guarantee, the "Open for commissions" chip, and the `discord.gg/VSe2cpfj5` invite.
- [x] Confirmed the new nav links render in `TopBar`.

Closes #73
Closes #40
Closes #106

_drafted by Claude on behalf of Daniel Stephenson_