### PR TITLE
feat(leaderboard): surface server IP and Discord link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
+
 ## [0.12.0] – 2026-06-13
 
 ### Changed

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -7,16 +7,21 @@ import {
     Chip,
     Container,
     Skeleton,
+    Snackbar,
+    Stack,
     Table,
     TableBody,
     TableCell,
     TableContainer,
     TableHead,
     TableRow,
+    Tooltip,
     Typography,
 } from '@mui/material'
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
 import GroupIcon from '@mui/icons-material/Group'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useState} from 'react'
 import TopBar from '../components/TopBar'
@@ -57,6 +62,17 @@ const LeaderboardPage: NextPage = () => {
     const [factions, setFactions] = useState<Faction[]>([])
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [copied, setCopied] = useState(false)
+
+    const copyServerIp = useCallback(async (ip: string) => {
+        try {
+            await navigator.clipboard.writeText(ip)
+            setCopied(true)
+        } catch {
+            // Clipboard can be unavailable (older browsers, insecure origin); the
+            // address is still visible on the chip for manual copying.
+        }
+    }, [])
 
     const fetchFactions = useCallback(async () => {
         setLoading(true)
@@ -194,11 +210,37 @@ const LeaderboardPage: NextPage = () => {
                                                     )}
                                                 </TableCell>
                                                 <TableCell>
-                                                    <Chip
-                                                        label={faction.serverId}
-                                                        size="small"
-                                                        variant="outlined"
-                                                    />
+                                                    <Stack spacing={0.5} alignItems="flex-start">
+                                                        <Chip
+                                                            label={faction.serverId}
+                                                            size="small"
+                                                            variant="outlined"
+                                                        />
+                                                        {faction.serverIp && (
+                                                            <Tooltip title="Click to copy server address">
+                                                                <Chip
+                                                                    label={faction.serverIp}
+                                                                    size="small"
+                                                                    color="primary"
+                                                                    variant="outlined"
+                                                                    icon={<ContentCopyIcon/>}
+                                                                    onClick={() => copyServerIp(faction.serverIp as string)}
+                                                                    sx={{fontFamily: 'monospace', cursor: 'pointer'}}
+                                                                />
+                                                            </Tooltip>
+                                                        )}
+                                                        {faction.discordLink && (
+                                                            <Button
+                                                                size="small"
+                                                                startIcon={<ChatBubbleOutlineIcon/>}
+                                                                href={faction.discordLink}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                            >
+                                                                Discord
+                                                            </Button>
+                                                        )}
+                                                    </Stack>
                                                 </TableCell>
                                                 <TableCell align="right">
                                                     <Typography
@@ -217,6 +259,13 @@ const LeaderboardPage: NextPage = () => {
                     </CardContent>
                 </Card>
             </Container>
+            <Snackbar
+                open={copied}
+                autoHideDuration={2000}
+                onClose={() => setCopied(false)}
+                message="Server address copied to clipboard"
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+            />
             <BottomBar version={version}/>
         </Box>
     )


### PR DESCRIPTION
## Summary
The faction leaderboard already fetched `serverIp` and `discordLink` from `/api/v1/factions` but rendered neither, so visitors couldn't act on the ranking. The Server column now shows:
- the existing `serverId` chip,
- the **server IP** as a click-to-copy monospace chip (with a "copied to clipboard" Snackbar), shown only when present,
- a **Discord** button linking to the faction's community, shown only when present.

Both new elements are conditional on non-null values (many factions may not publish them).

## Test plan
- [x] `npx tsc --noEmit` clean; `npm run lint` clean
- [x] No new `any`; MUI-only components (Stack, Tooltip, Chip, Button, Snackbar)
- [x] Build verified by the **Build Website** CI check
- [ ] Manual: with a faction that has serverIp/discordLink, the chip copies and the Snackbar shows; rows without them render unchanged

Clipboard failures (insecure origin / old browsers) are swallowed — the IP is still visible on the chip for manual copying.

Closes #158

## Deferred this cycle (skip reasons)
- #159 / #160 / #162 — subsequent loop cycles (each its own subsystem).
- #161 (guides on-site) — needs a markdown-renderer dependency (do-not-auto-merge), planned with a hand-off.
- #87 — larger feature (write API + auth UI to edit plugin JSON).
- #57 — infra (compose.yml / nginx TLS); a do-not-auto-merge path, will hand off for manual review.
- #142 / #24 — blocked on / owned by the open Discord-ingestion draft (#141).

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_