### PR TITLE
test: cover GlobalExceptionHandler status/body mapping

### DIFF
--- a/dpc-api/src/test/java/com/dansplugins/api/config/GlobalExceptionHandlerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,158 @@
+package com.dansplugins.api.config;
+
+import com.dansplugins.api.exception.InvalidCredentialsException;
+import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.exception.UsernameAlreadyTakenException;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleValidation_returns400WithFieldErrors() {
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(
+                new FieldError("request", "username", "must not be blank"),
+                new FieldError("request", "password", "size must be between 8 and 64")));
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+
+        ProblemDetail problem = handler.handleValidation(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getTitle()).isEqualTo("Bad Request");
+        assertThat(problem.getProperties()).containsKey("errors");
+        @SuppressWarnings("unchecked")
+        var errors = (java.util.Map<String, String>) problem.getProperties().get("errors");
+        assertThat(errors)
+                .containsEntry("username", "must not be blank")
+                .containsEntry("password", "size must be between 8 and 64");
+    }
+
+    @Test
+    void handleMethodValidation_returns400() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+
+        ProblemDetail problem = handler.handleMethodValidation(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getTitle()).isEqualTo("Bad Request");
+        assertThat(problem.getDetail()).isEqualTo("Validation failed");
+    }
+
+    @Test
+    void handleConstraintViolation_returns400() {
+        ConstraintViolationException ex = new ConstraintViolationException(Collections.emptySet());
+
+        ProblemDetail problem = handler.handleConstraintViolation(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Validation failed");
+    }
+
+    @Test
+    void handleUnreadable_returns400() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        ProblemDetail problem = handler.handleUnreadable(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Malformed request body");
+    }
+
+    @Test
+    void handleTypeMismatch_returns400WithParameterName() {
+        MethodArgumentTypeMismatchException ex = mock(MethodArgumentTypeMismatchException.class);
+        when(ex.getName()).thenReturn("factionId");
+
+        ProblemDetail problem = handler.handleTypeMismatch(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Invalid value for parameter 'factionId'");
+    }
+
+    @Test
+    void handleUsernameAlreadyTaken_returns409WithMessage() {
+        ProblemDetail problem = handler.handleUsernameAlreadyTaken(
+                new UsernameAlreadyTakenException("alice"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(problem.getTitle()).isEqualTo("Conflict");
+        assertThat(problem.getDetail()).isEqualTo("Username already taken: alice");
+    }
+
+    @Test
+    void handleIllegalArgument_returns400WithMessage() {
+        ProblemDetail problem = handler.handleIllegalArgument(
+                new IllegalArgumentException("bad argument"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("bad argument");
+    }
+
+    @Test
+    void handleInvalidCredentials_returns401WithMessage() {
+        ProblemDetail problem = handler.handleInvalidCredentials(new InvalidCredentialsException());
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(problem.getTitle()).isEqualTo("Unauthorized");
+        assertThat(problem.getDetail()).isEqualTo("Invalid credentials");
+    }
+
+    @Test
+    void handleResourceNotFound_returns404WithMessage() {
+        ProblemDetail problem = handler.handleResourceNotFound(
+                new ResourceNotFoundException("Account not found"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(problem.getTitle()).isEqualTo("Not Found");
+        assertThat(problem.getDetail()).isEqualTo("Account not found");
+    }
+
+    @Test
+    void handleResponseStatus_propagatesStatusAndReason() {
+        ProblemDetail problem = handler.handleResponseStatus(
+                new ResponseStatusException(HttpStatus.FORBIDDEN, "no access"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(problem.getTitle()).isEqualTo(HttpStatus.FORBIDDEN.getReasonPhrase());
+        assertThat(problem.getDetail()).isEqualTo("no access");
+    }
+
+    @Test
+    void handleResponseStatus_fallsBackToReasonPhraseWhenReasonNull() {
+        ProblemDetail problem = handler.handleResponseStatus(
+                new ResponseStatusException(HttpStatus.FORBIDDEN));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(problem.getDetail()).isEqualTo(HttpStatus.FORBIDDEN.getReasonPhrase());
+    }
+
+    @Test
+    void handleGeneral_returns500GenericMessage() {
+        ProblemDetail problem = handler.handleGeneral(new RuntimeException("boom"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(problem.getTitle()).isEqualTo("Internal Server Error");
+        // The raw exception message is deliberately NOT leaked to the client.
+        assertThat(problem.getDetail()).isEqualTo("Internal server error");
+    }
+}


### PR DESCRIPTION
## Summary
Adds characterization unit tests for `GlobalExceptionHandler` (the `@RestControllerAdvice` mapping every exception to a `ProblemDetail`), which previously had **zero** test coverage. 12 tests over all 11 handler methods, asserting:

- the mapped HTTP **status** and **title** for each exception type (400 validation/constraint/unreadable/type-mismatch/illegal-arg, 409 username-taken, 401 invalid-credentials, 404 not-found, pass-through for `ResponseStatusException`, 500 catch-all);
- the per-field **errors map** built by `handleValidation`;
- the `ResponseStatusException` reason-vs-reason-phrase fallback;
- that `handleGeneral` returns the generic `"Internal server error"` detail and does **not** leak the raw exception message.

Framework exceptions awkward to construct (`MethodArgumentNotValidException`, `HttpMessageNotReadableException`, `MethodArgumentTypeMismatchException`, `HandlerMethodValidationException`) are mocked; custom and JDK exceptions are instantiated directly. No Spring context or DB. **No production code changed** (characterization only).

## Test plan
- [x] `./mvnw -Dtest=GlobalExceptionHandlerTest test` → **Tests run: 12, Failures: 0, Errors: 0**
- [x] Full `Build & Test API (Java)` suite runs in CI.

This was a **Stage B (unit-test expansion)** cycle — the open backlog (#142/#87/#57/#24) is blocked on the unmerged Discord draft (#141) or larger than one cycle's scope ceiling. No tracking issue — coverage gap confirmed during triage (it was surfaced alongside #149's filter gap). No `CHANGELOG.md` entry: internal test-only change.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_