### PR TITLE
docs: document Guides/Leaderboard/Account pages and __tests__/data dirs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,8 @@ This repository is a monorepo containing a frontend and a backend.
 - `public/` – Static assets served at the root URL
 - `utils/` – Shared utility functions
 - `services/` – Data-fetching or business-logic services
+- `__tests__/` – Unit tests (Vitest)
+- `data/` – Runtime-persisted JSON (`news.json`, `visits.json`); bind-mounted in `compose.yml`
 
 ### Backend
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `USER_GUIDE.md` now documents the **Guides**, **Leaderboard**, and **Account** pages. These are all reachable from the top navigation bar but were previously absent from the guide's "Common Scenarios", which only covered News, About, Road Map, and Commissions.
+- `.github/copilot-instructions.md` now lists the `__tests__/` (Vitest) and `data/` (runtime-persisted JSON, bind-mounted in `compose.yml`) directories in its frontend Project Structure, which previously omitted both tracked directories.
+
 ## [0.10.0] – 2026-06-07
 
 ### Fixed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -25,6 +25,16 @@ No special software is required to use the website. Simply visit [https://danspl
 1. Click **News** in the top navigation bar (or visit `/news`).
 2. Browse the posts, shown newest first.
 
+### Browsing Plugin Guides
+
+1. Click **Guides** in the top navigation bar (or visit `/guides`).
+2. Select a plugin from the list to open that plugin's user guide in a new tab.
+
+### Viewing the Faction Leaderboard
+
+1. Click **Leaderboard** in the top navigation bar (or visit `/leaderboard`).
+2. Review the factions, ranked by number of members across all servers.
+
 ### Learning About the Community
 
 1. Click **About** in the top navigation bar (or visit `/about`).
@@ -42,6 +52,12 @@ No special software is required to use the website. Simply visit [https://danspl
 1. Click **Commissions** in the top navigation bar (or visit `/commissions`).
 2. Review the pricing options, what's included, and the current availability status.
 3. Click **Join the Commissions Discord** to discuss your project.
+
+### Managing Your Account
+
+1. Click **Account** in the top navigation bar (or visit `/account`).
+2. Register a new account, or log in with an existing username and password.
+3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
 
 ### Getting Support
 


### PR DESCRIPTION
## Summary
- `USER_GUIDE.md` — added "Common Scenarios" entries for **Browsing Plugin Guides** (`/guides`), **Viewing the Faction Leaderboard** (`/leaderboard`), and **Managing Your Account** (`/account`). All three pages are rendered in the top nav (`components/TopBar.tsx:75-80`) but were previously absent from the guide.
- `.github/copilot-instructions.md` — added `__tests__/` (Vitest) and `data/` (runtime-persisted JSON, bind-mounted in `compose.yml:14`) to the frontend Project Structure, which previously omitted both tracked directories.
- `CHANGELOG.md` — recorded both fixes under `[Unreleased]`.

Docs-only; no code paths touched.

## Test plan
- [x] `npm run lint` — no warnings or errors
- [x] `npm run build` — clean (all pages compile)
- [x] Guide text traced against source: Guides (`pages/guides.tsx` — select a plugin, opens its USER_GUIDE.md in a new tab), Leaderboard (`pages/leaderboard.tsx` — factions ranked by member count), Account (`pages/account.tsx` — register/login + create/delete API keys)

Closes #147
Closes #148

## Deferred this cycle (skip reasons)
- #149 (Java auth-filter test expansion), #150 / #151 (refactors) — deferred to later cycles; not bundled to keep this PR a coherent docs-only change.
- #142 / #87 / #57 / #24 — larger feature/infra work; #24 is already in flight as draft PR #141.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_