### PR TITLE
feat(home): search/filter the plugin catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- The home-page plugin catalogue now has a search box that filters plugins by name or description (in addition to the existing sort), with an empty state when nothing matches.
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
 - Every page now sets a descriptive `<title>`, meta description, and Open Graph / Twitter card tags (via a shared `Seo` component), so browser tabs, search engines, and shared links show meaningful information.
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
-import {Box, Container, Grid, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
+import {Box, Container, Grid, InputAdornment, TextField, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
 import type {NextPage} from 'next'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
@@ -72,6 +73,7 @@ interface PluginsSectionProps {
 
 const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
     const [sortBy, setSortBy] = React.useState<SortOption>('popularity');
+    const [query, setQuery] = React.useState('');
 
     const handleSortChange = (
         event: React.MouseEvent<HTMLElement>,
@@ -105,13 +107,35 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
         }
     };
 
+    const normalizedQuery = query.trim().toLowerCase();
+    const visiblePlugins = normalizedQuery
+        ? getSortedPlugins().filter((plugin) =>
+            plugin.title.toLowerCase().includes(normalizedQuery) ||
+            plugin.description.toLowerCase().includes(normalizedQuery))
+        : getSortedPlugins();
+
     return (
         <Box id="plugins" sx={pluginsBoxStyle}>
             <Typography variant="h3" component="div" gutterBottom sx={sectionHeaderStyle}>
                 Plugins
             </Typography>
-            
-            <Box sx={{ display: 'flex', justifyContent: 'center', marginBottom: 3 }}>
+
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, flexWrap: 'wrap', marginBottom: 3 }}>
+                <TextField
+                    size="small"
+                    placeholder="Search plugins…"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    aria-label="Search plugins"
+                    sx={{ minWidth: 240 }}
+                    InputProps={{
+                        startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon fontSize="small" />
+                            </InputAdornment>
+                        ),
+                    }}
+                />
                 <ToggleButtonGroup
                     value={sortBy}
                     exclusive
@@ -127,8 +151,14 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
                     </ToggleButton>
                 </ToggleButtonGroup>
             </Box>
-            
-            <PluginSection plugins={getSortedPlugins()} />
+
+            {visiblePlugins.length > 0 ? (
+                <PluginSection plugins={visiblePlugins} />
+            ) : (
+                <Typography color="text.secondary" align="center" sx={{ py: 4 }}>
+                    No plugins match your search.
+                </Typography>
+            )}
         </Box>
     );
 };


### PR DESCRIPTION
## Summary
The plugin catalogue could only be sorted (popularity/alphabetical), not searched. Adds a search `TextField` (with a search icon adornment) that filters the catalogue by plugin **title or description**, case-insensitively, alongside the existing sort. When no plugin matches, an empty state is shown instead of an empty grid.

- Filtering is client-side over the already-loaded `initialPlugins`; sort is applied first, then the filter.

## Test plan
- [x] `npx tsc --noEmit` clean; `npm run lint` clean
- [x] No new `any`; MUI-only (TextField, InputAdornment, SearchIcon)
- [x] Build verified by the **Build Website** CI check
- [ ] Manual: typing narrows the grid live; clearing restores it; a no-match query shows the empty state; sort still works with a query active

Closes #160

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_