### PR TITLE
feat(guides): render plugin guides on-site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.
 - The home-page plugin catalogue now has a search box that filters plugins by name or description (in addition to the existing sort), with an empty state when nothing matches.
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
 - Every page now sets a descriptive `<title>`, meta description, and Open Graph / Twitter card tags (via a shared `Seo` component), so browser tabs, search engines, and shared links show meaningful information.

--- a/__tests__/guides.test.ts
+++ b/__tests__/guides.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { userGuideUrl } from '../utils/guides';
+import { userGuideUrl, userGuideRawUrl } from '../utils/guides';
 
 describe('userGuideUrl', () => {
     it('points at USER_GUIDE.md on the default branch of the repo', () => {
@@ -10,5 +10,17 @@ describe('userGuideUrl', () => {
     it('does not double up the slash when the link has a trailing slash', () => {
         expect(userGuideUrl('https://github.com/Dans-Plugins/Medieval-Factions/'))
             .toBe('https://github.com/Dans-Plugins/Medieval-Factions/blob/HEAD/USER_GUIDE.md');
+    });
+});
+
+describe('userGuideRawUrl', () => {
+    it('points at the raw USER_GUIDE.md on the default branch', () => {
+        expect(userGuideRawUrl('https://github.com/Dans-Plugins/Fiefs'))
+            .toBe('https://raw.githubusercontent.com/Dans-Plugins/Fiefs/HEAD/USER_GUIDE.md');
+    });
+
+    it('does not double up the slash when the link has a trailing slash', () => {
+        expect(userGuideRawUrl('https://github.com/Dans-Plugins/Medieval-Factions/'))
+            .toBe('https://raw.githubusercontent.com/Dans-Plugins/Medieval-Factions/HEAD/USER_GUIDE.md');
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.7",
+        "markdown-to-jsx": "^9.8.2",
         "next": "12.2.2",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -4152,6 +4153,33 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.8.2.tgz",
+      "integrity": "sha512-rWUuxKB5NsuJmSfUOuXkQ0O5qk0J/Lr3Lk6dzxKoKQI/jeHYlsVfz3zJdMLAhI46hHoXDYERWhtBOiqtWDZ4LA==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "react": ">= 16.0.0",
+        "solid-js": ">=1.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge-stream": {
@@ -8459,6 +8487,12 @@
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "markdown-to-jsx": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.8.2.tgz",
+      "integrity": "sha512-rWUuxKB5NsuJmSfUOuXkQ0O5qk0J/Lr3Lk6dzxKoKQI/jeHYlsVfz3zJdMLAhI46hHoXDYERWhtBOiqtWDZ4LA==",
+      "requires": {}
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.7",
+    "markdown-to-jsx": "^9.8.2",
     "next": "12.2.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -1,11 +1,10 @@
 import {Box, Container, List, ListItem, ListItemButton, ListItemText, Paper, Typography} from '@mui/material';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
-import {userGuideUrl} from '../utils/guides';
 
 // Import styles
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
@@ -35,7 +34,7 @@ const Guides: NextPage = () => (
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 Each plugin&apos;s guide (its <code>USER_GUIDE.md</code>) lives in the plugin&apos;s
-                repository. Select a plugin below to open its guide in a new tab.
+                repository. Select a plugin below to read its guide.
             </Typography>
             <Paper elevation={0} sx={{maxWidth: 600, overflow: 'hidden'}}>
                 <List disablePadding>
@@ -43,12 +42,10 @@ const Guides: NextPage = () => (
                         <ListItem key={plugin.id} disablePadding divider={index < guides.length - 1}>
                             <ListItemButton
                                 component="a"
-                                href={userGuideUrl(plugin.githubLink)}
-                                target="_blank"
-                                rel="noopener noreferrer"
+                                href={`/guides/${plugin.id}`}
                             >
                                 <ListItemText primary={`${plugin.title} Guide`}/>
-                                <OpenInNewIcon fontSize="small" color="action"/>
+                                <ChevronRightIcon fontSize="small" color="action"/>
                             </ListItemButton>
                         </ListItem>
                     ))}

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -1,0 +1,135 @@
+import {Alert, Box, Button, Container, Typography} from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import Markdown from 'markdown-to-jsx';
+import type {GetServerSideProps, NextPage} from 'next';
+import React from 'react';
+import TopBar from '../../components/TopBar';
+import Seo from '../../components/Seo';
+import BottomBar from '../../components/BottomBar';
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles';
+import {userGuideUrl, userGuideRawUrl} from '../../utils/guides';
+
+const version = require('../../package.json').version;
+
+interface GuidePlugin {
+    id: string;
+    title: string;
+    githubLink: string;
+}
+
+const pluginData = require('../data/plugins.json') as { plugins: GuidePlugin[] };
+
+interface GuidePageProps {
+    title: string;
+    githubLink: string;
+    // The fetched guide markdown, or null if it couldn't be loaded (the page then
+    // falls back to a link to GitHub).
+    markdown: string | null;
+}
+
+export const getServerSideProps: GetServerSideProps<GuidePageProps> = async ({params}) => {
+    const id = typeof params?.id === 'string' ? params.id : '';
+    const plugin = pluginData.plugins.find((p) => p.id === id);
+    if (!plugin) {
+        return {notFound: true};
+    }
+    let markdown: string | null = null;
+    try {
+        const res = await fetch(userGuideRawUrl(plugin.githubLink));
+        if (res.ok) {
+            markdown = await res.text();
+        }
+    } catch {
+        // Leave markdown null; the page renders a fallback link to GitHub.
+    }
+    return {props: {title: plugin.title, githubLink: plugin.githubLink, markdown}};
+};
+
+// Themed styling for the rendered markdown elements (markdown-to-jsx emits plain
+// HTML tags, so these are descendant-selector rules rather than component props).
+const guideBodyStyle = {
+    '& h1': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.8rem', fontWeight: 700, mt: 4, mb: 1.5},
+    '& h2': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.4rem', fontWeight: 600, mt: 4, mb: 1.5},
+    '& h3': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.15rem', fontWeight: 600, mt: 3, mb: 1},
+    '& p': {mb: 2, lineHeight: 1.7},
+    '& ul, & ol': {pl: 3, mb: 2},
+    '& li': {mb: 0.5},
+    '& a': {color: 'primary.main'},
+    '& code': {
+        bgcolor: 'action.hover',
+        px: 0.6,
+        py: 0.2,
+        borderRadius: 0.5,
+        fontFamily: 'monospace',
+        fontSize: '0.9em',
+    },
+    '& pre': {
+        bgcolor: '#0d1117',
+        color: '#c9d1d9',
+        border: '1px solid',
+        borderColor: 'divider',
+        p: 2,
+        borderRadius: 2,
+        overflow: 'auto',
+    },
+    '& pre code': {bgcolor: 'transparent', p: 0, color: 'inherit', fontSize: '0.85rem'},
+    '& blockquote': {borderLeft: '4px solid', borderColor: 'divider', pl: 2, ml: 0, color: 'text.secondary'},
+    '& img': {maxWidth: '100%'},
+    '& table': {borderCollapse: 'collapse', width: '100%'},
+    '& th, & td': {border: '1px solid', borderColor: 'divider', p: 1, textAlign: 'left'},
+};
+
+const GuidePage: NextPage<GuidePageProps> = ({title, githubLink, markdown}) => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title={`${title} Guide`} description={`User guide for the ${title} plugin from Dan's Plugins Community.`}/>
+        <TopBar/>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+            <Button href="/guides" startIcon={<ArrowBackIcon/>} sx={{mb: 2}}>
+                All guides
+            </Button>
+            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                {title} Guide
+            </Typography>
+
+            {markdown ? (
+                <Box sx={guideBodyStyle}>
+                    <Markdown>{markdown}</Markdown>
+                </Box>
+            ) : (
+                <Alert
+                    severity="info"
+                    action={
+                        <Button
+                            color="inherit"
+                            size="small"
+                            href={userGuideUrl(githubLink)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            endIcon={<OpenInNewIcon/>}
+                        >
+                            View on GitHub
+                        </Button>
+                    }
+                >
+                    This guide couldn&apos;t be loaded right now — you can read it on GitHub instead.
+                </Alert>
+            )}
+
+            <Box sx={{mt: 4}}>
+                <Button
+                    href={userGuideUrl(githubLink)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    endIcon={<OpenInNewIcon/>}
+                    size="small"
+                >
+                    View this guide on GitHub
+                </Button>
+            </Box>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default GuidePage;

--- a/utils/guides.ts
+++ b/utils/guides.ts
@@ -7,3 +7,9 @@
 // See https://github.com/Dans-Plugins/dpc-conventions (DOCUMENTATION_PRACTICES.md).
 export const userGuideUrl = (githubLink: string): string =>
     `${githubLink.replace(/\/+$/, '')}/blob/HEAD/USER_GUIDE.md`;
+
+// The raw (plain-text) URL for the same USER_GUIDE.md, used to fetch and render
+// the guide on-site. raw.githubusercontent.com accepts `HEAD` as the default
+// branch, so we don't need to know whether the repo uses main or master.
+export const userGuideRawUrl = (githubLink: string): string =>
+    `${githubLink.replace(/\/+$/, '').replace('https://github.com/', 'https://raw.githubusercontent.com/')}/HEAD/USER_GUIDE.md`;


### PR DESCRIPTION
## Summary
The Guides page only linked out to raw GitHub markdown. Now each plugin's guide renders **on-site**:

- New SSR route `pages/guides/[id].tsx` fetches the plugin's `USER_GUIDE.md` from `raw.githubusercontent.com/.../HEAD/USER_GUIDE.md` (HEAD resolves the default branch, so no main-vs-master guessing and no GitHub API/rate-limit) and renders it with **markdown-to-jsx**, themed to match the site (headings in Space Grotesk, dark code blocks, etc.).
- `pages/guides.tsx` now links each entry to `/guides/[id]` (internal) with a chevron instead of an external-link icon.
- New `userGuideRawUrl` helper in `utils/guides.ts` (with unit tests).
- Robustness: an unknown id returns **404**; a fetch failure renders an info alert with a "View on GitHub" link; every guide also keeps a "View this guide on GitHub" link.

## Dependency added
- **markdown-to-jsx@^9.8.2** — chosen over react-markdown because it's a single CJS-friendly package (no remark/unified ESM chain) that builds cleanly under Next 12, and renders to safe JSX (no raw-HTML injection). This makes `package.json` a do-not-auto-merge path; flagging for your awareness (you directed this issue).

## Test plan
- [x] `npx tsc --noEmit` clean; `npm run lint` clean
- [x] `npx vitest run __tests__/guides.test.ts` → 4 passed (incl. new userGuideRawUrl tests)
- [x] **`npm run build` compiled successfully** — `/guides/[id]` builds as an SSR route with the dep bundled
- [x] Smoke test via `next start`: `/guides/fiefs` → 200 with the rendered guide ("What is Fiefs", "All guides", GitHub link); `/guides/does-not-exist` → 404
- [x] No new `any`; no new `process.env`; MUI + next + markdown-to-jsx only

Closes #161

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_