### PR TITLE
ux: active-page nav indicator + leaderboard retry action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The top navigation now highlights the link for the page you are on (bold + underline, with `aria-current="page"`), so the current location is visible at a glance instead of having to recall which link was clicked.
+- The faction leaderboard error message now includes a **Retry** action that re-runs the fetch in place, so a transient API failure no longer requires a full page reload to recover from.
 - External links now behave consistently: the top-bar community links (Discord, Patreon, LinkedIn, RPKit), the footer links (Source Code, Report a Bug), the plugin-card GitHub/SpigotMC buttons, and the About-page links all open in a new tab with `rel="noopener noreferrer"`, matching the News, Road Map, and home-page cards. The external links in the top navigation also carry an external-link icon so they are distinguishable from in-site navigation.
 - The home-page info cards (Contribute, Download, Try it Out) are now keyboard-accessible: they are focusable, expose a `link` role, and activate on Enter/Space, where previously they responded only to mouse clicks.
 - The dark/light mode toggle now **persists** across navigation and reloads (saved to `localStorage`) and a first-time visitor's initial mode follows their operating-system `prefers-color-scheme` setting instead of always starting in dark. Previously the choice was lost on every page change because navigation triggers a full page load and the mode lived only in memory.

--- a/__tests__/nav.test.ts
+++ b/__tests__/nav.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isActiveNavLink } from '../utils/nav';
+
+describe('isActiveNavLink', () => {
+    it('marks an internal link active when it matches the current route', () => {
+        expect(isActiveNavLink('/news', '/news')).toBe(true);
+        expect(isActiveNavLink('/', '/')).toBe(true);
+    });
+
+    it('does not mark an internal link active on a different route', () => {
+        expect(isActiveNavLink('/news', '/about')).toBe(false);
+        expect(isActiveNavLink('/', '/news')).toBe(false);
+    });
+
+    it('never marks an external link active, even on a matching string', () => {
+        expect(isActiveNavLink('https://discord.gg/xXtuAQ2', 'https://discord.gg/xXtuAQ2')).toBe(false);
+        expect(isActiveNavLink('/', 'https://github.com/Dans-Plugins')).toBe(false);
+    });
+});

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,8 +1,10 @@
 import {AppBar, Box, Button, Toolbar, Typography, useTheme} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import {useRouter} from 'next/router';
 import React, {useContext} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
