### PR TITLE
design: UI refresh foundation (brand theme, fonts, calmer surfaces)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.12.0] – 2026-06-13
+
+### Changed
+
+- Site-wide visual refresh. A new brand palette and type pairing (Inter for body, Space Grotesk for headings, loaded via a custom `_document`); solid app bars in place of the indigo gradient; removal of the gradient-clip text and the 20px grid-pattern page background; flat surfaces with hairline borders and softened hover lifts; a redesigned home hero with call-to-action buttons; restyled plugin cards (per-plugin avatar, server-count chip, clearer button hierarchy); and consistent table/card/page treatments across the Leaderboard, Account, Commissions, Road Map, About, Guides, and News pages.
+- Bumped the site version to 0.12.0.
+
 ### Fixed
 
 - `USER_GUIDE.md` now documents the **Guides**, **Leaderboard**, and **Account** pages. These are all reachable from the top navigation bar but were previously absent from the guide's "Common Scenarios", which only covered News, About, Road Map, and Commissions.

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import {Box, Typography, Paper, Grid} from '@mui/material';
+import {Box, Button, Typography, Paper, Grid, Stack} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import DownloadIcon from '@mui/icons-material/Download';
 import GamesIcon from '@mui/icons-material/Games';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 import {
     blurbBoxStyle,
@@ -22,7 +23,7 @@ const InfoCard: React.FC<{
 }> = ({icon, title, content, href}) => (
     <Grid item xs={12} md={4}>
         <Paper
-            elevation={3}
+            elevation={0}
             // When the card links somewhere, expose it as a focusable, keyboard-
             // operable control: a mouse-only onClick left keyboard and screen-
             // reader users unable to reach or activate these cards.
@@ -32,8 +33,9 @@ const InfoCard: React.FC<{
                 ...infoCardStyle(theme),
                 cursor: href ? 'pointer' : 'default',
                 '&:hover': href ? {
-                    transform: 'scale(1.02)',
-                    transition: 'transform 0.2s ease-in-out'
+                    transform: 'translateY(-2px)',
+                    boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+                    transition: 'transform 0.2s ease, box-shadow 0.2s ease'
                 } : {}
             })}
             onClick={() => href && window.open(href, '_blank', 'noopener,noreferrer')}
