### PR TITLE
feat: ingest Discord announcements into the News feed (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- The News page now pulls in **announcements from the community Discord server** alongside hand-written posts. A scheduled poller in the `dpc-api` backend ingests the announcements channel into a new `discord_announcements` table (upsert-by-message-id, never deleting) and serves them at `GET /api/v1/news`; the frontend merges them into the single News feed (newest-first, "From Discord" badge), degrading to local-only posts if the API is unavailable. The integration is **disabled by default** and configured per-environment via the `DISCORD_*` variables documented in the `dpc-api` README.
 - Added a **News** page (`/news`) listing posts newest-first, with a **News** link in the top navigation bar. Posts are read at request time from a runtime `data/news.json` (on the mounted data volume), so they can be edited on the server without rebuilding the site; the file is seeded with default posts on first run, and an invalid file falls back to defaults without being overwritten. Each post has a `source` (`direct`, `discord`, or `external`) rendered as a badge, with an optional `sourceUrl` link and `author`.
 - Added an **About Us** page (`/about`) introducing the community, with links to GitHub, Discord, and Patreon.
 - Added a **Road Map** page (`/roadmap`) that lists planned, in-progress, and completed work, driven by an editable `pages/data/roadmap.json`.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -62,6 +62,7 @@ The News page (`/news`) reads its posts at request time from `data/news.json`. I
 - The file is **seeded with default posts on first run** if it does not exist.
 - If the file is present but contains invalid JSON, the page serves the default posts and **does not overwrite your file**, so an editing typo never destroys content. Fix the JSON and reload.
 - Posts are displayed newest-first (by `date`).
+- The News page also **merges in community posts from the DPC API** (`GET ${NEXT_PUBLIC_API_URL}/api/v1/news`, currently Discord announcements). These appear in the same feed with a "From Discord" badge. If the API is unreachable the page still renders the local `data/news.json` posts. On an `id` collision a local post wins. See the `dpc-api` README for enabling Discord ingestion (`DISCORD_*` variables).
 
 Each entry in the `posts` array supports these fields:
 

--- a/__tests__/discordNewsService.test.ts
+++ b/__tests__/discordNewsService.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getApiNewsPosts } from '../services/discordNewsService';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+const validApiPost = {
+    id: 'discord-100',
+    title: 'Server event',
+    date: '2026-06-01',
+    body: 'Join us this weekend.',
+    source: 'discord',
+    sourceUrl: 'https://discord.com/channels/1/2/100',
+    author: 'Dan'
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getApiNewsPosts', () => {
+    it('maps a well-formed API response into NewsPost objects', async () => {
+        stubFetch({ ok: true, json: async () => [validApiPost] });
+        const posts = await getApiNewsPosts();
+        expect(posts).toHaveLength(1);
+        expect(posts[0]).toMatchObject({ id: 'discord-100', source: 'discord', author: 'Dan' });
+    });
+
+    it('returns an empty list on a non-ok response', async () => {
+        stubFetch({ ok: false, status: 503, json: async () => ({}) });
+        expect(await getApiNewsPosts()).toEqual([]);
+    });
+
+    it('returns an empty list when the payload is not an array', async () => {
+        stubFetch({ ok: true, json: async () => ({ posts: [] }) });
+        expect(await getApiNewsPosts()).toEqual([]);
+    });
+
+    it('drops malformed posts but keeps valid ones', async () => {
+        stubFetch({ ok: true, json: async () => [validApiPost, { id: 'x' }, null] });
+        const posts = await getApiNewsPosts();
+        expect(posts).toHaveLength(1);
+        expect(posts[0].id).toBe('discord-100');
+    });
+
+    it('returns an empty list when fetch rejects', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+        expect(await getApiNewsPosts()).toEqual([]);
+    });
+});

--- a/__tests__/newsMerge.test.ts
+++ b/__tests__/newsMerge.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { mergeNewsPosts, NewsPost } from '../utils/newsStorage';
+
+const post = (id: string, date: string, source: NewsPost['source'] = 'direct'): NewsPost => ({
+    id,
+    title: `Post ${id}`,
+    date,
+    body: 'body',
+    source,
+    sourceUrl: null,
+    author: null
+});
+
+describe('mergeNewsPosts', () => {
+    it('combines local and remote posts newest-first', () => {
+        const local = [post('a', '2026-06-01')];
+        const remote = [post('discord-1', '2026-06-03', 'discord'), post('discord-2', '2026-05-30', 'discord')];
+        const merged = mergeNewsPosts(local, remote);
+        expect(merged.map((p) => p.id)).toEqual(['discord-1', 'a', 'discord-2']);
+    });
+
+    it('lets a local post win over a remote post with the same id', () => {
+        const local = [{ ...post('shared', '2026-06-01'), title: 'Local wins' }];
+        const remote = [{ ...post('shared', '2026-06-01', 'discord'), title: 'Remote loses' }];
+        const merged = mergeNewsPosts(local, remote);
+        expect(merged).toHaveLength(1);
+        expect(merged[0].title).toBe('Local wins');
+    });
+
+    it('handles empty inputs on either side', () => {
+        expect(mergeNewsPosts([], [])).toEqual([]);
+        expect(mergeNewsPosts([post('a', '2026-06-01')], [])).toHaveLength(1);
+        expect(mergeNewsPosts([], [post('discord-1', '2026-06-01', 'discord')])).toHaveLength(1);
+    });
+});

