### PR TITLE
docs(roadmap): bring the road map up to date

### DIFF
--- a/pages/data/roadmap.json
+++ b/pages/data/roadmap.json
@@ -29,12 +29,22 @@
     {
       "title": "About, Road Map & Commissions Pages",
       "description": "Informational pages introducing the community, its plans, and custom-development availability.",
-      "status": "In Progress"
+      "status": "Completed"
     },
     {
       "title": "News Page",
-      "description": "A news page surfacing community announcements, including posts pulled from the Discord server.",
-      "status": "Planned"
+      "description": "A news page surfacing community announcements, newest-first, with posts editable on the server at runtime.",
+      "status": "Completed"
+    },
+    {
+      "title": "UX & Accessibility Improvements",
+      "description": "A dark/light theme that persists and follows the operating-system preference, current-page navigation highlighting, consistent new-tab external links, keyboard-accessible cards, and in-place error retry on the leaderboard.",
+      "status": "Completed"
+    },
+    {
+      "title": "Discord Announcements in News",
+      "description": "Automatically pull announcements from the community Discord server into the News feed alongside hand-written posts.",
+      "status": "In Progress"
     },
     {
       "title": "Editable Plugin Catalogue",


### PR DESCRIPTION
## Summary

The Road Map page showed shipped work as unfinished. This refreshes `pages/data/roadmap.json` to match the actual state of the project:

- **About, Road Map & Commissions Pages**: `In Progress` → **`Completed`** (these pages shipped).
- **News Page**: `Planned` → **`Completed`** (the base page shipped; posts are runtime-editable).
- **Added "UX & Accessibility Improvements"** (`Completed`) — theme persistence + OS preference, current-page nav highlighting, consistent new-tab external links, keyboard-accessible cards, and leaderboard retry.
- **Added "Discord Announcements in News"** (`In Progress`) — split out of the News item, since pulling Discord announcements is still in review (PR #141, draft).
- Unchanged: *Editable Plugin Catalogue* and *TLS via Reverse Proxy* (`Planned`).

Result: 8 Completed / 1 In Progress / 2 Planned.

## Test plan
- [x] `roadmap.json` is valid JSON (11 items)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] Viewed locally at `/roadmap` — all items render under the correct status sections

## Note
*TLS via Reverse Proxy* (#57) is kept as Planned, but may be obsolete: production TLS is already handled by the Traefik reverse proxy in the gateway deployment. Flagging for a separate decision rather than changing it here.

---

_drafted by Claude on behalf of Daniel Stephenson_