### PR TITLE
chore(release): cut 0.10.0 changelog and bump to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.10.0] – 2026-06-07
+
 ### Fixed
 
 - The **Guides** page now lists a guide for every plugin in the catalogue, not just Medieval Factions. Links are derived from `pages/data/plugins.json` and point at each plugin's in-repo `USER_GUIDE.md` (the required in-repo guide per the DPC conventions), opening in a new tab with `rel="noopener noreferrer"`. Previously the page claimed guides existed "for each plugin" but linked only one.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dpc-website",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dpc-website",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Post-release housekeeping for the **0.10.0** tag (already created from `main`).

- `CHANGELOG.md`: moved the `[Unreleased]` entries into a dated **`[0.10.0] – 2026-06-07`** section and opened a fresh empty `[Unreleased]`.
- `package.json` + `package-lock.json`: bumped `0.10.0` → **`0.11.0`** to begin the next cycle (a `0.11.0` milestone is already open).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `package-lock.json` diff is only the version (2 lines), so `npm ci` stays consistent

---

_drafted by Claude on behalf of Daniel Stephenson_