--- a/compose.yml
+++ b/compose.yml
@@ -47,6 +47,13 @@ services:
       DPC_SYNC_MIN_INCOMING: ${DPC_SYNC_MIN_INCOMING:-2}
       DPC_SYNC_MAX_DEACTIVATION_RATIO: ${DPC_SYNC_MAX_DEACTIVATION_RATIO:-0.5}
       DPC_SYNC_MAX_DEACTIVATIONS: ${DPC_SYNC_MAX_DEACTIVATIONS:-1000}
+      # Discord announcement ingestion (News feed). Disabled by default; set
+      # DISCORD_ENABLED=true and provide a bot token + channel id to enable.
+      # See dpc-api/README.md "Discord announcement ingestion".
+      DISCORD_ENABLED: ${DISCORD_ENABLED:-false}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_ANNOUNCEMENTS_CHANNEL_ID: ${DISCORD_ANNOUNCEMENTS_CHANNEL_ID:-}
+      DISCORD_GUILD_ID: ${DISCORD_GUILD_ID:-}
     depends_on:
       dpc-db:
         condition: service_healthy

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -275,6 +275,44 @@ Discord server's announcements channel and stores them in the
 - **Configuration.** See the `DISCORD_*` variables in the
   [Configuration](#configuration) table.
 
+##### Setting up the Discord bot (one-time)
+
+To enable ingestion you need a Discord bot that can read the announcements
+channel, plus the channel and (optionally) server ids.
+
+1. **Create the application and bot.** Go to the
+   [Discord Developer Portal](https://discord.com/developers/applications) →
+   **New Application**. Open the **Bot** tab and **Reset Token** to reveal the
+   bot token — this is the `DISCORD_BOT_TOKEN` value (treat it as a secret).
+2. **Enable the Message Content intent.** On the **Bot** tab, turn on the
+   **Message Content Intent** (under *Privileged Gateway Intents*).
+   > ⚠️ **Required.** Without this intent the Discord REST API returns **empty**
+   > `content` for messages, so every announcement would be ingested as blank and
+   > skipped. Per Discord's docs, an app "will receive empty values in the
+   > `content`, `embeds`, `attachments` … fields … if they have not configured
+   > (or been approved for) the `MESSAGE_CONTENT` privileged intent." Apps in
+   > 100+ servers must additionally be approved for it; below that the toggle is
+   > sufficient.
+3. **Invite the bot to your server.** Under **OAuth2 → URL Generator**, select
+   the `bot` scope and the **View Channel** + **Read Message History**
+   permissions, open the generated URL, and add the bot to the server. These two
+   permissions are what `GET /channels/{id}/messages` requires; without
+   *Read Message History* it returns no messages.
+4. **Get the ids.** In Discord, enable **User Settings → Advanced → Developer
+   Mode**, then right-click the announcements channel → **Copy Channel ID**
+   (`DISCORD_ANNOUNCEMENTS_CHANNEL_ID`) and right-click the server icon →
+   **Copy Server ID** (`DISCORD_GUILD_ID`, used only to build `sourceUrl`
+   permalinks).
+5. **Configure and enable.** Put the values in the deployment's environment
+   (e.g. the gateway `.env`) and set `DISCORD_ENABLED=true`, then restart/recreate
+   the `dpc-backend` service. Verify with `curl https://api.dansplugins.com/api/v1/news`
+   — it should return the recent announcements within one poll interval
+   (`DISCORD_POLL_INTERVAL_MILLIS`, default 5 minutes).
+
+> The bot only needs **read** access to the announcements channel. It never
+> posts, edits, or deletes anything on Discord, and the ingestion path never
+> deletes stored rows (see above).
+
 ## Plugin Authentication Flow
 
 Minecraft plugins can register and manage API keys programmatically:

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -66,6 +66,13 @@ Configuration is managed via environment variables:
 | `DPC_SYNC_MIN_INCOMING` | `2` | Minimum batch size eligible to deactivate factions (see [Sync safety guards](#sync-safety-guards)) |
 | `DPC_SYNC_MAX_DEACTIVATION_RATIO` | `0.5` | Fraction cap on factions one sync may deactivate |
 | `DPC_SYNC_MAX_DEACTIVATIONS` | `1000` | Absolute cap on factions one sync may deactivate (`0` disables) |
+| `DISCORD_ENABLED` | `false` | Enable ingesting Discord announcements into the News feed (see [Discord announcement ingestion](#discord-announcement-ingestion)) |
+| `DISCORD_BOT_TOKEN` | *(empty)* | Discord bot token (server-only secret); the bot must be in the guild with read access to the announcements channel |
+| `DISCORD_ANNOUNCEMENTS_CHANNEL_ID` | *(empty)* | Numeric id of the announcements channel to read |
+| `DISCORD_GUILD_ID` | *(empty)* | Numeric guild id, used only to build message permalinks (`sourceUrl`); when empty, posts have no source link |
+| `DISCORD_FETCH_LIMIT` | `20` | How many recent messages to request per poll (1–100) |
+| `DISCORD_API_BASE_URL` | `https://discord.com/api/v10` | Discord REST API base URL |
+| `DISCORD_POLL_INTERVAL_MILLIS` | `300000` | Delay between polls, in milliseconds (default 5 minutes) |
 
 The Docker Compose file also supports the `API_PORT` variable (default `45345`) to control the published host port for the API.
 
@@ -221,6 +228,52 @@ curl "http://localhost:45345/api/v1/factions?page=0&size=20"
 ```bash
 curl http://localhost:45345/api/v1/factions/<faction-uuid>
 ```
+
+### News
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `GET` | `/api/v1/news` | Public | List recent community news posts (Discord announcements), newest-first |
+
+```bash
+curl http://localhost:45345/api/v1/news
+```
+
+Each item matches the website's News post shape:
+
+```json
+[
+  {
+    "id": "discord-1234567890",
+    "title": "Server event this weekend",
+    "date": "2026-06-09",
+    "body": "Join us for a community build event.",
+    "source": "discord",
+    "sourceUrl": "https://discord.com/channels/<guild>/<channel>/<message>",
+    "author": "Dan"
+  }
+]
+```
+
+The website merges these into its own News feed (see the site's News page).
+
+#### Discord announcement ingestion
+
+When enabled, a scheduled poller reads recent messages from the community
+Discord server's announcements channel and stores them in the
+`discord_announcements` table, where `GET /api/v1/news` serves them.
+
+- **Disabled by default.** With `DISCORD_ENABLED=false` (or a missing
+  `DISCORD_BOT_TOKEN` / `DISCORD_ANNOUNCEMENTS_CHANNEL_ID`) the poller is a
+  no-op and the API makes no calls to Discord.
+- **Upsert-only, never delete.** Messages are upserted by Discord message id —
+  inserted once and updated in place if edited. The ingestion path never
+  deletes rows, so a Discord outage or an empty fetch cannot wipe
+  previously-ingested announcements.
+- **Title derivation.** A post's title is the first non-empty line of the
+  message (truncated); the full message becomes the body.
+- **Configuration.** See the `DISCORD_*` variables in the
+  [Configuration](#configuration) table.
 
 ## Plugin Authentication Flow
 

--- a/dpc-api/src/main/java/com/dansplugins/api/DpcApiApplication.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/DpcApiApplication.java
@@ -1,12 +1,15 @@
 package com.dansplugins.api;
 
+import com.dansplugins.api.config.DiscordProperties;
 import com.dansplugins.api.config.FactionSyncSafetyProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties(FactionSyncSafetyProperties.class)
+@EnableScheduling
+@EnableConfigurationProperties({FactionSyncSafetyProperties.class, DiscordProperties.class})
 public class DpcApiApplication {
 
     public static void main(String[] args) {

--- a/dpc-api/src/main/java/com/dansplugins/api/client/DiscordClient.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/client/DiscordClient.java
@@ -1,0 +1,50 @@
+package com.dansplugins.api.client;
+
+import com.dansplugins.api.config.DiscordProperties;
+import com.dansplugins.api.dto.DiscordMessageDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Thin client over the Discord REST API for reading recent messages from the
+ * announcements channel. Failures are swallowed (logged, empty list returned)
+ * so a Discord outage never propagates into the News page or the poller.
+ */
+@Component
+@Slf4j
+public class DiscordClient {
+
+    private final DiscordProperties properties;
+    private final RestClient restClient;
+
+    public DiscordClient(DiscordProperties properties, RestClient.Builder restClientBuilder) {
+        this.properties = properties;
+        this.restClient = restClientBuilder.build();
+    }
+
+    /**
+     * Fetch the most recent messages from the configured announcements channel,
+     * newest-first (Discord's default ordering). Returns an empty list on any
+     * error or non-2xx response.
+     */
+    public List<DiscordMessageDto> fetchAnnouncements() {
+        try {
+            DiscordMessageDto[] messages = restClient.get()
+                    .uri(properties.apiBaseUrl() + "/channels/{channelId}/messages?limit={limit}",
+                            properties.announcementsChannelId(), properties.fetchLimit())
+                    .header(HttpHeaders.AUTHORIZATION, "Bot " + properties.botToken())
+                    .retrieve()
+                    .body(DiscordMessageDto[].class);
+            return messages == null ? List.of() : Arrays.asList(messages);
+        } catch (RestClientException e) {
+            log.warn("Failed to fetch Discord announcements: {}", e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/config/DiscordProperties.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/DiscordProperties.java
@@ -1,0 +1,46 @@
+package com.dansplugins.api.config;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration for ingesting announcements from the community Discord server's
+ * announcements channel into the News feed.
+ *
+ * <p>The integration ships <b>disabled by default</b>: with {@code enabled=false}
+ * (or a missing bot token / channel id) the poller is a no-op and no calls are
+ * made to Discord. Enable it per-environment via the {@code DISCORD_*}
+ * environment variables documented in the dpc-api README; defaults are supplied
+ * in {@code application.yml}.</p>
+ *
+ * @param enabled                whether Discord ingestion is active
+ * @param botToken               Discord bot token (server-only secret); the bot
+ *                               must be in the guild with read access to the
+ *                               announcements channel
+ * @param announcementsChannelId numeric id of the announcements channel to read
+ * @param guildId                numeric guild id, used only to build message
+ *                               permalinks; when blank, posts have no sourceUrl
+ * @param fetchLimit             how many recent messages to request per poll (1..100)
+ * @param apiBaseUrl             Discord REST API base URL
+ * @param pollIntervalMillis     delay between polls, in milliseconds
+ */
+@Validated
+@ConfigurationProperties(prefix = "dpc.discord")
+public record DiscordProperties(
+        boolean enabled,
+        String botToken,
+        String announcementsChannelId,
+        String guildId,
+        @Min(1) @Max(100) int fetchLimit,
+        String apiBaseUrl,
+        @Min(1000) long pollIntervalMillis
+) {
+    /** True when the integration is switched on and the required credentials are present. */
+    public boolean isConfigured() {
+        return enabled
+                && botToken != null && !botToken.isBlank()
+                && announcementsChannelId != null && !announcementsChannelId.isBlank();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/accounts/register").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/accounts/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/factions/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/news/**").permitAll()
                         // Swagger/OpenAPI
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // Account endpoints require JWT auth

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/NewsController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/NewsController.java
@@ -1,0 +1,34 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.dto.NewsPostResponse;
+import com.dansplugins.api.service.DiscordAnnouncementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/news")
+@RequiredArgsConstructor
+@Tag(name = "News", description = "Community news posts surfaced on the website")
+public class NewsController {
+
+    private final DiscordAnnouncementService discordAnnouncementService;
+
+    @GetMapping
+    @Operation(
+            summary = "List community news posts",
+            description = "Returns recent community news posts (currently Discord announcements), "
+                    + "newest-first. Public endpoint; the website merges these with its own posts."
+    )
+    @ApiResponse(responseCode = "200", description = "News posts retrieved successfully")
+    public ResponseEntity<List<NewsPostResponse>> getNews() {
+        return ResponseEntity.ok(discordAnnouncementService.getRecentAsNewsPosts());
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/DiscordMessageDto.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/DiscordMessageDto.java
@@ -1,0 +1,30 @@
+package com.dansplugins.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Subset of a Discord message object (from {@code GET /channels/{id}/messages})
+ * that the News ingestion needs. Unknown fields are ignored so Discord can add
+ * fields without breaking deserialization.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DiscordMessageDto(
+        String id,
+        String content,
+        OffsetDateTime timestamp,
+        Author author
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Author(
+            String username,
+            @JsonProperty("global_name") String globalName
+    ) {
+        /** Preferred display name: the Discord display name if set, else the username. */
+        public String displayName() {
+            return globalName != null && !globalName.isBlank() ? globalName : username;
+        }
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/NewsPostResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/NewsPostResponse.java
@@ -1,0 +1,33 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * A news post exposed by {@code GET /api/v1/news}. The shape matches the
+ * website's {@code NewsPost} model so the frontend can merge these posts
+ * directly into its News feed.
+ */
+@Schema(description = "A community news post (currently sourced from Discord announcements)")
+public record NewsPostResponse(
+        @Schema(description = "Stable unique id, e.g. \"discord-<messageId>\"")
+        String id,
+
+        @Schema(description = "Post heading (derived from the first line of the announcement)")
+        String title,
+
+        @Schema(description = "Post date in YYYY-MM-DD (UTC)")
+        String date,
+
+        @Schema(description = "Full post body")
+        String body,
+
+        @Schema(description = "Provenance of the post, e.g. \"discord\"")
+        String source,
+
+        @Schema(description = "Link to the original source, or null")
+        String sourceUrl,
+
+        @Schema(description = "Author display name, or null")
+        String author
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/entity/DiscordAnnouncement.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/entity/DiscordAnnouncement.java
@@ -1,0 +1,87 @@
+package com.dansplugins.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * An announcement ingested from the community Discord server's announcements
+ * channel, surfaced as a post on the website's News page.
+ *
+ * <p>Rows are upserted by {@code messageId} (see {@code DiscordAnnouncementService}):
+ * a message is inserted once and updated in place if it is edited on Discord.
+ * The ingestion path never deletes rows.</p>
+ */
+@Entity
+@Table(name = "discord_announcements", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"message_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class DiscordAnnouncement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(lombok.AccessLevel.NONE)
+    private UUID id;
+
+    @Column(name = "message_id", nullable = false, length = 32)
+    private String messageId;
+
+    @Column(name = "channel_id", nullable = false, length = 32)
+    private String channelId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(length = 255)
+    private String author;
+
+    @Column(name = "message_url", length = 512)
+    private String messageUrl;
+
+    @Column(name = "posted_at", nullable = false)
+    private Instant postedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public DiscordAnnouncement(String messageId, String channelId, String content,
+                               String author, String messageUrl, Instant postedAt) {
+        this.messageId = messageId;
+        this.channelId = channelId;
+        this.content = content;
+        this.author = author;
+        this.messageUrl = messageUrl;
+        this.postedAt = postedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/DiscordAnnouncementRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/DiscordAnnouncementRepository.java
@@ -1,0 +1,18 @@
+package com.dansplugins.api.repository;
+
+import com.dansplugins.api.entity.DiscordAnnouncement;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DiscordAnnouncementRepository extends JpaRepository<DiscordAnnouncement, UUID> {
+
+    /** Look up an existing announcement by its Discord message id (the upsert key). */
+    Optional<DiscordAnnouncement> findByMessageId(String messageId);
+
+    /** Announcements newest-first, for the News feed. */
+    List<DiscordAnnouncement> findAllByOrderByPostedAtDesc(Pageable pageable);
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/scheduler/DiscordAnnouncementPoller.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/scheduler/DiscordAnnouncementPoller.java
@@ -1,0 +1,34 @@
+package com.dansplugins.api.scheduler;
+
+import com.dansplugins.api.service.DiscordAnnouncementService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodically polls Discord for new announcements. The poll cadence is the
+ * {@code dpc.discord.poll-interval-millis} property; the service itself is a
+ * no-op when the integration is disabled/unconfigured, so this runs harmlessly
+ * even when Discord ingestion is off.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordAnnouncementPoller {
+
+    private final DiscordAnnouncementService discordAnnouncementService;
+
+    @Scheduled(
+            fixedDelayString = "${dpc.discord.poll-interval-millis}",
+            initialDelayString = "${dpc.discord.initial-delay-millis:15000}"
+    )
+    public void poll() {
+        try {
+            discordAnnouncementService.syncAnnouncements();
+        } catch (Exception e) {
+            // Never let a poll failure kill the scheduler thread.
+            log.warn("Discord announcement poll failed: {}", e.getMessage());
+        }
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/DiscordAnnouncementService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/DiscordAnnouncementService.java
@@ -1,0 +1,147 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.client.DiscordClient;
+import com.dansplugins.api.config.DiscordProperties;
+import com.dansplugins.api.dto.DiscordMessageDto;
+import com.dansplugins.api.dto.NewsPostResponse;
+import com.dansplugins.api.entity.DiscordAnnouncement;
+import com.dansplugins.api.repository.DiscordAnnouncementRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Ingests Discord announcements into the {@code discord_announcements} table and
+ * exposes them as news posts.
+ *
+ * <p>Ingestion is a pure <b>upsert by message id</b>: each message is inserted
+ * once and updated in place if it is later edited. The service <b>never deletes</b>
+ * rows — mirroring the faction-sync safety ethos, a Discord outage or an empty
+ * fetch can never wipe previously-ingested announcements. When the integration
+ * is not {@link DiscordProperties#isConfigured() configured}, ingestion is a
+ * no-op.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordAnnouncementService {
+
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+
+    /** Cap on the derived title length before it is truncated with an ellipsis. */
+    static final int MAX_TITLE_LENGTH = 100;
+
+    private final DiscordProperties properties;
+    private final DiscordClient discordClient;
+    private final DiscordAnnouncementRepository repository;
+
+    /**
+     * Poll Discord and upsert each non-empty message. Returns the number of
+     * messages upserted (0 when the integration is disabled/unconfigured).
+     */
+    @Transactional
+    public int syncAnnouncements() {
+        if (!properties.isConfigured()) {
+            log.debug("Discord ingestion is disabled or unconfigured; skipping sync.");
+            return 0;
+        }
+
+        List<DiscordMessageDto> messages = discordClient.fetchAnnouncements();
+        int upserted = 0;
+        for (DiscordMessageDto message : messages) {
+            if (message.id() == null || isBlank(message.content())) {
+                // Skip messages with no usable text (e.g. embed- or attachment-only posts).
+                continue;
+            }
+            upsert(message);
+            upserted++;
+        }
+        if (upserted > 0) {
+            log.info("Ingested {} Discord announcement(s) from channel {}.",
+                    upserted, properties.announcementsChannelId());
+        }
+        return upserted;
+    }
+
+    /** Recent announcements as news posts, newest-first. */
+    @Transactional(readOnly = true)
+    public List<NewsPostResponse> getRecentAsNewsPosts() {
+        return repository.findAllByOrderByPostedAtDesc(PageRequest.of(0, properties.fetchLimit()))
+                .stream()
+                .map(this::toNewsPost)
+                .toList();
+    }
+
+    private void upsert(DiscordMessageDto message) {
+        String author = message.author() != null ? message.author().displayName() : null;
+        String messageUrl = buildMessageUrl(message.id());
+        Instant postedAt = message.timestamp() != null ? message.timestamp().toInstant() : Instant.now();
+
+        DiscordAnnouncement entity = repository.findByMessageId(message.id()).orElse(null);
+        if (entity == null) {
+            entity = new DiscordAnnouncement(message.id(), properties.announcementsChannelId(),
+                    message.content(), author, messageUrl, postedAt);
+        } else {
+            // Update in place if the message was edited on Discord — never replace the row.
+            entity.setContent(message.content());
+            entity.setAuthor(author);
+            entity.setMessageUrl(messageUrl);
+            entity.setPostedAt(postedAt);
+        }
+        repository.save(entity);
+    }
+
+    private NewsPostResponse toNewsPost(DiscordAnnouncement announcement) {
+        return new NewsPostResponse(
+                "discord-" + announcement.getMessageId(),
+                deriveTitle(announcement.getContent()),
+                DATE_FORMAT.format(announcement.getPostedAt()),
+                announcement.getContent(),
+                "discord",
+                announcement.getMessageUrl(),
+                announcement.getAuthor()
+        );
+    }
+
+    private String buildMessageUrl(String messageId) {
+        if (properties.guildId() == null || properties.guildId().isBlank()) {
+            return null;
+        }
+        return "https://discord.com/channels/%s/%s/%s"
+                .formatted(properties.guildId(), properties.announcementsChannelId(), messageId);
+    }
+
+    /**
+     * Derive a post title from a message body: the first non-empty line,
+     * truncated to {@link #MAX_TITLE_LENGTH}. Pure/static for testability.
+     */
+    static String deriveTitle(String content) {
+        if (content == null) {
+            return "Discord announcement";
+        }
+        String firstLine = content.strip().lines()
+                .map(String::strip)
+                .filter(line -> !line.isEmpty())
+                .findFirst()
+                .orElse("");
+        if (firstLine.isEmpty()) {
+            return "Discord announcement";
+        }
+        if (firstLine.length() > MAX_TITLE_LENGTH) {
+            return firstLine.substring(0, MAX_TITLE_LENGTH - 1).stripTrailing() + "…";
+        }
+        return firstLine;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -38,3 +38,21 @@ dpc:
       max-deactivation-ratio: ${DPC_SYNC_MAX_DEACTIVATION_RATIO:0.5}
       # Hard absolute cap on factions that one sync may deactivate. 0 disables.
       max-deactivations-per-sync: ${DPC_SYNC_MAX_DEACTIVATIONS:1000}
+  discord:
+    # Ingest announcements from the community Discord into the News feed.
+    # Disabled by default: with enabled=false (or no bot token / channel id)
+    # the poller is a no-op and no calls are made to Discord.
+    enabled: ${DISCORD_ENABLED:false}
+    # Discord bot token (server-only secret). The bot must be a member of the
+    # guild with permission to read the announcements channel.
+    bot-token: ${DISCORD_BOT_TOKEN:}
+    # Numeric id of the announcements channel to read.
+    announcements-channel-id: ${DISCORD_ANNOUNCEMENTS_CHANNEL_ID:}
+    # Numeric guild id, used only to build message permalinks (sourceUrl).
+    guild-id: ${DISCORD_GUILD_ID:}
+    # How many recent messages to request per poll (1..100).
+    fetch-limit: ${DISCORD_FETCH_LIMIT:20}
+    # Discord REST API base URL.
+    api-base-url: ${DISCORD_API_BASE_URL:https://discord.com/api/v10}
+    # Delay between polls, in milliseconds (default 5 minutes).
+    poll-interval-millis: ${DISCORD_POLL_INTERVAL_MILLIS:300000}

--- a/dpc-api/src/main/resources/db/migration/V8__create_discord_announcements_table.sql
+++ b/dpc-api/src/main/resources/db/migration/V8__create_discord_announcements_table.sql
@@ -1,0 +1,28 @@
+-- Stores announcements ingested from the community Discord server's
+-- announcements channel so they can be surfaced as posts on the website's News
+-- page. This migration is purely additive: it creates one new table and its
+-- indexes and does not alter or touch the factions tables in any way.
+--
+-- Rows are upserted by message_id (see DiscordAnnouncementService): an
+-- announcement is inserted once and updated in place if the Discord message is
+-- edited. The ingestion path never deletes rows, so a Discord outage or an
+-- empty fetch cannot wipe previously-ingested announcements.
+CREATE TABLE discord_announcements (
+    id          UUID PRIMARY KEY,
+    message_id  VARCHAR(32)  NOT NULL,
+    channel_id  VARCHAR(32)  NOT NULL,
+    content     TEXT         NOT NULL,
+    author      VARCHAR(255),
+    message_url VARCHAR(512),
+    posted_at   TIMESTAMPTZ  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- One row per Discord message; the upsert path looks rows up by message_id.
+CREATE UNIQUE INDEX idx_discord_announcements_message_id_unique
+    ON discord_announcements (message_id);
+
+-- The News feed reads announcements newest-first.
+CREATE INDEX idx_discord_announcements_posted_at
+    ON discord_announcements (posted_at DESC);

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/NewsControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/NewsControllerTest.java
@@ -1,0 +1,60 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.entity.DiscordAnnouncement;
+import com.dansplugins.api.repository.DiscordAnnouncementRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NewsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DiscordAnnouncementRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void getNews_isPublic_andReturnsAnnouncementsAsNewsPosts() throws Exception {
+        DiscordAnnouncement announcement = new DiscordAnnouncement("555", "1234567890",
+                "Server event this weekend\nJoin us!", "Dan", null,
+                Instant.parse("2026-06-01T12:00:00Z"));
+        repository.save(announcement);
+
+        // No authentication is provided: the endpoint must be public.
+        mockMvc.perform(get("/api/v1/news"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id", is("discord-555")))
+                .andExpect(jsonPath("$[0].title", is("Server event this weekend")))
+                .andExpect(jsonPath("$[0].source", is("discord")))
+                .andExpect(jsonPath("$[0].date", is("2026-06-01")));
+    }
+
+    @Test
+    void getNews_withNoAnnouncements_returnsEmptyArray() throws Exception {
+        mockMvc.perform(get("/api/v1/news"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/service/DiscordAnnouncementServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/DiscordAnnouncementServiceTest.java
@@ -1,0 +1,153 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.client.DiscordClient;
+import com.dansplugins.api.config.DiscordProperties;
+import com.dansplugins.api.dto.DiscordMessageDto;
+import com.dansplugins.api.dto.NewsPostResponse;
+import com.dansplugins.api.entity.DiscordAnnouncement;
+import com.dansplugins.api.repository.DiscordAnnouncementRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DiscordAnnouncementServiceTest {
+
+    @Mock
+    private DiscordClient discordClient;
+
+    @Mock
+    private DiscordAnnouncementRepository repository;
+
+    private DiscordAnnouncementService serviceWith(DiscordProperties properties) {
+        return new DiscordAnnouncementService(properties, discordClient, repository);
+    }
+
+    private static DiscordProperties configured() {
+        return new DiscordProperties(true, "bot-token", "1234567890", "999",
+                20, "https://discord.com/api/v10", 300000L);
+    }
+
+    private static DiscordProperties disabled() {
+        return new DiscordProperties(false, "", "", "",
+                20, "https://discord.com/api/v10", 300000L);
+    }
+
+    private static DiscordMessageDto message(String id, String content) {
+        return new DiscordMessageDto(id, content,
+                OffsetDateTime.of(2026, 6, 1, 12, 0, 0, 0, ZoneOffset.UTC),
+                new DiscordMessageDto.Author("dan", "Dan"));
+    }
+
+    @Test
+    void syncAnnouncements_whenDisabled_isNoOpAndNeverCallsDiscord() {
+        int upserted = serviceWith(disabled()).syncAnnouncements();
+
+        assertThat(upserted).isZero();
+        verifyNoInteractions(discordClient);
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void syncAnnouncements_insertsNewMessages_andNeverDeletes() {
+        when(discordClient.fetchAnnouncements()).thenReturn(List.of(
+                message("100", "First announcement"),
+                message("101", "Second announcement")
+        ));
+        when(repository.findByMessageId(any())).thenReturn(Optional.empty());
+
+        int upserted = serviceWith(configured()).syncAnnouncements();
+
+        assertThat(upserted).isEqualTo(2);
+        verify(repository, times(2)).save(any(DiscordAnnouncement.class));
+        // The ingestion path must never delete previously-ingested announcements.
+        verify(repository, never()).delete(any());
+        verify(repository, never()).deleteAll();
+    }
+
+    @Test
+    void syncAnnouncements_updatesExistingMessageInPlace() {
+        DiscordAnnouncement existing = new DiscordAnnouncement("100", "1234567890",
+                "Old text", "dan", null, Instant.parse("2026-05-01T00:00:00Z"));
+
+        when(discordClient.fetchAnnouncements()).thenReturn(List.of(message("100", "Edited text")));
+        when(repository.findByMessageId("100")).thenReturn(Optional.of(existing));
+
+        int upserted = serviceWith(configured()).syncAnnouncements();
+
+        assertThat(upserted).isEqualTo(1);
+        // Same entity is updated (not a new row) and its content reflects the edit.
+        assertThat(existing.getContent()).isEqualTo("Edited text");
+        verify(repository).save(existing);
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    void syncAnnouncements_skipsMessagesWithBlankContent() {
+        when(discordClient.fetchAnnouncements()).thenReturn(List.of(
+                message("100", "Real content"),
+                message("101", "   "),
+                message("102", "")
+        ));
+        when(repository.findByMessageId("100")).thenReturn(Optional.empty());
+
+        int upserted = serviceWith(configured()).syncAnnouncements();
+
+        assertThat(upserted).isEqualTo(1);
+        verify(repository, times(1)).save(any(DiscordAnnouncement.class));
+    }
+
+    @Test
+    void getRecentAsNewsPosts_mapsEntityToNewsPostShape() {
+        DiscordAnnouncement entity = new DiscordAnnouncement("12345", "1234567890",
+                "Patch 1.2 is live\nDetails follow.", "Dan",
+                "https://discord.com/channels/999/1234567890/12345",
+                Instant.parse("2026-06-01T12:00:00Z"));
+
+        when(repository.findAllByOrderByPostedAtDesc(any())).thenReturn(List.of(entity));
+
+        List<NewsPostResponse> posts = serviceWith(configured()).getRecentAsNewsPosts();
+
+        assertThat(posts).hasSize(1);
+        NewsPostResponse post = posts.get(0);
+        assertThat(post.id()).isEqualTo("discord-12345");
+        assertThat(post.title()).isEqualTo("Patch 1.2 is live");
+        assertThat(post.date()).isEqualTo("2026-06-01");
+        assertThat(post.source()).isEqualTo("discord");
+        assertThat(post.sourceUrl()).isEqualTo("https://discord.com/channels/999/1234567890/12345");
+        assertThat(post.author()).isEqualTo("Dan");
+    }
+
+    @Test
+    void deriveTitle_usesFirstNonEmptyLine() {
+        assertThat(DiscordAnnouncementService.deriveTitle("\nHeadline\nbody")).isEqualTo("Headline");
+    }
+
+    @Test
+    void deriveTitle_truncatesLongFirstLine() {
+        String longLine = "x".repeat(200);
+        String title = DiscordAnnouncementService.deriveTitle(longLine);
+        assertThat(title).hasSize(DiscordAnnouncementService.MAX_TITLE_LENGTH);
+        assertThat(title).endsWith("…");
+    }
+
+    @Test
+    void deriveTitle_fallsBackForEmptyContent() {
+        assertThat(DiscordAnnouncementService.deriveTitle("   ")).isEqualTo("Discord announcement");
+    }
+}

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -3,7 +3,8 @@ import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
-import {getNewsPosts, NewsPost, NewsSource} from '../utils/newsStorage';
+import {getNewsPosts, mergeNewsPosts, NewsPost, NewsSource} from '../utils/newsStorage';
+import {getApiNewsPosts} from '../services/discordNewsService';
 
 // Import styles
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
@@ -28,9 +29,16 @@ interface NewsProps {
     posts: NewsPost[];
 }
 
-export const getServerSideProps = async () => ({
-    props: {posts: getNewsPosts()}
-});
+export const getServerSideProps = async () => {
+    // Merge locally-authored posts (data/news.json) with community posts from the
+    // DPC API (Discord announcements). The API fetch degrades to an empty list on
+    // failure, so the page always renders at least the local posts.
+    const [localPosts, apiPosts] = await Promise.all([
+        Promise.resolve(getNewsPosts()),
+        getApiNewsPosts()
+    ]);
+    return {props: {posts: mergeNewsPosts(localPosts, apiPosts)}};
+};
 
 const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
     const badge = SOURCE_BADGE[post.source];

--- a/services/discordNewsService.ts
+++ b/services/discordNewsService.ts
@@ -1,0 +1,27 @@
+import { NewsPost, normalizePost } from '../utils/newsStorage';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+
+// Fetch community news posts from the DPC API (currently Discord announcements)
+// and normalize them into the site's NewsPost shape. This is server-side only
+// (called from getServerSideProps). Like the visit counter, it is non-essential
+// and must never break the News page: any failure (API down, non-2xx, bad
+// payload) resolves to an empty list so the page still renders local posts.
+export const getApiNewsPosts = async (): Promise<NewsPost[]> => {
+    try {
+        const response = await fetch(`${API_BASE}/api/v1/news`);
+        if (!response.ok) {
+            return [];
+        }
+        const data: unknown = await response.json();
+        if (!Array.isArray(data)) {
+            return [];
+        }
+        return data
+            .map(normalizePost)
+            .filter((post): post is NewsPost => post !== null);
+    } catch (error) {
+        console.error('Failed to fetch news from the DPC API; showing local posts only.', error);
+        return [];
+    }
+};

--- a/utils/newsStorage.ts
+++ b/utils/newsStorage.ts
@@ -45,9 +45,10 @@ const DEFAULT_POSTS: NewsPost[] = [
 
 const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.length > 0;
 
-// Normalize a raw post from the file into a fully-populated, serializable
-// NewsPost (no `undefined` values, which Next.js cannot serialize into props).
-const normalizePost = (raw: unknown): NewsPost | null => {
+// Normalize a raw post (from the file or the DPC API) into a fully-populated,
+// serializable NewsPost (no `undefined` values, which Next.js cannot serialize
+// into props).
+export const normalizePost = (raw: unknown): NewsPost | null => {
     if (typeof raw !== 'object' || raw === null) {
         return null;
     }
@@ -70,6 +71,20 @@ const normalizePost = (raw: unknown): NewsPost | null => {
 
 const sortNewestFirst = (posts: NewsPost[]): NewsPost[] =>
     [...posts].sort((a, b) => b.date.localeCompare(a.date));
+
+// Combine locally-authored posts with posts from the DPC API into a single
+// feed, newest-first. Local posts win on an id collision so a hand-authored
+// post is never overridden by an API post sharing its id.
+export const mergeNewsPosts = (local: NewsPost[], remote: NewsPost[]): NewsPost[] => {
+    const byId = new Map<string, NewsPost>();
+    for (const post of remote) {
+        byId.set(post.id, post);
+    }
+    for (const post of local) {
+        byId.set(post.id, post);
+    }
+    return sortNewestFirst(Array.from(byId.values()));
+};
 
 // Write atomically: temp file + rename, so an interrupted write cannot leave a
 // partial/invalid news.json behind.


### PR DESCRIPTION
## Summary

Implements #24 — community Discord **announcements appear as posts on the News page**, merged into the single chronological feed (with the existing "From Discord" badge), per the chosen design: **backend (dpc-api) integration + merged feed**.

### Backend (`dpc-api`, Spring Boot)
- **Migration `V8__create_discord_announcements_table.sql`** — *purely additive*: one new `discord_announcements` table (unique `message_id`) + indexes. **No faction table is touched.**
- **`DiscordAnnouncementService`** — a `@Scheduled` poller reads recent messages from the announcements channel via the Discord REST API (`DiscordClient`, Spring `RestClient`) and **upserts by `message_id`**: inserted once, updated in place if edited on Discord, **never deleted**. This mirrors the faction-sync safety ethos — a Discord outage or an empty fetch can't wipe previously-ingested announcements. No-op when unconfigured.
- **`GET /api/v1/news`** (public, like the factions GET) returns announcements in the website's `NewsPost` shape: `id` = `discord-<msgId>`, `title` = first line, `body` = full message, `source` = `"discord"`, UTC `date`, optional permalink `sourceUrl`.
- **Disabled by default** (`DISCORD_ENABLED=false`); enabled per-environment via `DISCORD_*` (documented in `dpc-api/README.md`). `@EnableScheduling` added; `DiscordProperties` registered.

### Frontend (Next.js)
- `services/discordNewsService.getApiNewsPosts()` fetches the API **server-side** and degrades to `[]` on any failure (like the visit counter) — the page always renders local posts.
- `utils/newsStorage.mergeNewsPosts()` merges local `news.json` + API posts, **deduped by id (local wins)**, newest-first; `news.tsx` `getServerSideProps` uses it.

## Test plan

**Backend** (`cd dpc-api && ./mvnw test`) — all 12 suites pass, **0 failures/errors**:
- [x] `DiscordAnnouncementServiceTest` (8) — disabled no-op, insert, in-place update, **never deletes** (`verify(never()).delete`), blank-content skip, NewsPost mapping, title derivation
- [x] `NewsControllerTest` (2) — public access, mapped response, empty case
- [x] `FlywayMigrationTest` — **validates V8 against real Postgres 16** (Testcontainers) with `ddl-auto=validate`, so the entity ↔ migration match
- [x] `DpcApiPactProviderTest` still passes — the Medieval Factions ↔ API contract is unaffected

**Frontend** (`npm run lint && npm test && npm run build`):
- [x] lint clean; build succeeds
- [x] 39 tests pass incl. new `discordNewsService` (5) and `newsMerge` (3)

## Notes / decisions
- Ships **disabled by default** — safe no-op with no credentials; no calls to Discord until enabled.
- Title derivation: first non-empty line (truncated to 100 chars), full message as body. Documented in `dpc-api/README.md`.
- `sourceUrl` permalink requires `DISCORD_GUILD_ID`; omitted (null) when not set.
- **Size:** this is a dedicated feature (not a polish cycle), ~950 LOC across 24 files (15 new), spanning Java + TS. Given it touches the backend, a DB migration, security config, and a new public endpoint, **It is left open for human review rather than auto-merged.**

Closes #24

---

_drafted by Claude on behalf of Daniel Stephenson_