### PR TITLE
test: cover ApiKeyAuthFilter and JwtAuthFilter

### DIFF
--- a/dpc-api/src/test/java/com/dansplugins/api/filter/ApiKeyAuthFilterTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/filter/ApiKeyAuthFilterTest.java
@@ -1,0 +1,142 @@
+package com.dansplugins.api.filter;
+
+import com.dansplugins.api.service.ApiKeyService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.FilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApiKeyAuthFilterTest {
+
+    @Mock
+    private ApiKeyService apiKeyService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private ApiKeyAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        // Real ObjectMapper so the 401 error body is serialized exactly as in production.
+        filter = new ApiKeyAuthFilter(apiKeyService, new ObjectMapper());
+    }
+
+    private MockHttpServletRequest request(String method, String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod(method);
+        request.setRequestURI(uri);
+        return request;
+    }
+
+    @Test
+    void doFilterInternal_exemptRegisterPath_passesThroughWithoutKey() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/accounts/register");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_exemptLoginPath_passesThroughWithoutKey() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/accounts/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_accountManagementPath_passesThroughWithoutKey() throws Exception {
+        MockHttpServletRequest request = request("DELETE", "/api/v1/accounts/me/keys/abc");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_readMethod_isNotGatedByApiKey() throws Exception {
+        MockHttpServletRequest request = request("GET", "/api/v1/factions");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_writeWithValidKey_passesThrough() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/factions");
+        request.addHeader("X-API-Key", "valid-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(apiKeyService.isValidKey("valid-key")).thenReturn(true);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void doFilterInternal_writeWithMissingKey_returns401AndDoesNotProceed() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/factions");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.getContentAsString()).contains("Invalid or missing API key");
+    }
+
+    @Test
+    void doFilterInternal_writeWithInvalidKey_returns401AndDoesNotProceed() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/factions");
+        request.addHeader("X-API-Key", "bogus");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(apiKeyService.isValidKey("bogus")).thenReturn(false);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    void doFilterInternal_writeWithWhitespacePaddedKey_isTrimmedBeforeValidation() throws Exception {
+        MockHttpServletRequest request = request("PUT", "/api/v1/factions");
+        request.addHeader("X-API-Key", "  valid-key  ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // Only the trimmed form is a valid key; the padded form must be trimmed first.
+        when(apiKeyService.isValidKey("valid-key")).thenReturn(true);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
@@ -1,0 +1,108 @@
+package com.dansplugins.api.filter;
+
+import com.dansplugins.api.service.JwtService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import jakarta.servlet.FilterChain;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthFilterTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthFilter filter;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void doFilterInternal_withValidBearerToken_setsAuthentication() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer good-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("alice");
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_withNoAuthHeader_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_withNonBearerHeader_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_whenTokenHasNoUsername_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer expired-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(jwtService.extractUsername("expired-token")).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_doesNotOverwriteExistingAuthentication() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer good-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        lenient().when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
+        var existing = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                "preexisting", null, java.util.List.of());
+        SecurityContextHolder.getContext().setAuthentication(existing);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(existing);
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
@@ -17,7 +17,6 @@ import jakarta.servlet.FilterChain;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,7 +94,7 @@ class JwtAuthFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer good-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
-        lenient().when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
+        when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
         var existing = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
                 "preexisting", null, java.util.List.of());
         SecurityContextHolder.getContext().setAuthentication(existing);


### PR DESCRIPTION
## Summary
Adds characterization unit tests for the two Spring Security filters in `dpc-api`, which previously had **zero** test coverage (the authentication boundary for all API writes).

- `dpc-api/src/test/.../filter/ApiKeyAuthFilterTest.java` (8 tests) — exempt `register`/`login`/`/api/v1/accounts/` paths pass through without a key; read methods are not gated; a write with a valid `X-API-Key` proceeds; a write with a missing or invalid key returns **401** and does **not** invoke the filter chain; a whitespace-padded key is trimmed before validation.
- `dpc-api/src/test/.../filter/JwtAuthFilterTest.java` (5 tests) — a valid `Bearer` token populates the `SecurityContext`; no header / non-Bearer / username-less token leave it unauthenticated; an existing authentication is not overwritten; the chain is always invoked.

Collaborators (`JwtService`, `ApiKeyService`, `FilterChain`) are mocked; servlet objects use Spring's `MockHttpServletRequest/Response`. No Spring context, network, or DB — pure unit tests. **No production code changed** (characterization only).

## Test plan
- [x] `./mvnw -Dtest='JwtAuthFilterTest,ApiKeyAuthFilterTest' test` → `Tests run: 13, Failures: 0, Errors: 0`
- [x] Full `Build & Test API (Java)` suite runs in CI

No `CHANGELOG.md` entry: this is an internal test-only change with no user-facing behavior (consistent with Keep a Changelog).

Closes #149

## Deferred this cycle (skip reasons)
- #150, #151 — refactors, deferred to later cycles (kept this PR a single cohesive test-expansion area).
- #142 / #87 / #57 / #24 — larger feature/infra work; #24 in flight as draft PR #141.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_