### PR TITLE
fix: correct commissions Discord invite link

### DIFF
--- a/pages/data/commissions.json
+++ b/pages/data/commissions.json
@@ -1,6 +1,6 @@
 {
   "availability": "open",
-  "discordInvite": "https://discord.gg/VSe2cpfj5",
+  "discordInvite": "https://discord.gg/fJYH34k9m3",
   "tiers": [
     {
       "name": "Fork & Repair",


### PR DESCRIPTION
The commissions Discord invite in pages/data/commissions.json was pointing at an outdated link. It has been corrected to the current invite (https://discord.gg/fJYH34k9m3), which the commissions page surfaces via the "Join the Commissions Discord" button.

- Changed `discordInvite` from `https://discord.gg/VSe2cpfj5` to `https://discord.gg/fJYH34k9m3`.

drafted by Claude on behalf of Daniel Stephenson

🤖 Generated with [Claude Code](https://claude.com/claude-code)