### PR TITLE
refactor: extract shared writeJsonAtomic helper for storage modules

### DIFF
--- a/__tests__/atomicJson.test.ts
+++ b/__tests__/atomicJson.test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DATA_DIR, writeJsonAtomic } from '../utils/atomicJson';
+
+const TEST_DIR = path.join(DATA_DIR, '__atomicjson_test__');
+
+const cleanup = () => {
+    if (fs.existsSync(TEST_DIR)) {
+        fs.rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+};
+
+describe('writeJsonAtomic', () => {
+    afterEach(cleanup);
+
+    it('writes compact JSON by default', () => {
+        const file = path.join(TEST_DIR, 'compact.json');
+        writeJsonAtomic(file, { a: 1, b: 2 });
+        expect(fs.readFileSync(file, 'utf8')).toBe('{"a":1,"b":2}');
+    });
+
+    it('writes pretty-printed JSON when the pretty option is set', () => {
+        const file = path.join(TEST_DIR, 'pretty.json');
+        writeJsonAtomic(file, { a: 1 }, { pretty: true });
+        expect(fs.readFileSync(file, 'utf8')).toBe('{\n  "a": 1\n}');
+    });
+
+    it('creates the parent directory if it does not exist', () => {
+        const file = path.join(TEST_DIR, 'nested', 'deep', 'file.json');
+        writeJsonAtomic(file, { ok: true });
+        expect(fs.existsSync(file)).toBe(true);
+    });
+
+    it('overwrites an existing file and leaves no temp file behind', () => {
+        const file = path.join(TEST_DIR, 'overwrite.json');
+        writeJsonAtomic(file, { v: 1 });
+        writeJsonAtomic(file, { v: 2 });
+        expect(JSON.parse(fs.readFileSync(file, 'utf8'))).toEqual({ v: 2 });
+        const leftovers = fs.readdirSync(TEST_DIR).filter((name) => name.includes('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+});

--- a/utils/atomicJson.ts
+++ b/utils/atomicJson.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+// Shared directory for server-persisted JSON (visits.json, news.json). Lives on
+// the ./data volume bind-mounted in compose.yml, so it survives container
+// restarts and can be edited in place.
+export const DATA_DIR = path.join(process.cwd(), 'data');
+
+// Write JSON atomically: ensure the parent directory exists, serialize, write to
+// a temp file in the same directory, then rename it into place. rename is atomic
+// on POSIX filesystems, so a crash or restart mid-write cannot leave a
+// partially-written (invalid) file behind.
+export const writeJsonAtomic = (
+    filePath: string,
+    value: unknown,
+    options: { pretty?: boolean } = {}
+): void => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const json = options.pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+    const tempFile = `${filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tempFile, json);
+    fs.renameSync(tempFile, filePath);
+};

--- a/utils/newsStorage.ts
+++ b/utils/newsStorage.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { DATA_DIR, writeJsonAtomic } from './atomicJson';
 
-const DATA_DIR = path.join(process.cwd(), 'data');
 const NEWS_FILE = path.join(DATA_DIR, 'news.json');
 
 // Where a post came from, so the UI can label its provenance.
@@ -71,16 +71,7 @@ const normalizePost = (raw: unknown): NewsPost | null => {
 const sortNewestFirst = (posts: NewsPost[]): NewsPost[] =>
     [...posts].sort((a, b) => b.date.localeCompare(a.date));
 
-// Write atomically: temp file + rename, so an interrupted write cannot leave a
-// partial/invalid news.json behind.
-const writeNewsData = (posts: NewsPost[]) => {
-    if (!fs.existsSync(DATA_DIR)) {
-        fs.mkdirSync(DATA_DIR, { recursive: true });
-    }
-    const tempFile = `${NEWS_FILE}.${process.pid}.tmp`;
-    fs.writeFileSync(tempFile, JSON.stringify({ posts }, null, 2));
-    fs.renameSync(tempFile, NEWS_FILE);
-};
+const writeNewsData = (posts: NewsPost[]) => writeJsonAtomic(NEWS_FILE, { posts }, { pretty: true });
 
 // Read the news posts, newest first. If the file is absent, seed it with the
 // default posts. If it is present but unreadable/invalid, log and serve the

--- a/utils/visitStorage.ts
+++ b/utils/visitStorage.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { DATA_DIR, writeJsonAtomic } from './atomicJson';
 
-const DATA_DIR = path.join(process.cwd(), 'data');
 const VISITS_FILE = path.join(DATA_DIR, 'visits.json');
 
 interface VisitData {
@@ -22,17 +22,7 @@ const isValidVisitData = (value: unknown): value is VisitData => {
     return typeof data.visits === 'number' && typeof data.startDate === 'string';
 };
 
-// Write atomically: write to a temp file in the same directory, then rename it
-// into place. rename is atomic on POSIX filesystems, so a crash or restart
-// mid-write cannot leave a partially-written (invalid) visits.json behind.
-const writeVisitData = (data: VisitData) => {
-    if (!fs.existsSync(DATA_DIR)) {
-        fs.mkdirSync(DATA_DIR, { recursive: true });
-    }
-    const tempFile = `${VISITS_FILE}.${process.pid}.tmp`;
-    fs.writeFileSync(tempFile, JSON.stringify(data));
-    fs.renameSync(tempFile, VISITS_FILE);
-};
+const writeVisitData = (data: VisitData) => writeJsonAtomic(VISITS_FILE, data);
 
 export const initializeVisitStorage = () => {
     if (!fs.existsSync(VISITS_FILE)) {


### PR DESCRIPTION
## Summary
`utils/visitStorage.ts` and `utils/newsStorage.ts` each contained a byte-for-byte identical atomic-write block (ensure dir → temp file keyed by PID → rename) and each independently defined `DATA_DIR`. This extracts both into a single `utils/atomicJson.ts`:

- `writeJsonAtomic(filePath, value, { pretty })` — the shared atomic write.
- `DATA_DIR` — the shared data directory constant.

Behavior is preserved exactly: `visits.json` stays compact (`JSON.stringify(data)`), `news.json` stays pretty-printed (2-space). The redundant `if (!fs.existsSync(DATA_DIR)) mkdirSync(...)` guard is dropped because `fs.mkdirSync(..., { recursive: true })` is already idempotent.

## Test plan
- [x] `npx vitest run` → **37 passed** — the existing `visitStorage.test.ts` (5) and `newsStorage.test.ts` (6) real-fs tests pass unchanged, confirming behavior is preserved.
- [x] New `__tests__/atomicJson.test.ts` (4) — compact default, pretty option, parent-dir creation, overwrite-leaves-no-temp-file.
- [x] `npm run lint` clean; `npm run build` compiled successfully.

No `CHANGELOG.md` entry: internal refactor with no user-facing behavior change (consistent with Keep a Changelog).

Closes #150

## Deferred this cycle (skip reasons)
- #151 — sibling refactor (Java controller), planned for the next cycle.
- #142 / #87 / #57 / #24 — larger feature/infra work; #24 in flight as draft PR #141.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_