+import {isActiveNavLink} from '../utils/nav';
 
 import {
     appBarStyle,
@@ -16,7 +18,7 @@ import {
 // Internal routes navigate in the same tab; off-site links open in a new tab
 // (with rel="noopener noreferrer") and carry an external-link icon so they are
 // visually distinguishable from the in-site navigation they sit beside.
-const NavButton: React.FC<{ href: string; children: React.ReactNode }> = ({href, children}) => {
+const NavButton: React.FC<{ href: string; active?: boolean; children: React.ReactNode }> = ({href, active = false, children}) => {
     const isExternal = href.startsWith('http');
     return (
         <Button
@@ -25,7 +27,17 @@ const NavButton: React.FC<{ href: string; children: React.ReactNode }> = ({href,
             target={isExternal ? '_blank' : undefined}
             rel={isExternal ? 'noopener noreferrer' : undefined}
             endIcon={isExternal ? <OpenInNewIcon fontSize="small"/> : undefined}
-            sx={(theme) => navButtonStyle(theme)}
+            aria-current={active ? 'page' : undefined}
+            sx={(theme) => ({
+                ...navButtonStyle(theme),
+                // "You are here": highlight the link for the current page so the
+                // user can tell where they are within the site.
+                ...(active && {
+                    fontWeight: 'bold',
+                    textDecoration: 'underline',
+                    textUnderlineOffset: '6px',
+                }),
+            })}
         >
             {children}
         </Button>
@@ -46,6 +58,7 @@ const BrandName: React.FC = () => (
 const TopBar: React.FC = () => {
     const colorMode = useContext(ColorModeContext);
     const theme = useTheme();
+    const {pathname} = useRouter();
 
     return (
         <AppBar
@@ -57,14 +70,14 @@ const TopBar: React.FC = () => {
                     <BrandName/>
 
                     <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
-                        <NavButton href="/">Home</NavButton>
-                        <NavButton href="/news">News</NavButton>
-                        <NavButton href="/guides">Guides</NavButton>
-                        <NavButton href="/leaderboard">Leaderboard</NavButton>
-                        <NavButton href="/about">About</NavButton>
-                        <NavButton href="/roadmap">Road Map</NavButton>
-                        <NavButton href="/commissions">Commissions</NavButton>
-                        <NavButton href="/account">Account</NavButton>
+                        <NavButton href="/" active={isActiveNavLink(pathname, '/')}>Home</NavButton>
+                        <NavButton href="/news" active={isActiveNavLink(pathname, '/news')}>News</NavButton>
+                        <NavButton href="/guides" active={isActiveNavLink(pathname, '/guides')}>Guides</NavButton>
+                        <NavButton href="/leaderboard" active={isActiveNavLink(pathname, '/leaderboard')}>Leaderboard</NavButton>
+                        <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>
+                        <NavButton href="/roadmap" active={isActiveNavLink(pathname, '/roadmap')}>Road Map</NavButton>
+                        <NavButton href="/commissions" active={isActiveNavLink(pathname, '/commissions')}>Commissions</NavButton>
+                        <NavButton href="/account" active={isActiveNavLink(pathname, '/account')}>Account</NavButton>
                         <NavButton href="https://discord.gg/xXtuAQ2">Discord</NavButton>
                         <NavButton href="https://www.patreon.com/danspluginscommunity">Patreon</NavButton>
                         <NavButton href="https://www.linkedin.com/company/dansplugins">LinkedIn</NavButton>

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -1,6 +1,7 @@
 import {
     Alert,
     Box,
+    Button,
     Card,
     CardContent,
     Chip,
@@ -94,7 +95,16 @@ const LeaderboardPage: NextPage = () => {
                 </Typography>
 
                 {error && (
-                    <Alert severity="error" sx={{mb: 2}} onClose={() => setError(null)}>
+                    <Alert
+                        severity="error"
+                        sx={{mb: 2}}
+                        onClose={() => setError(null)}
+                        action={
+                            <Button color="inherit" size="small" onClick={fetchFactions}>
+                                Retry
+                            </Button>
+                        }
+                    >
                         {error}
                     </Alert>
                 )}

--- a/utils/nav.ts
+++ b/utils/nav.ts
@@ -1,0 +1,6 @@
+// True when a navigation link points at the page currently being viewed.
+// External links (http/https) are never treated as "active" — only in-site
+// routes participate in the "you are here" indication. Kept pure so it can be
+// unit-tested and reused by the navigation bar.
+export const isActiveNavLink = (pathname: string, href: string): boolean =>
+    !href.startsWith('http') && pathname === href;


### PR DESCRIPTION
## Summary

- **"You are here" in the top nav (#132).** The internal nav link for the current page is now highlighted (bold + underline) and carries `aria-current="page"`. Driven by a pure, unit-tested `isActiveNavLink(pathname, href)` helper (external links never match). Previously none of the 12 nav buttons reflected the active route.
- **Leaderboard retry (#136).** The error Alert on `/leaderboard` now has a **Retry** action that re-invokes the existing `fetchFactions` callback in place, so a transient API failure no longer forces a full page reload.

Heuristics: Krug — *you are here*; Nielsen #1 (visibility of status), #6 (recognition over recall), #9 (recover from errors).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 31/31 pass, incl. 3 new `__tests__/nav.test.ts` (match, non-match, external-never-active)
- [x] `npm run build` — succeeds
- [x] Manual trace: `useRouter().pathname` compared per link via `isActiveNavLink`; on `/news` the News button is bold+underlined with `aria-current`. Retry button calls `fetchFactions`, which resets `loading`/`error` and re-fetches.

Closes #132
Closes #136

---

_drafted by Claude on behalf of Daniel Stephenson_