### PR TITLE
feat(seo): per-page titles, meta descriptions, and Open Graph tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
+- Every page now sets a descriptive `<title>`, meta description, and Open Graph / Twitter card tags (via a shared `Seo` component), so browser tabs, search engines, and shared links show meaningful information.
 
 ## [0.12.0] – 2026-06-13
 

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,0 +1,36 @@
+import Head from 'next/head';
+import React from 'react';
+
+// Shared per-page document metadata: title, description, and Open Graph /
+// Twitter card tags so browser tabs, search engines, and shared links (Discord,
+// social) all show meaningful information. Render once near the top of each page.
+const SITE_NAME = "Dan's Plugins Community";
+const DEFAULT_DESCRIPTION =
+    "Free, open-source plugins for Minecraft servers — Medieval Factions and a catalogue of complementary plugins, all developed in the open and free to use.";
+
+interface SeoProps {
+    // Page-specific title; the site name is appended automatically. Omit on the
+    // home page to use the site name alone.
+    title?: string;
+    description?: string;
+}
+
+const Seo: React.FC<SeoProps> = ({title, description}) => {
+    const fullTitle = title ? `${title} — ${SITE_NAME}` : SITE_NAME;
+    const desc = description ?? DEFAULT_DESCRIPTION;
+    return (
+        <Head>
+            <title>{fullTitle}</title>
+            <meta name="description" content={desc}/>
+            <meta property="og:title" content={fullTitle}/>
+            <meta property="og:description" content={desc}/>
+            <meta property="og:type" content="website"/>
+            <meta property="og:site_name" content={SITE_NAME}/>
+            <meta name="twitter:card" content="summary"/>
+            <meta name="twitter:title" content={fullTitle}/>
+            <meta name="twitter:description" content={desc}/>
+        </Head>
+    );
+};
+
+export default Seo;

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,6 +2,7 @@ import {Box, Button, Container, Stack, Typography} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
@@ -13,6 +14,7 @@ const version = require('../package.json').version;
 
 const About: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="About Us" description="Learn about Dan's Plugins Community, an open-source community building plugins for Minecraft servers."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -19,6 +19,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
+import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 
@@ -223,6 +224,7 @@ const AccountPage: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Account" description="Manage your account and the API keys your Minecraft servers use to sync with the DPC community data API."/>
             <TopBar/>
             <Container maxWidth="md" sx={{py: 4}}>
                 <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -19,6 +19,7 @@ import {
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
@@ -50,6 +51,7 @@ const Commissions: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Commissions" description="Custom Minecraft plugin development by the creator of Dan's Plugins Community — pricing and availability."/>
             <TopBar/>
             <Container maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -2,6 +2,7 @@ import {Box, Container, List, ListItem, ListItemButton, ListItemText, Paper, Typ
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 import {userGuideUrl} from '../utils/guides';
@@ -26,6 +27,7 @@ const guides = [...pluginData.plugins].sort((a, b) => a.title.localeCompare(b.ti
 
 const Guides: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="Guides" description="User guides for every Dan's Plugins Community plugin."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import {Box, Container, Grid, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
 import type {NextPage} from 'next'
 import TopBar from '../components/TopBar'
+import Seo from '../components/Seo'
 import Blurb from '../components/Blurb'
 import PluginCard from '../components/PluginCard'
 import React from 'react';
@@ -178,6 +179,7 @@ export const getServerSideProps = async () => {
 const Home: NextPage<HomeProps> = ({ visits, startDate, pluginsWithCounts }) => {
     return (
         <Box sx={pageStyle}>
+            <Seo/>
             <TopBar/>
             <Container maxWidth="xl" sx={{py: 4}}>
                 <Blurb/>

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -25,6 +25,7 @@ import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useState} from 'react'
 import TopBar from '../components/TopBar'
+import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles'
 
@@ -101,6 +102,7 @@ const LeaderboardPage: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Faction Leaderboard" description="Medieval Factions ranked by member count across all servers."/>
             <TopBar/>
             <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
                 <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -1,6 +1,7 @@
 import {Box, Chip, Container, Link, Paper, Typography} from '@mui/material';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 import {getNewsPosts, NewsPost, NewsSource} from '../utils/newsStorage';
@@ -63,6 +64,7 @@ const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
 
 const News: NextPage<NewsProps> = ({posts}) => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="News" description="Announcements and updates from Dan's Plugins Community."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -1,6 +1,7 @@
 import {Box, Chip, Container, Link, Paper, Typography} from '@mui/material';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
@@ -51,6 +52,7 @@ const RoadmapCard: React.FC<{ item: RoadmapItem; color: 'success' | 'warning' | 
 
 const Roadmap: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="Road Map" description="What's planned, in progress, and completed across Dan's Plugins Community."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>


### PR DESCRIPTION
## Summary
No page set a `<title>` or any meta tags, so browser tabs showed the bare URL, search engines had nothing to index, and links shared to Discord/social rendered with no preview.

- New `components/Seo.tsx` (uses `next/head`) emits `<title>`, `<meta name="description">`, and Open Graph / Twitter card tags, with a site-wide default description and `og:site_name`.
- Rendered on all eight pages with a page-specific title + description (home uses the site name + default description).

## Test plan
- [x] `npx tsc --noEmit` clean; `npm run lint` clean
- [x] No new `any`; no new `process.env`; MUI/`next/head` only
- [x] Production build verified by the **Build Website** CI check

A dedicated `og:image` share image is intentionally **not** included — there is no suitable banner asset in `public/` (only small plugin icons); that's a good follow-up once a share image exists.

Closes #159

## Deferred this cycle
- #160 / #162 — subsequent cycles. #161 — needs a markdown dep (hand-off). #87 / #57 — larger/infra. #142 / #24 — blocked on draft #141.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_