### PR TITLE
feat: add News page (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added a **News** page (`/news`) listing posts newest-first, driven by an editable `pages/data/news.json`, with a **News** link in the top navigation bar.
 - Added an **About Us** page (`/about`) introducing the community, with links to GitHub, Discord, and Patreon.
 - Added a **Road Map** page (`/roadmap`) that lists planned, in-progress, and completed work, driven by an editable `pages/data/roadmap.json`.
 - Added a **Commissions** page (`/commissions`) with a pricing table, what's-included list, availability status, and a link to the commissions Discord, driven by an editable `pages/data/commissions.json`.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -20,6 +20,11 @@ No special software is required to use the website. Simply visit [https://danspl
 2. Browse the plugin cards displayed on the page.
 3. Click a plugin card to open its details or external page.
 
+### Reading the Latest News
+
+1. Click **News** in the top navigation bar (or visit `/news`).
+2. Browse the posts, shown newest first.
+
 ### Learning About the Community
 
 1. Click **About** in the top navigation bar (or visit `/about`).

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -48,6 +48,7 @@ const TopBar: React.FC = () => {
 
                     <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
                         <NavButton href="/">Home</NavButton>
+                        <NavButton href="/news">News</NavButton>
                         <NavButton href="/guides">Guides</NavButton>
                         <NavButton href="/leaderboard">Leaderboard</NavButton>
                         <NavButton href="/about">About</NavButton>

--- a/pages/data/news.json
+++ b/pages/data/news.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "News posts shown on the /news page, newest first (sorted by date on render). Hard-coded for now; a future change (see issue #24) may populate this from the Discord announcements feed. Each post needs an id, title, date (YYYY-MM-DD), and body.",
+  "posts": [
+    {
+      "id": "community-data-api",
+      "title": "Community Data API and Factions Leaderboard",
+      "date": "2026-06-06",
+      "body": "A new backend API lets Medieval Factions servers publish faction data to a shared community registry, and the website now features a public factions leaderboard built from it."
+    },
+    {
+      "id": "new-pages",
+      "title": "New About, Road Map, and Commissions Pages",
+      "date": "2026-06-06",
+      "body": "The site now has an About page introducing the community, a Road Map of planned and completed work, and a Commissions page for custom plugin development."
+    }
+  ]
+}

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -1,0 +1,62 @@
+import {Box, Container, Paper, Typography} from '@mui/material';
+import type {NextPage} from 'next';
+import TopBar from '../components/TopBar';
+import React from 'react';
+import BottomBar from '../components/BottomBar';
+
+// Import styles
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
+
+// Pull version from package.json
+const version = require('../package.json').version;
+
+interface NewsPost {
+    id: string;
+    title: string;
+    date: string;
+    body: string;
+}
+
+interface NewsData {
+    posts: NewsPost[];
+}
+
+const newsData = require('./data/news.json') as NewsData;
+
+// Newest first.
+const sortedPosts = [...newsData.posts].sort((a, b) => b.date.localeCompare(a.date));
+
+// A date-only string (YYYY-MM-DD) is parsed as UTC, so format in UTC too. This
+// keeps the displayed day matching the input regardless of timezone, and keeps
+// it identical on the server and client (avoiding a hydration mismatch).
+const formatDate = (date: string): string =>
+    new Date(date).toLocaleDateString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'});
+
+const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => (
+    <Paper elevation={3} sx={{p: 2, mb: 2}}>
+        <Typography variant="h6">{post.title}</Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+            {formatDate(post.date)}
+        </Typography>
+        <Typography variant="body1">{post.body}</Typography>
+    </Paper>
+);
+
+const News: NextPage = () => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <TopBar/>
+        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                News
+            </Typography>
+            {sortedPosts.length > 0 ? (
+                sortedPosts.map((post) => <NewsCard key={post.id} post={post}/>)
+            ) : (
+                <Typography variant="body1">No news yet. Check back soon!</Typography>
+            )}
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default News;


### PR DESCRIPTION
## Summary

Scaffolds a **News** page that lists posts, hard-coded for now per #23. Content lives in an editable `pages/data/news.json` so it can be curated without touching the component — and so a future change (#24) can populate the same data source from the Discord announcements feed.

- **`/news`** (`pages/news.tsx`) — renders posts newest-first as MUI cards (title, date, body), with a graceful "No news yet" empty state. Matches the existing `guides.tsx`/`roadmap.tsx` page structure.
- **`pages/data/news.json`** — editable posts (`id`, `title`, `date`, `body`), seeded with two posts about recent site updates as a starting point.
- **Nav** — added a **News** link to `TopBar` (after Home).
- **Dates** are formatted in **UTC** (`timeZone: 'UTC'`) so a date-only post date renders the same calendar day regardless of timezone and stays identical on server and client (avoids an off-by-one and a hydration mismatch — caught and fixed during local verification).

## Test plan
- [x] `npm run lint` — no ESLint warnings or errors
- [x] `npm test` — 18/18 (no regressions)
- [x] `npm run build` — compiled successfully; `/news` generated as a static route
- [x] Served the production build: `GET /news` returns **200** with both posts rendered newest-first and the date showing correctly (`June 6, 2026`)

## Notes for you
- The two seed posts in `news.json` are placeholders grounded in recent changes — edit/replace them with your real announcements.
- #24 (pull Discord announcements into News) can build on this by replacing the static `news.json` with a live feed; the page already renders whatever posts the data source provides.

Closes #23

_drafted by Claude on behalf of Daniel Stephenson_