@@ -50,19 +52,57 @@ const InfoCard: React.FC<{
             <Typography variant="h6" gutterBottom sx={(theme) => infoCardTitleStyle()}>
                 {title}
             </Typography>
-            <Typography variant="body1">{content}</Typography>
+            <Typography variant="body1" color="text.secondary">{content}</Typography>
         </Paper>
     </Grid>
 );
 
 const Blurb: React.FC = () => (
     <Box sx={(theme) => blurbBoxStyle(theme)}>
+        <Box sx={{textAlign: 'center', py: {xs: 4, md: 8}}}>
+            <Typography
+                variant="h2"
+                gutterBottom
+                sx={(theme) => ({...blurbTitleStyle(theme), marginBottom: theme.spacing(2)})}
+            >
+                Dan&apos;s Plugins Community
+            </Typography>
+            <Typography
+                variant="h6"
+                color="text.secondary"
+                sx={{maxWidth: 640, mx: 'auto', fontWeight: 400}}
+            >
+                Free, open-source plugins for Minecraft servers — built in the open,
+                and easy to run, extend, and contribute to.
+            </Typography>
+            <Stack
+                direction={{xs: 'column', sm: 'row'}}
+                spacing={2}
+                justifyContent="center"
+                sx={{mt: 4}}
+            >
+                <Button variant="contained" size="large" href="#plugins">
+                    Browse Plugins
+                </Button>
+                <Button
+                    variant="outlined"
+                    size="large"
+                    href="https://github.com/Dans-Plugins"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    endIcon={<OpenInNewIcon fontSize="small"/>}
+                >
+                    View on GitHub
+                </Button>
+            </Stack>
+        </Box>
+
         <Typography
-            variant="h2"
-            gutterBottom
-            sx={(theme) => blurbTitleStyle(theme)}
+            variant="overline"
+            color="text.secondary"
+            sx={{display: 'block', textAlign: 'center', letterSpacing: '0.1em'}}
         >
-            Welcome to Dan&apos;s Plugins Community
+            Get involved
         </Typography>
 
         <Grid container spacing={4} sx={(theme) => blurbGridContainerStyle(theme)}>

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { Button, Card, CardActions, CardContent, Link, Typography } from '@mui/material';
+import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, Typography} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import DnsIcon from '@mui/icons-material/Dns';
 import {
     pluginCardStyle,
     pluginCardContentStyle,
     pluginCardActionsStyle,
-    pluginCardButtonStyle,
-    pluginCardTitleStyle,
-    pluginCardDescriptionStyle,
-    pluginCardServerCountStyle,
 } from '../styles/styles';
 
 interface PluginCardProps {
@@ -19,32 +17,95 @@ interface PluginCardProps {
     serverCount?: number | null;
 }
 
-const PluginCard: React.FC<PluginCardProps> = ({ 
-    title, 
-    description, 
-    githubLink, 
-    spigotmcLink, 
-    bStatsId, 
-    serverCount 
+// A small, fixed palette of muted brand-ish colours. Each plugin gets a stable
+// colour derived from its title so cards have a bit of visual identity without
+// being random on every render.
+const AVATAR_COLORS = ['#4263eb', '#7048e8', '#1098ad', '#f59f00', '#e8590c', '#0ca678'];
+
+const colorForTitle = (title: string): string => {
+    let hash = 0;
+    for (let i = 0; i < title.length; i++) {
+        hash = (hash * 31 + title.charCodeAt(i)) >>> 0;
+    }
+    return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+};
+
+const PluginCard: React.FC<PluginCardProps> = ({
+    title,
+    description,
+    githubLink,
+    spigotmcLink,
+    serverCount
 }) => {
     return (
         <Card sx={pluginCardStyle}>
             <CardContent sx={pluginCardContentStyle}>
-                <Typography {...pluginCardTitleStyle} component="div" variant="h5">{title}</Typography>
-                <Typography {...pluginCardDescriptionStyle} component="p" variant="body1">{description}</Typography>
-                {serverCount && serverCount > 0 ? (
-                    <Typography {...pluginCardServerCountStyle} component="span" variant="body2">
-                        <br />
-                        {serverCount} servers running
+                <Stack direction="row" spacing={1.5} alignItems="center" sx={{mb: 1.5}}>
+                    <Avatar
+                        variant="rounded"
+                        aria-hidden
+                        sx={{
+                            bgcolor: colorForTitle(title),
+                            width: 40,
+                            height: 40,
+                            fontFamily: '"Space Grotesk", sans-serif',
+                            fontWeight: 700,
+                        }}
+                    >
+                        {title.charAt(0).toUpperCase()}
+                    </Avatar>
+                    <Typography variant="h6" component="div" sx={{fontWeight: 600, lineHeight: 1.2}}>
+                        {title}
                     </Typography>
-                ) : null}
+                </Stack>
+                <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                        // Clamp to keep every card the same height regardless of
+                        // how long the plugin's description is.
+                        display: '-webkit-box',
+                        WebkitLineClamp: 3,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                    }}
+                >
+                    {description}
+                </Typography>
             </CardContent>
+
+            {serverCount && serverCount > 0 ? (
+                <Box sx={{px: 2, pb: 1}}>
+                    <Chip
+                        size="small"
+                        variant="outlined"
+                        icon={<DnsIcon/>}
+                        label={`${serverCount.toLocaleString()} servers`}
+                    />
+                </Box>
+            ) : null}
+
             <CardActions sx={pluginCardActionsStyle}>
-                <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={githubLink} target="_blank" rel="noopener noreferrer">
+                <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<GitHubIcon/>}
+                    component={Link}
+                    href={githubLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     GitHub
                 </Button>
                 {spigotmcLink ? (
-                    <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={spigotmcLink} target="_blank" rel="noopener noreferrer">
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        component={Link}
+                        href={spigotmcLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         SpigotMC
                     </Button>
                 ) : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dpc-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dpc-website",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,16 +34,59 @@ function MyApp({Component, pageProps}: AppProps) {
     );
 
     const theme = useMemo(
-        () => createTheme({
-            palette: {
-                mode
-            },
-            typography: {
-                button: {
-                    textTransform: 'none'
-                }
-            }
-        }),
+        () => {
+            const isDark = mode === 'dark';
+            const headingFont = '"Space Grotesk", system-ui, sans-serif';
+            return createTheme({
+                palette: {
+                    mode,
+                    primary: {main: isDark ? '#5c7cfa' : '#4263eb'},
+                    // Gold accent — used sparingly for emphasis (a nod to the
+                    // Minecraft/medieval audience without leaning faux-medieval).
+                    secondary: {main: '#f59f00'},
+                    background: isDark
+                        ? {default: '#0e1117', paper: '#161b22'}
+                        : {default: '#f6f8fa', paper: '#ffffff'},
+                },
+                shape: {borderRadius: 10},
+                typography: {
+                    fontFamily: '"Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+                    h1: {fontFamily: headingFont, fontWeight: 700, letterSpacing: '-0.02em'},
+                    h2: {fontFamily: headingFont, fontWeight: 700, letterSpacing: '-0.02em'},
+                    h3: {fontFamily: headingFont, fontWeight: 600, letterSpacing: '-0.01em'},
+                    h4: {fontFamily: headingFont, fontWeight: 600},
+                    h5: {fontFamily: headingFont, fontWeight: 600},
+                    h6: {fontFamily: headingFont, fontWeight: 600},
+                    button: {textTransform: 'none', fontWeight: 600},
+                },
+                components: {
+                    // Solid app bars instead of the old indigo gradient.
+                    MuiAppBar: {
+                        defaultProps: {elevation: 0},
+                        styleOverrides: {
+                            root: ({theme}) => ({
+                                backgroundImage: 'none',
+                                backgroundColor: isDark ? '#161b22' : theme.palette.primary.main,
+                                borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.16)'}`,
+                            }),
+                        },
+                    },
+                    // Flat surfaces with a hairline border rather than heavy MUI elevation.
+                    MuiPaper: {
+                        styleOverrides: {
+                            root: ({theme}) => ({
+                                backgroundImage: 'none',
+                                border: `1px solid ${theme.palette.divider}`,
+                            }),
+                        },
+                    },
+                    MuiButton: {
+                        defaultProps: {disableElevation: true},
+                        styleOverrides: {root: {borderRadius: 8}},
+                    },
+                },
+            });
+        },
         [mode]
     );
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,23 @@
+import {Html, Head, Main, NextScript} from 'next/document';
+
+// Load the brand fonts (Inter for body, Space Grotesk for headings) from Google
+// Fonts. Next 12 predates next/font, so they are linked here in the document
+// head; preconnect hints keep the extra round-trip cheap.
+export default function Document() {
+    return (
+        <Html>
+            <Head>
+                <link rel="preconnect" href="https://fonts.googleapis.com"/>
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous"/>
+                <link
+                    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+                    rel="stylesheet"
+                />
+            </Head>
+            <body>
+                <Main/>
+                <NextScript/>
+            </body>
+        </Html>
+    );
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,11 +1,12 @@
-import {Box, Button, Container, Typography} from '@mui/material';
+import {Box, Button, Container, Stack, Typography} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
 // Import styles
-import {pageStyle, sectionHeaderStyle, pluginsBoxStyle, containerPaddingStyle} from '../styles/styles';
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
 
 // Pull version from package.json
 const version = require('../package.json').version;
@@ -13,7 +14,7 @@ const version = require('../package.json').version;
 const About: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 About Us
             </Typography>
@@ -31,38 +32,36 @@ const About: NextPage = () => (
                 Want to get involved? Join the conversation on Discord, support development on Patreon,
                 or browse the source on GitHub.
             </Typography>
-            <Box sx={pluginsBoxStyle}>
+            <Stack direction="row" spacing={2} sx={{mt: 3, flexWrap: 'wrap', rowGap: 1}}>
                 <Button
                     variant="contained"
                     color="primary"
+                    startIcon={<GitHubIcon/>}
                     href="https://github.com/Dans-Plugins"
                     target="_blank"
                     rel="noopener noreferrer"
-                    sx={{mr: 1, mb: 1}}
                 >
                     GitHub
                 </Button>
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     color="primary"
                     href="https://discord.gg/xXtuAQ2"
                     target="_blank"
                     rel="noopener noreferrer"
-                    sx={{mr: 1, mb: 1}}
                 >
                     Discord
                 </Button>
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     color="primary"
                     href="https://www.patreon.com/danspluginscommunity"
                     target="_blank"
                     rel="noopener noreferrer"
-                    sx={{mr: 1, mb: 1}}
                 >
                     Patreon
                 </Button>
-            </Box>
+            </Stack>
         </Container>
         <BottomBar version={version}/>
     </Box>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -20,6 +20,7 @@ import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
 import BottomBar from '../components/BottomBar'
+import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 
 const version = require('../package.json').version
 
@@ -221,19 +222,22 @@ const AccountPage: NextPage = () => {
     }
 
     return (
-        <Box>
+        <Box sx={(theme) => pageStyle(theme)}>
             <TopBar/>
             <Container maxWidth="md" sx={{py: 4}}>
-                <Typography variant="h4" gutterBottom>
-                    Account Management
+                <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                    Account
+                </Typography>
+                <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
+                    Manage your account and the API keys your Minecraft servers use to sync with the DPC community data API.
                 </Typography>
 
                 {error && <Alert severity="error" sx={{mb: 2}} onClose={() => setError(null)}>{error}</Alert>}
                 {success && <Alert severity="success" sx={{mb: 2}} onClose={() => setSuccess(null)}>{success}</Alert>}
 
                 {!token ? (
-                    <>
-                        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{mb: 2}}>
+                    <Box sx={{maxWidth: 460, mx: 'auto', mt: 2}}>
+                        <Tabs value={tab} onChange={(_, v) => setTab(v)} centered sx={{mb: 2}}>
                             <Tab label="Login"/>
                             <Tab label="Register"/>
                         </Tabs>
@@ -291,7 +295,7 @@ const AccountPage: NextPage = () => {
                                 </CardContent>
                             </Card>
                         )}
-                    </>
+                    </Box>
                 ) : (
                     <>
                         {profile && (
@@ -321,9 +325,23 @@ const AccountPage: NextPage = () => {
                                 {newApiKey && (
                                     <Alert severity="warning" sx={{mb: 2}} onClose={() => setNewApiKey(null)}>
                                         <strong>Save this key now — it won&apos;t be shown again:</strong>
-                                        <Box sx={{display: 'flex', alignItems: 'center', mt: 1}}>
-                                            <code>{newApiKey}</code>
-                                            <IconButton size="small" onClick={() => copyToClipboard(newApiKey)} sx={{ml: 1}} aria-label="Copy API key to clipboard">
+                                        <Box sx={{display: 'flex', alignItems: 'center', gap: 1, mt: 1}}>
+                                            <Box
+                                                component="code"
+                                                sx={{
+                                                    flex: 1,
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.85rem',
+                                                    wordBreak: 'break-all',
+                                                    bgcolor: 'action.hover',
+                                                    px: 1,
+                                                    py: 0.5,
+                                                    borderRadius: 1,
+                                                }}
+                                            >
+                                                {newApiKey}
+                                            </Box>
+                                            <IconButton size="small" onClick={() => copyToClipboard(newApiKey)} aria-label="Copy API key to clipboard">
                                                 <ContentCopyIcon fontSize="small"/>
                                             </IconButton>
                                         </Box>
@@ -375,12 +393,15 @@ const AccountPage: NextPage = () => {
                                     Use these commands in your Minecraft server plugin to manage your account:
                                 </Typography>
                                 <Box component="pre" sx={{
-                                    bgcolor: 'grey.900',
-                                    color: 'grey.100',
+                                    bgcolor: '#0d1117',
+                                    color: '#c9d1d9',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
                                     p: 2,
-                                    borderRadius: 1,
+                                    borderRadius: 2,
                                     overflow: 'auto',
-                                    fontSize: '0.875rem'
+                                    fontSize: '0.85rem',
+                                    fontFamily: 'monospace',
                                 }}>
 {`# Register (creates account and returns JWT token)
 POST /api/v1/accounts/register

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -5,6 +5,7 @@ import {
     Container,
     List,
     ListItem,
+    ListItemIcon,
     ListItemText,
     Paper,
     Table,
@@ -15,6 +16,7 @@ import {
     TableRow,
     Typography
 } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import React from 'react';
@@ -49,7 +51,7 @@ const Commissions: NextPage = () => {
     return (
         <Box sx={(theme) => pageStyle(theme)}>
             <TopBar/>
-            <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+            <Container maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>
                     <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                         Commissions
@@ -57,37 +59,51 @@ const Commissions: NextPage = () => {
                     <Chip
                         label={isOpen ? 'Open for commissions' : 'Currently closed'}
                         color={isOpen ? 'success' : 'default'}
+                        variant={isOpen ? 'filled' : 'outlined'}
                     />
                 </Box>
-                <Typography variant="body1" gutterBottom>
+                <Typography variant="body1" color="text.secondary" sx={{mb: 3, maxWidth: 760}}>
                     Custom Minecraft plugin development by the creator of the Dan&apos;s Plugins Community
                     catalogue. Whether you need an existing plugin fixed and extended or a brand-new plugin
                     built to your specification, the pricing options below cover one-time projects, monthly
                     retainers, and ad-hoc hourly work.
                 </Typography>
 
-                <TableContainer component={Paper} sx={{mt: 3, mb: 3}}>
+                <TableContainer component={Paper} sx={{mt: 3, mb: 4}}>
                     <Table aria-label="commission pricing">
                         <TableHead>
-                            <TableRow>
+                            <TableRow
+                                sx={{
+                                    '& th': {
+                                        bgcolor: 'action.hover',
+                                        borderBottom: 2,
+                                        borderColor: 'divider',
+                                        fontWeight: 600,
+                                        fontSize: '0.72rem',
+                                        textTransform: 'uppercase',
+                                        letterSpacing: '0.07em',
+                                        color: 'text.secondary',
+                                    },
+                                }}
+                            >
                                 <TableCell>Service</TableCell>
-                                <TableCell>One-time</TableCell>
-                                <TableCell>Monthly retainer</TableCell>
-                                <TableCell>Ad hoc</TableCell>
+                                <TableCell align="right">One-time</TableCell>
+                                <TableCell align="right">Monthly retainer</TableCell>
+                                <TableCell align="right">Ad hoc</TableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
                             {commissionsData.tiers.map((tier) => (
-                                <TableRow key={tier.name}>
+                                <TableRow key={tier.name} sx={{'&:hover': {bgcolor: 'action.hover'}}}>
                                     <TableCell>
-                                        <Typography variant="subtitle1">{tier.name}</Typography>
+                                        <Typography variant="subtitle1" fontWeight={600}>{tier.name}</Typography>
                                         <Typography variant="body2" color="text.secondary">
                                             {tier.description}
                                         </Typography>
                                     </TableCell>
-                                    <TableCell>{tier.oneTime}</TableCell>
-                                    <TableCell>{tier.retainer}</TableCell>
-                                    <TableCell>{tier.adHoc}</TableCell>
+                                    <TableCell align="right">{tier.oneTime}</TableCell>
+                                    <TableCell align="right">{tier.retainer}</TableCell>
+                                    <TableCell align="right">{tier.adHoc}</TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -95,21 +111,25 @@ const Commissions: NextPage = () => {
                 </TableContainer>
 
                 <Typography variant="h5" gutterBottom>What&apos;s included</Typography>
-                <List dense>
+                <List>
                     {commissionsData.included.map((item) => (
-                        <ListItem key={item} sx={{display: 'list-item', listStyleType: 'disc', ml: 3, py: 0}}>
+                        <ListItem key={item} disableGutters sx={{py: 0.25}}>
+                            <ListItemIcon sx={{minWidth: 36}}>
+                                <CheckCircleOutlineIcon color="primary" fontSize="small"/>
+                            </ListItemIcon>
                             <ListItemText primary={item}/>
                         </ListItem>
                     ))}
                 </List>
 
-                <Typography variant="body1" sx={{mt: 2}} gutterBottom>
+                <Typography variant="body1" color="text.secondary" sx={{mt: 3}} gutterBottom>
                     To discuss a commission, join the commissions Discord server:
                 </Typography>
                 <Box sx={pluginsBoxStyle}>
                     <Button
                         variant="contained"
                         color="primary"
+                        size="large"
                         href={commissionsData.discordInvite}
                         target="_blank"
                         rel="noopener"

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -1,4 +1,4 @@
-import {Box, Container, List, ListItem, ListItemButton, ListItemText, Typography} from '@mui/material';
+import {Box, Container, List, ListItem, ListItemButton, ListItemText, Paper, Typography} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
@@ -27,29 +27,31 @@ const guides = [...pluginData.plugins].sort((a, b) => a.title.localeCompare(b.ti
 const Guides: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 Guides
             </Typography>
-            <Typography variant="body1" gutterBottom>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 Each plugin&apos;s guide (its <code>USER_GUIDE.md</code>) lives in the plugin&apos;s
                 repository. Select a plugin below to open its guide in a new tab.
             </Typography>
-            <List sx={{maxWidth: 600}}>
-                {guides.map((plugin) => (
-                    <ListItem key={plugin.id} disablePadding>
-                        <ListItemButton
-                            component="a"
-                            href={userGuideUrl(plugin.githubLink)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <ListItemText primary={`${plugin.title} Guide`}/>
-                            <OpenInNewIcon fontSize="small"/>
-                        </ListItemButton>
-                    </ListItem>
-                ))}
-            </List>
+            <Paper elevation={0} sx={{maxWidth: 600, overflow: 'hidden'}}>
+                <List disablePadding>
+                    {guides.map((plugin, index) => (
+                        <ListItem key={plugin.id} disablePadding divider={index < guides.length - 1}>
+                            <ListItemButton
+                                component="a"
+                                href={userGuideUrl(plugin.githubLink)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                <ListItemText primary={`${plugin.title} Guide`}/>
+                                <OpenInNewIcon fontSize="small" color="action"/>
+                            </ListItemButton>
+                        </ListItem>
+                    ))}
+                </List>
+            </Paper>
         </Container>
         <BottomBar version={version}/>
     </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -105,7 +105,7 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
     };
 
     return (
-        <Box sx={pluginsBoxStyle}>
+        <Box id="plugins" sx={pluginsBoxStyle}>
             <Typography variant="h3" component="div" gutterBottom sx={sectionHeaderStyle}>
                 Plugins
             </Typography>

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -114,13 +114,26 @@ const LeaderboardPage: NextPage = () => {
                         <TableContainer>
                             <Table>
                                 <TableHead>
-                                    <TableRow>
-                                        <TableCell sx={{fontWeight: 'bold', width: 60}} align="center">
+                                    <TableRow
+                                        sx={{
+                                            '& th': {
+                                                bgcolor: 'action.hover',
+                                                borderBottom: 2,
+                                                borderColor: 'divider',
+                                                fontWeight: 600,
+                                                fontSize: '0.72rem',
+                                                textTransform: 'uppercase',
+                                                letterSpacing: '0.07em',
+                                                color: 'text.secondary',
+                                            },
+                                        }}
+                                    >
+                                        <TableCell sx={{width: 60}} align="center">
                                             Rank
                                         </TableCell>
-                                        <TableCell sx={{fontWeight: 'bold'}}>Faction</TableCell>
-                                        <TableCell sx={{fontWeight: 'bold'}}>Server</TableCell>
-                                        <TableCell sx={{fontWeight: 'bold'}} align="right">
+                                        <TableCell>Faction</TableCell>
+                                        <TableCell>Server</TableCell>
+                                        <TableCell align="right">
                                             <Box sx={{display: 'inline-flex', alignItems: 'center', gap: 0.5}}>
                                                 <GroupIcon fontSize="small"/>
                                                 Members

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -35,7 +35,15 @@ export const getServerSideProps = async () => ({
 const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
     const badge = SOURCE_BADGE[post.source];
     return (
-        <Paper elevation={3} sx={{p: 2, mb: 2}}>
+        <Paper
+            elevation={0}
+            sx={{
+                p: 2.5,
+                mb: 2,
+                transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+                '&:hover': {transform: 'translateY(-2px)', boxShadow: '0 6px 20px rgba(0,0,0,0.12)'},
+            }}
+        >
             <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
                 <Typography variant="h6">{post.title}</Typography>
                 <Chip label={badge.label} color={badge.color} size="small"/>
@@ -56,7 +64,7 @@ const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
 const News: NextPage<NewsProps> = ({posts}) => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 News
             </Typography>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -30,23 +30,33 @@ const STATUS_ORDER: { status: RoadmapItem['status']; color: 'success' | 'warning
 ];
 
 const RoadmapCard: React.FC<{ item: RoadmapItem; color: 'success' | 'warning' | 'info' }> = ({item, color}) => (
-    <Paper elevation={3} sx={{p: 2, mb: 2}}>
+    <Paper
+        elevation={0}
+        sx={(theme) => ({
+            p: 2,
+            mb: 2,
+            // Status-coloured accent stripe down the left edge for quick scanning.
+            borderLeft: `4px solid ${theme.palette[color].main}`,
+            transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+            '&:hover': {transform: 'translateY(-2px)', boxShadow: '0 6px 20px rgba(0,0,0,0.12)'},
+        })}
+    >
         <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
             <Typography variant="h6">{item.title}</Typography>
             <Chip label={item.status} color={color} size="small"/>
         </Box>
-        <Typography variant="body2" sx={{mt: 1}}>{item.description}</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{mt: 1}}>{item.description}</Typography>
     </Paper>
 );
 
 const Roadmap: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 Road Map
             </Typography>
-            <Typography variant="body1" gutterBottom>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 This page tracks where Dan&apos;s Plugins Community is headed. For the day-to-day detail,
                 see the{' '}
                 <Link href="https://github.com/Dans-Plugins/dansplugins-dot-com/issues" target="_blank" rel="noopener">
@@ -60,7 +70,10 @@ const Roadmap: NextPage = () => (
                 }
                 return (
                     <Box key={status} sx={{mt: 4}}>
-                        <Typography variant="h5" gutterBottom>{status}</Typography>
+                        <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5}}>
+                            <Typography variant="h5">{status}</Typography>
+                            <Chip label={items.length} color={color} size="small" variant="outlined"/>
+                        </Box>
                         {items.map((item) => (
                             <RoadmapCard key={item.title} item={item} color={color}/>
                         ))}

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -283,37 +283,3 @@ export const pluginCardContentStyle = {
 export const pluginCardActionsStyle = {
     flexGrow: 0,
 };
-
-/**
- * Standard button style for plugin cards
- */
-export const pluginCardButtonStyle = () => ({
-    variant: 'contained',
-    size: 'small',
-    textTransform: 'none',
-});
-
-/**
- * Title configuration for plugin cards
- */
-export const pluginCardTitleStyle = {
-    gutterBottom: true,
-    variant: 'h5',
-    component: 'div',
-};
-
-/**
- * Description text style for plugin cards
- */
-export const pluginCardDescriptionStyle = {
-    variant: 'body2',
-    color: 'text.secondary',
-};
-
-/**
- * Server count text style for plugin cards
- */
-export const pluginCardServerCountStyle = {
-    variant: 'body2',
-    color: 'text.secondary',
-};

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -46,8 +46,11 @@ export const gridContainerStyle = {spacing: {xs: 2, md: 3}, pb: 4};
  * Card wrapper with hover lift animation
  */
 export const cardWrapperStyle = {
-    ...commonTransition,
-    '&:hover': {transform: 'translateY(-4px)'},
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+    },
 };
 
 /**
@@ -63,14 +66,12 @@ export const sectionDividerStyle = (theme: Theme) => {
 };
 
 /**
- * Main page layout with adaptive grid background pattern
+ * Main page layout. Uses a clean themed background (the former 20px grid
+ * overlay was removed as part of the UI refresh).
  */
 export const pageStyle = (theme: Theme) => ({
     flexGrow: 1,
-    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.background.default : '#f5f5f5',
-    backgroundImage: `linear-gradient(${theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.8)'} 1px, transparent 1px), 
-                   linear-gradient(90deg, ${theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.8)'} 1px, transparent 1px)`,
-    backgroundSize: '20px 20px',
+    backgroundColor: theme.palette.background.default,
     minHeight: '100vh',
 });
 
@@ -95,11 +96,12 @@ export const containerPaddingStyle = (theme: Theme) => ({
 });
 
 /**
- * App bar with gradient background based on theme mode
+ * App bar surface. Solid colour instead of the former indigo gradient (kept in
+ * sync with the MuiAppBar theme override in _app.tsx).
  */
 export const appBarStyle = (theme: Theme) => ({
-    background: `linear-gradient(45deg, ${theme.palette.mode === 'dark' ? '#1a237e 30%, #283593' : '#1976d2 30%, #2196f3'} 90%)`,
-    elevation: 4,
+    backgroundImage: 'none',
+    backgroundColor: theme.palette.mode === 'dark' ? '#161b22' : theme.palette.primary.main,
 });
 
 /**
@@ -121,12 +123,9 @@ export const navButtonStyle = (theme: Theme) => ({
 export const brandNameStyle = (theme: Theme) => ({
     display: 'inline',
     marginRight: theme.spacing(2),
-    fontWeight: 'bold',
-    background: 'linear-gradient(45deg, #fff 30%, rgba(255,255,255,0.8) 90%)',
-    backgroundClip: 'text',
-    textFillColor: 'transparent',
-    ...commonTransition,
-    '&:hover': {transform: 'scale(1.05)'},
+    fontWeight: 700,
+    letterSpacing: '-0.01em',
+    color: 'inherit',
 });
 
 /**
@@ -210,11 +209,9 @@ export const blurbBoxStyle = (theme: Theme) => ({
  * Gradient title style for blurb sections
  */
 export const blurbTitleStyle = (theme: Theme) => ({
-    fontWeight: 'bold',
+    fontWeight: 700,
+    letterSpacing: '-0.02em',
     marginBottom: theme.spacing(4),
-    background: 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
-    WebkitBackgroundClip: 'text',
-    textFillColor: 'transparent',
     textAlign: 'center',
 });
 
@@ -231,8 +228,11 @@ export const blurbGridContainerStyle = (theme: Theme) => ({
 export const infoCardStyle = (theme: Theme) => ({
     padding: theme.spacing(3),
     height: '100%',
-    ...commonTransition,
-    '&:hover': {transform: 'translateY(-4px)'},
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+    },
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -1,16 +1,6 @@
 import {Theme} from '@mui/material/styles';
 
 /**
- * Creates theme-aware gradient values for light/dark modes
- * Light mode: transparent black gradients
- * Dark mode: transparent white gradients
- */
-const getCommonGradient = (theme: Theme) => ({
-    light: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0)' : 'rgba(0,0,0,0)',
-    medium: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
-});
-
-/**
  * Standard animation transition for interactive elements
  */
 const commonTransition = {
@@ -27,14 +17,24 @@ const commonHoverBg = (theme: Theme) => ({
 });
 
 /**
- * Styles for section headers with underline accent
+ * Section headers: heading text in the standard text colour with a short
+ * primary-coloured accent bar underneath (replaces the former full-width blue
+ * underline).
  */
 export const sectionHeaderStyle = (theme: Theme) => ({
-    fontWeight: 'bold',
-    color: theme.palette.primary.main,
-    borderBottom: `2px solid ${theme.palette.primary.main}`,
-    paddingBottom: theme.spacing(1),
+    fontWeight: 700,
+    letterSpacing: '-0.01em',
+    display: 'inline-block',
     marginBottom: theme.spacing(3),
+    '&::after': {
+        content: '""',
+        display: 'block',
+        width: '44px',
+        height: '3px',
+        marginTop: theme.spacing(1),
+        borderRadius: '2px',
+        backgroundColor: theme.palette.primary.main,
+    },
 });
 
 /**
@@ -54,16 +54,14 @@ export const cardWrapperStyle = {
 };
 
 /**
- * Creates a responsive horizontal divider with fade effect
+ * Clean hairline section divider (replaces the former gradient-fade line).
  */
-export const sectionDividerStyle = (theme: Theme) => {
-    const gradient = getCommonGradient(theme);
-    return {
-        height: '2px',
-        background: `linear-gradient(to right, ${gradient.light}, ${gradient.medium}, ${gradient.light})`,
-        marginY: theme.spacing(4),
-    };
-};
+export const sectionDividerStyle = (theme: Theme) => ({
+    height: '1px',
+    border: 0,
+    backgroundColor: theme.palette.divider,
+    marginY: theme.spacing(6),
+});
 
 /**
  * Main page layout. Uses a clean themed background (the former 20px grid
@@ -84,7 +82,9 @@ export const pluginsBoxStyle = {flexGrow: 1, marginBottom: 2};
  * Responsive grid item configuration for different breakpoints
  */
 export const gridItemStyle = {
-    xs: 12, sm: 6, md: 4, lg: 3, xl: 2,
+    // Cap at 4 columns (lg) so cards stay readable on wide screens instead of
+    // squeezing to 6 across.
+    xs: 12, sm: 6, md: 4, lg: 3,
     sx: cardWrapperStyle,
 };
 


### PR DESCRIPTION
## Draft for visual review — not ready to merge

A first-pass **design-system refresh** addressing the "generic / unbranded", "too busy / dated effects", and "layout & spacing" feedback. Concentrated in the central theme + styles so it restyles the whole site at once; **no page logic changed** (all 37 vitest tests + the Java suite still pass).

### What changed
- **Palette** (`pages/_app.tsx`) — intentional brand blue (`#4263eb`, `#5c7cfa` in dark) + a sparingly-used gold accent (`#f59f00`); real dark surfaces (`#0e1117` / `#161b22`) instead of MUI's default greys.
- **Typography** — Inter (body) + **Space Grotesk** (headings), loaded via a new `pages/_document.tsx` (Next 12 predates `next/font`). Kills the default-Roboto "MUI site" tell.
- **Calmer surfaces** (`styles/styles.ts`) — solid app bars (indigo gradient gone), gradient-clip text removed from the brand name & blurb title, the 20px grid-pattern page background removed, hover-lifts softened from a 4px jump to a 2px + subtle-shadow, rounded corners + hairline borders via `MuiPaper`/`MuiButton` theme defaults.

### How to preview
```bash
git checkout design/ui-refresh-foundation
npm run dev   # http://localhost:3000 — toggle light/dark with the switch
```
(I can't render screenshots from my environment — no headless browser, hence the draft-for-preview workflow.)

### Deliberately deferred
Deeper per-page layout surgery (home hero, plugin-card grid density/proportions, page spacing/hierarchy) is held until this foundation is reviewed — easy to dial the gold accent / heading font up or down, or re-skin entirely, once you've seen it.

_Opened by Claude as a design prototype for review._