### PR TITLE
ux: external links — consistent new-tab behavior + keyboard-accessible cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- External links now behave consistently: the top-bar community links (Discord, Patreon, LinkedIn, RPKit), the footer links (Source Code, Report a Bug), the plugin-card GitHub/SpigotMC buttons, and the About-page links all open in a new tab with `rel="noopener noreferrer"`, matching the News, Road Map, and home-page cards. The external links in the top navigation also carry an external-link icon so they are distinguishable from in-site navigation.
+- The home-page info cards (Contribute, Download, Try it Out) are now keyboard-accessible: they are focusable, expose a `link` role, and activate on Enter/Space, where previously they responded only to mouse clicks.
 - The dark/light mode toggle now **persists** across navigation and reloads (saved to `localStorage`) and a first-time visitor's initial mode follows their operating-system `prefers-color-scheme` setting instead of always starting in dark. Previously the choice was lost on every page change because navigation triggers a full page load and the mode lived only in memory.
 - The dark-mode toggle switch now has an accessible label (`aria-label="Toggle dark mode"`) in both the top and bottom bars, so assistive technology announces its purpose.
 - `CONFIG.md` no longer documents a phantom `NEXT_PUBLIC_SITE_URL` environment variable: it was read nowhere in the code, Dockerfile, or `compose.yml`. Removed its section and corrected the example `.env.local` block to use `NEXT_PUBLIC_BASE_URL` (the variable actually read by `services/visitService.ts` for the site's own origin).

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -23,6 +23,11 @@ const InfoCard: React.FC<{
     <Grid item xs={12} md={4}>
         <Paper
             elevation={3}
+            // When the card links somewhere, expose it as a focusable, keyboard-
+            // operable control: a mouse-only onClick left keyboard and screen-
+            // reader users unable to reach or activate these cards.
+            role={href ? 'link' : undefined}
+            tabIndex={href ? 0 : undefined}
             sx={(theme) => ({
                 ...infoCardStyle(theme),
                 cursor: href ? 'pointer' : 'default',
@@ -31,7 +36,13 @@ const InfoCard: React.FC<{
                     transition: 'transform 0.2s ease-in-out'
                 } : {}
             })}
-            onClick={() => href && window.open(href, '_blank')}
+            onClick={() => href && window.open(href, '_blank', 'noopener,noreferrer')}
+            onKeyDown={(e) => {
+                if (href && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault();
+                    window.open(href, '_blank', 'noopener,noreferrer');
+                }
+            }}
         >
             <Box sx={(theme) => infoCardIconStyle(theme)}>
                 {icon}

--- a/components/BottomBar.tsx
+++ b/components/BottomBar.tsx
@@ -21,7 +21,7 @@ const FooterButton: React.FC<{ href: string; icon: React.ReactNode; children: Re
                                                                                                         icon,
                                                                                                         children,
                                                                                                     }) => (
-    <Button color="inherit" href={href} startIcon={icon} sx={(theme) => footerButtonStyle(theme)}>
+    <Button color="inherit" href={href} target="_blank" rel="noopener noreferrer" startIcon={icon} sx={(theme) => footerButtonStyle(theme)}>
         {children}
     </Button>
 );

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -40,11 +40,11 @@ const PluginCard: React.FC<PluginCardProps> = ({
                 ) : null}
             </CardContent>
             <CardActions sx={pluginCardActionsStyle}>
-                <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={githubLink}>
+                <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={githubLink} target="_blank" rel="noopener noreferrer">
                     GitHub
                 </Button>
                 {spigotmcLink ? (
-                    <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={spigotmcLink}>
+                    <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={spigotmcLink} target="_blank" rel="noopener noreferrer">
                         SpigotMC
                     </Button>
                 ) : null}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,4 +1,5 @@
 import {AppBar, Box, Button, Toolbar, Typography, useTheme} from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import React, {useContext} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
@@ -12,15 +13,24 @@ import {
     flexContainerStyle
 } from '../styles/styles';
 
-const NavButton: React.FC<{ href: string; children: React.ReactNode }> = ({href, children}) => (
-    <Button
-        color="inherit"
-        href={href}
-        sx={(theme) => navButtonStyle(theme)}
-    >
-        {children}
-    </Button>
-);
+// Internal routes navigate in the same tab; off-site links open in a new tab
+// (with rel="noopener noreferrer") and carry an external-link icon so they are
+// visually distinguishable from the in-site navigation they sit beside.
+const NavButton: React.FC<{ href: string; children: React.ReactNode }> = ({href, children}) => {
+    const isExternal = href.startsWith('http');
+    return (
+        <Button
+            color="inherit"
+            href={href}
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}
+            endIcon={isExternal ? <OpenInNewIcon fontSize="small"/> : undefined}
+            sx={(theme) => navButtonStyle(theme)}
+        >
+            {children}
+        </Button>
+    );
+};
 
 const BrandName: React.FC = () => (
     <Typography

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -36,6 +36,8 @@ const About: NextPage = () => (
                     variant="contained"
                     color="primary"
                     href="https://github.com/Dans-Plugins"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     sx={{mr: 1, mb: 1}}
                 >
                     GitHub
@@ -44,6 +46,8 @@ const About: NextPage = () => (
                     variant="contained"
                     color="primary"
                     href="https://discord.gg/xXtuAQ2"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     sx={{mr: 1, mb: 1}}
                 >
                     Discord
@@ -52,6 +56,8 @@ const About: NextPage = () => (
                     variant="contained"
                     color="primary"
                     href="https://www.patreon.com/danspluginscommunity"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     sx={{mr: 1, mb: 1}}
                 >
                     Patreon


### PR DESCRIPTION
## Summary

- **Consistent external-link behavior (#133).** Off-site links now uniformly open in a new tab with `rel="noopener noreferrer"`: top-bar community links (Discord, Patreon, LinkedIn, RPKit), footer links (Source Code, Report a Bug), plugin-card GitHub/SpigotMC buttons, and the About-page links — matching what News, Road Map, and the home-page cards already did. The external links in the **top navigation** also get an `OpenInNewIcon` so they're visually distinguishable from in-site nav (internal routes still open in the same tab).
- **Keyboard-accessible home cards (#135).** The Contribute / Download / Try it Out cards now expose `role="link"`, are focusable (`tabIndex={0}`), and activate on Enter/Space. Previously they responded only to mouse clicks, so keyboard and screen-reader users couldn't use them. Their `window.open` now passes `noopener,noreferrer`.

Heuristics: Nielsen #4 (consistency & standards); Krug — *conventions over invention*; accessibility.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 28/28 pass
- [x] `npm run build` — succeeds
- [x] Manual trace: `NavButton` computes `isExternal = href.startsWith('http')` → external links get `target/_blank`, `rel`, and the icon; internal routes unchanged. Info card is reachable by Tab and fires on Enter/Space.

Closes #133
Closes #135

---

_drafted by Claude on behalf of Daniel Stephenson_