### PR TITLE
fix: home page 500 from unserializable undefined serverCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The home page no longer returns a 500 when a plugin has no bStats ID (or a bStats lookup fails): `serverCount` now falls back to `null` instead of an unserializable `undefined`, and the popularity sort treats `null` as "no count" so those plugins still sort to the end.
 - The home page no longer returns a 500 when the visits API is unavailable: `getServerSideProps` now guards the visit calls and falls back to a hidden counter, and `getVisits()` checks `response.ok` before parsing.
 - Visit persistence is now crash-tolerant: `visits.json` is written atomically (temp file + rename) and read defensively, re-initializing from defaults on a missing/corrupt/invalid file instead of throwing.
 

--- a/__tests__/index.getServerSideProps.test.ts
+++ b/__tests__/index.getServerSideProps.test.ts
@@ -1,0 +1,40 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+// The home page calls the visits API in getServerSideProps; mock it so the
+// test exercises only the plugin/server-count serialization path.
+vi.mock('../services/visitService', () => ({
+    incrementVisits: vi.fn().mockResolvedValue(undefined),
+    getVisits: vi.fn().mockResolvedValue({visits: 0, startDate: '2020-01-01T00:00:00.000Z'})
+}));
+
+import {getServerSideProps} from '../pages/index';
+
+interface HomePropsShape {
+    props: {
+        visits: number | null;
+        startDate: string | null;
+        pluginsWithCounts: Array<{ id: string; serverCount?: number | null }>;
+    };
+}
+
+beforeEach(() => {
+    // Simulate bStats being unreachable so every server-count lookup resolves
+    // to undefined inside getServerCount — the worst case for serialization.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('bstats unreachable')));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('home getServerSideProps serialization', () => {
+    it('never returns an undefined serverCount (Next.js cannot serialize undefined)', async () => {
+        const result = await getServerSideProps() as HomePropsShape;
+        const undefinedCounts = result.props.pluginsWithCounts.filter((p) => p.serverCount === undefined);
+        expect(undefinedCounts).toEqual([]);
+    });
+
+    it('uses null for a plugin that has no bStatsId', async () => {
+        const result = await getServerSideProps() as HomePropsShape;
+        const cookery = result.props.pluginsWithCounts.find((p) => p.id === 'medieval-cookery');
+        expect(cookery).toBeDefined();
+        expect(cookery?.serverCount).toBeNull();
+    });
+});

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -16,7 +16,7 @@ interface PluginCardProps {
     githubLink: string;
     spigotmcLink?: string;
     bStatsId?: string;
-    serverCount?: number;
+    serverCount?: number | null;
 }
 
 const PluginCard: React.FC<PluginCardProps> = ({ 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,7 +43,7 @@ interface Plugin {
 }
 
 interface PluginWithServerCount extends Plugin {
-    serverCount?: number;
+    serverCount?: number | null;
 }
 
 const PluginSection: React.FC<{ plugins: PluginWithServerCount[] }> = ({ plugins }) => (
@@ -85,8 +85,8 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
         if (sortBy === 'popularity') {
             // Sort by server count (descending), with plugins without counts at the end
             return [...initialPlugins].sort((a, b) => {
-                const hasCountA = a.serverCount !== undefined;
-                const hasCountB = b.serverCount !== undefined;
+                const hasCountA = a.serverCount != null;
+                const hasCountB = b.serverCount != null;
                 
                 // If both have counts, sort by count descending
                 if (hasCountA && hasCountB) {
@@ -163,7 +163,7 @@ export const getServerSideProps = async () => {
     // Create plugins with server counts
     const pluginsWithCounts: PluginWithServerCount[] = pluginData.plugins.map(plugin => ({
         ...plugin,
-        serverCount: plugin.bStatsId ? serverCountsMap.get(plugin.bStatsId) : undefined
+        serverCount: (plugin.bStatsId ? serverCountsMap.get(plugin.bStatsId) : undefined) ?? null
     }));
 
     return {


### PR DESCRIPTION
## Summary

The home page was returning a **500** whenever a catalogued plugin had no `bStatsId` (e.g. `medieval-cookery`) or a bStats lookup failed. `pages/index.tsx`'s `getServerSideProps` set `serverCount: undefined` in those cases, and Next.js cannot serialize `undefined` into page props (`SerializableError: ... 'undefined' cannot be serialized as JSON`).

Found while deploying the site locally for review of #123 (this bug is independent of that PR — `index.tsx` was untouched there).

## Changes
- Coalesce `serverCount` to `null` instead of `undefined` in `getServerSideProps`.
- Widen the `serverCount` type to `number | null` in `pages/index.tsx` and `components/PluginCard.tsx` (the card already hides a falsy count, so `null` renders correctly).
- Update the popularity sort to treat `null` as "no count" (`!= null`) so plugins without a count still sort to the end.
- Add `__tests__/index.getServerSideProps.test.ts`: asserts `getServerSideProps` returns no `undefined` server counts (worst case: bStats unreachable) and returns `null` for a plugin without a `bStatsId`.

## Test plan
- [x] `npm test` — 18/18 (the two new assertions **fail if the fix is reverted**, confirmed by a mutation check)
- [x] `npm run lint` — no ESLint warnings or errors
- [x] `npm run build` — compiled successfully
- [x] Served the production build with bStats unreachable (worst case): `GET /` returns **200** and renders the plugin catalogue (previously 500)

Closes #124

_drafted by Claude on behalf of Daniel Stephenson_