### PR TITLE
ux: color mode — persist choice, follow OS preference, label the toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The dark/light mode toggle now **persists** across navigation and reloads (saved to `localStorage`) and a first-time visitor's initial mode follows their operating-system `prefers-color-scheme` setting instead of always starting in dark. Previously the choice was lost on every page change because navigation triggers a full page load and the mode lived only in memory.
+- The dark-mode toggle switch now has an accessible label (`aria-label="Toggle dark mode"`) in both the top and bottom bars, so assistive technology announces its purpose.
 - `CONFIG.md` no longer documents a phantom `NEXT_PUBLIC_SITE_URL` environment variable: it was read nowhere in the code, Dockerfile, or `compose.yml`. Removed its section and corrected the example `.env.local` block to use `NEXT_PUBLIC_BASE_URL` (the variable actually read by `services/visitService.ts` for the site's own origin).
 - The home page no longer returns a 500 when a plugin has no bStats ID (or a bStats lookup fails): `serverCount` now falls back to `null` instead of an unserializable `undefined`, and the popularity sort treats `null` as "no count" so those plugins still sort to the end.
 - The home page no longer returns a 500 when the visits API is unavailable: `getServerSideProps` now guards the visit calls and falls back to a hidden counter, and `getVisits()` checks `response.ok` before parsing.

--- a/__tests__/colorMode.test.ts
+++ b/__tests__/colorMode.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInitialColorMode } from '../utils/colorMode';
+
+describe('resolveInitialColorMode', () => {
+    it('honours a saved "light" choice regardless of OS preference', () => {
+        expect(resolveInitialColorMode('light', true)).toBe('light');
+        expect(resolveInitialColorMode('light', false)).toBe('light');
+    });
+
+    it('honours a saved "dark" choice regardless of OS preference', () => {
+        expect(resolveInitialColorMode('dark', true)).toBe('dark');
+        expect(resolveInitialColorMode('dark', false)).toBe('dark');
+    });
+
+    it('falls back to the OS preference when nothing is saved', () => {
+        expect(resolveInitialColorMode(null, true)).toBe('dark');
+        expect(resolveInitialColorMode(null, false)).toBe('light');
+    });
+
+    it('ignores an unrecognised stored value and uses the OS preference', () => {
+        expect(resolveInitialColorMode('purple', false)).toBe('light');
+        expect(resolveInitialColorMode('', true)).toBe('dark');
+    });
+});

--- a/components/BottomBar.tsx
+++ b/components/BottomBar.tsx
@@ -86,6 +86,7 @@ const BottomBar: React.FC<BottomBarProps> = ({version, visits, startDate}) => {
                     <ColorModeToggleSwitch
                         checked={theme.palette.mode === 'dark'}
                         onChange={colorMode.toggleColorMode}
+                        inputProps={{'aria-label': 'Toggle dark mode'}}
                     />
                 </Box>
             </Toolbar>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -66,6 +66,7 @@ const TopBar: React.FC = () => {
                     <ColorModeToggleSwitch
                         checked={theme.palette.mode === 'dark'}
                         onChange={colorMode.toggleColorMode}
+                        inputProps={{'aria-label': 'Toggle dark mode'}}
                     />
                 </Box>
             </Toolbar>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,33 @@
 import type {AppProps} from 'next/app'
-import React, {useMemo, useState} from 'react';
-import {createTheme, CssBaseline, ThemeProvider, useMediaQuery} from '@mui/material';
+import React, {useEffect, useMemo, useState} from 'react';
+import {createTheme, CssBaseline, ThemeProvider} from '@mui/material';
 import {ColorModeContext} from '../utils/ColorModeContext';
+import {COLOR_MODE_STORAGE_KEY, ColorMode, resolveInitialColorMode} from '../utils/colorMode';
 
 function MyApp({Component, pageProps}: AppProps) {
-    const prefersDarkMode = true;
+    // Start from a stable default for server-side rendering, then resolve the
+    // real mode on the client in an effect. Doing the localStorage/matchMedia
+    // lookup during render would diverge between server and client and cause a
+    // hydration mismatch.
+    const [mode, setMode] = useState<ColorMode>('dark');
 
-    const [mode, setMode] = useState<'light' | 'dark'>(prefersDarkMode ? 'dark' : 'light');
+    useEffect(() => {
+        const stored = window.localStorage.getItem(COLOR_MODE_STORAGE_KEY);
+        const prefersDark = window.matchMedia
+            ? window.matchMedia('(prefers-color-scheme: dark)').matches
+            : true;
+        setMode(resolveInitialColorMode(stored, prefersDark));
+    }, []);
 
     const colorMode = useMemo(
         () => ({
             toggleColorMode: () => {
-                setMode((prevMode) => (prevMode === 'light' ? 'dark' : 'light'));
+                setMode((prevMode) => {
+                    const nextMode: ColorMode = prevMode === 'light' ? 'dark' : 'light';
+                    // Persist the explicit choice so it survives navigation and reloads.
+                    window.localStorage.setItem(COLOR_MODE_STORAGE_KEY, nextMode);
+                    return nextMode;
+                });
             }
         }),
         [],

--- a/utils/colorMode.ts
+++ b/utils/colorMode.ts
@@ -1,0 +1,22 @@
+export type ColorMode = 'light' | 'dark';
+
+// localStorage key under which the user's explicit color-mode choice is saved,
+// so the selection survives navigation (full page loads) and return visits.
+export const COLOR_MODE_STORAGE_KEY = 'dpc-color-mode';
+
+const isColorMode = (value: string | null): value is ColorMode =>
+    value === 'light' || value === 'dark';
+
+// Decide the color mode to start in: honour a previously-saved explicit choice,
+// otherwise fall back to the operating system's prefers-color-scheme setting.
+// Kept pure (no window access) so it can be unit-tested and reused on both the
+// initial client render and the toggle path.
+export const resolveInitialColorMode = (
+    stored: string | null,
+    prefersDark: boolean
+): ColorMode => {
+    if (isColorMode(stored)) {
+        return stored;
+    }
+    return prefersDark ? 'dark' : 'light';
+};


### PR DESCRIPTION
## Summary

- **Persist the color-mode choice.** The selected dark/light mode is now written to `localStorage` (`dpc-color-mode`) and restored on load, so it survives navigation (the nav uses full-page anchor links) and return visits. Previously the choice lived only in memory and reset on every page change.
- **Respect the OS preference on first visit.** With no saved choice, the initial mode follows `prefers-color-scheme` instead of the hard-coded `prefersDarkMode = true`. The unused `useMediaQuery` import is removed; the lookup runs in a `useEffect` to avoid an SSR hydration mismatch.
- **Accessible toggle.** Both the top- and bottom-bar switches get `inputProps={{ 'aria-label': 'Toggle dark mode' }}`, consistent with the labeled controls elsewhere (sort toggle, account icon buttons).
- Resolution logic extracted to a pure `utils/colorMode.ts` (`resolveInitialColorMode`) with unit tests.

Heuristics: Nielsen #1 (visibility of status), #7 (flexibility), #4 (consistency/standards); Krug — *don't make me think*.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 28/28 pass, incl. 4 new `__tests__/colorMode.test.ts` covering saved-choice precedence, OS-preference fallback, and unrecognised-value handling
- [x] `npm run build` — succeeds
- [x] Manual trace: SSR renders with default `dark`; on mount the effect reads `localStorage`/`matchMedia` and sets the resolved mode; toggling writes to `localStorage`, so a later full-page navigation restores it.

Closes #131
Closes #134

---

_drafted by Claude on behalf of Daniel Stephenson_