### PR TITLE
refactor: extract getCurrentAccount helper in AccountController

### DIFF
--- a/dpc-api/src/main/java/com/dansplugins/api/controller/AccountController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/AccountController.java
@@ -85,8 +85,7 @@ public class AccountController {
     @ApiResponse(responseCode = "200", description = "Profile retrieved")
     @ApiResponse(responseCode = "401", description = "Not authenticated")
     public ResponseEntity<AccountResponse> getProfile(Principal principal) {
-        Account account = accountService.findByUsername(principal.getName())
-                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+        Account account = getCurrentAccount(principal);
         List<ApiKey> keys = accountService.getApiKeys(account);
         return ResponseEntity.ok(accountMapper.toResponse(account, keys));
     }
@@ -103,8 +102,7 @@ public class AccountController {
     public ResponseEntity<CreateApiKeyResponse> createApiKey(
             Principal principal,
             @Valid @RequestBody CreateApiKeyRequest request) {
-        Account account = accountService.findByUsername(principal.getName())
-                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+        Account account = getCurrentAccount(principal);
         var apiKey = accountService.createApiKey(account, request.serverName());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CreateApiKeyResponse(apiKey.getId(), apiKey.getRawKey(),
@@ -121,11 +119,17 @@ public class AccountController {
     @ApiResponse(responseCode = "404", description = "API key not found or not owned by user")
     @ApiResponse(responseCode = "401", description = "Not authenticated")
     public ResponseEntity<Void> deleteApiKey(Principal principal, @PathVariable UUID keyId) {
-        Account account = accountService.findByUsername(principal.getName())
-                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+        Account account = getCurrentAccount(principal);
         if (!accountService.deleteApiKey(account, keyId)) {
             throw new ResourceNotFoundException("API key not found");
         }
         return ResponseEntity.noContent().build();
+    }
+
+    // Resolves the authenticated principal to its Account, or 404s if the account
+    // backing a valid token no longer exists.
+    private Account getCurrentAccount(Principal principal) {
+        return accountService.findByUsername(principal.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
     }
 }


### PR DESCRIPTION
## Summary
`getProfile()`, `createApiKey()`, and `deleteApiKey()` each repeated the same principal-to-account lookup:

```java
Account account = accountService.findByUsername(principal.getName())
        .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
```

Extracted into a private `getCurrentAccount(Principal)` helper so the not-found message and exception type live in one place. Behavior is unchanged.

## Test plan
- [x] `./mvnw -Dtest=AccountControllerTest test` → **Tests run: 23, Failures: 0, Errors: 0** — the existing controller tests (including the account-not-found paths) pass unchanged, confirming behavior is preserved.
- [x] Full `Build & Test API (Java)` suite runs in CI.

No `CHANGELOG.md` entry: internal refactor with no user-facing behavior change.

Closes #151

## Remaining backlog (skip reasons)
- #142 — bug in the Discord-announcements feature, which is still an unmerged draft (#141); fixing it now would be premature.
- #87 / #57 / #24 — larger feature/infra work (website-editable plugin JSON, nginx TLS, Discord ingestion); each is a multi-file change beyond a single cycle's scope ceiling.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_