### PR TITLE
release: v0.12.0 site redesign + features to main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,8 @@ This repository is a monorepo containing a frontend and a backend.
 - `public/` – Static assets served at the root URL
 - `utils/` – Shared utility functions
 - `services/` – Data-fetching or business-logic services
+- `__tests__/` – Unit tests (Vitest)
+- `data/` – Runtime-persisted JSON (`news.json`, `visits.json`); bind-mounted in `compose.yml`
 
 ### Backend
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
+
 ## [0.12.0] – 2026-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.10.0] – 2026-06-07
+
 ### Fixed
 
 - The **Guides** page now lists a guide for every plugin in the catalogue, not just Medieval Factions. Links are derived from `pages/data/plugins.json` and point at each plugin's in-repo `USER_GUIDE.md` (the required in-repo guide per the DPC conventions), opening in a new tab with `rel="noopener noreferrer"`. Previously the page claimed guides existed "for each plugin" but linked only one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.12.0] – 2026-06-13
+
+### Changed
+
+- Site-wide visual refresh. A new brand palette and type pairing (Inter for body, Space Grotesk for headings, loaded via a custom `_document`); solid app bars in place of the indigo gradient; removal of the gradient-clip text and the 20px grid-pattern page background; flat surfaces with hairline borders and softened hover lifts; a redesigned home hero with call-to-action buttons; restyled plugin cards (per-plugin avatar, server-count chip, clearer button hierarchy); and consistent table/card/page treatments across the Leaderboard, Account, Commissions, Road Map, About, Guides, and News pages.
+- Bumped the site version to 0.12.0.
+
 ### Fixed
 
 - `USER_GUIDE.md` now documents the **Guides**, **Leaderboard**, and **Account** pages. These are all reachable from the top navigation bar but were previously absent from the guide's "Common Scenarios", which only covered News, About, Road Map, and Commissions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.
 - The home-page plugin catalogue now has a search box that filters plugins by name or description (in addition to the existing sort), with an empty state when nothing matches.
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
 - Every page now sets a descriptive `<title>`, meta description, and Open Graph / Twitter card tags (via a shared `Seo` component), so browser tabs, search engines, and shared links show meaningful information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
+- Every page now sets a descriptive `<title>`, meta description, and Open Graph / Twitter card tags (via a shared `Seo` component), so browser tabs, search engines, and shared links show meaningful information.
 
 ## [0.12.0] – 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- The home-page plugin catalogue now has a search box that filters plugins by name or description (in addition to the existing sort), with an empty state when nothing matches.
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.
 - Every page now sets a descriptive `<title>`, meta description, and Open Graph / Twitter card tags (via a shared `Seo` component), so browser tabs, search engines, and shared links show meaningful information.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `USER_GUIDE.md` now documents the **Guides**, **Leaderboard**, and **Account** pages. These are all reachable from the top navigation bar but were previously absent from the guide's "Common Scenarios", which only covered News, About, Road Map, and Commissions.
+- `.github/copilot-instructions.md` now lists the `__tests__/` (Vitest) and `data/` (runtime-persisted JSON, bind-mounted in `compose.yml`) directories in its frontend Project Structure, which previously omitted both tracked directories.
+
 ## [0.10.0] – 2026-06-07
 
 ### Fixed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -25,6 +25,16 @@ No special software is required to use the website. Simply visit [https://danspl
 1. Click **News** in the top navigation bar (or visit `/news`).
 2. Browse the posts, shown newest first.
 
+### Browsing Plugin Guides
+
+1. Click **Guides** in the top navigation bar (or visit `/guides`).
+2. Select a plugin from the list to open that plugin's user guide in a new tab.
+
+### Viewing the Faction Leaderboard
+
+1. Click **Leaderboard** in the top navigation bar (or visit `/leaderboard`).
+2. Review the factions, ranked by number of members across all servers.
+
 ### Learning About the Community
 
 1. Click **About** in the top navigation bar (or visit `/about`).
@@ -42,6 +52,12 @@ No special software is required to use the website. Simply visit [https://danspl
 1. Click **Commissions** in the top navigation bar (or visit `/commissions`).
 2. Review the pricing options, what's included, and the current availability status.
 3. Click **Join the Commissions Discord** to discuss your project.
+
+### Managing Your Account
+
+1. Click **Account** in the top navigation bar (or visit `/account`).
+2. Register a new account, or log in with an existing username and password.
+3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
 
 ### Getting Support
 

--- a/__tests__/atomicJson.test.ts
+++ b/__tests__/atomicJson.test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DATA_DIR, writeJsonAtomic } from '../utils/atomicJson';
+
+const TEST_DIR = path.join(DATA_DIR, '__atomicjson_test__');
+
+const cleanup = () => {
+    if (fs.existsSync(TEST_DIR)) {
+        fs.rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+};
+
+describe('writeJsonAtomic', () => {
+    afterEach(cleanup);
+
+    it('writes compact JSON by default', () => {
+        const file = path.join(TEST_DIR, 'compact.json');
+        writeJsonAtomic(file, { a: 1, b: 2 });
+        expect(fs.readFileSync(file, 'utf8')).toBe('{"a":1,"b":2}');
+    });
+
+    it('writes pretty-printed JSON when the pretty option is set', () => {
+        const file = path.join(TEST_DIR, 'pretty.json');
+        writeJsonAtomic(file, { a: 1 }, { pretty: true });
+        expect(fs.readFileSync(file, 'utf8')).toBe('{\n  "a": 1\n}');
+    });
+
+    it('creates the parent directory if it does not exist', () => {
+        const file = path.join(TEST_DIR, 'nested', 'deep', 'file.json');
+        writeJsonAtomic(file, { ok: true });
+        expect(fs.existsSync(file)).toBe(true);
+    });
+
+    it('overwrites an existing file and leaves no temp file behind', () => {
+        const file = path.join(TEST_DIR, 'overwrite.json');
+        writeJsonAtomic(file, { v: 1 });
+        writeJsonAtomic(file, { v: 2 });
+        expect(JSON.parse(fs.readFileSync(file, 'utf8'))).toEqual({ v: 2 });
+        const leftovers = fs.readdirSync(TEST_DIR).filter((name) => name.includes('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+});

--- a/__tests__/guides.test.ts
+++ b/__tests__/guides.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { userGuideUrl } from '../utils/guides';
+import { userGuideUrl, userGuideRawUrl } from '../utils/guides';
 
 describe('userGuideUrl', () => {
     it('points at USER_GUIDE.md on the default branch of the repo', () => {
@@ -10,5 +10,17 @@ describe('userGuideUrl', () => {
     it('does not double up the slash when the link has a trailing slash', () => {
         expect(userGuideUrl('https://github.com/Dans-Plugins/Medieval-Factions/'))
             .toBe('https://github.com/Dans-Plugins/Medieval-Factions/blob/HEAD/USER_GUIDE.md');
+    });
+});
+
+describe('userGuideRawUrl', () => {
+    it('points at the raw USER_GUIDE.md on the default branch', () => {
+        expect(userGuideRawUrl('https://github.com/Dans-Plugins/Fiefs'))
+            .toBe('https://raw.githubusercontent.com/Dans-Plugins/Fiefs/HEAD/USER_GUIDE.md');
+    });
+
+    it('does not double up the slash when the link has a trailing slash', () => {
+        expect(userGuideRawUrl('https://github.com/Dans-Plugins/Medieval-Factions/'))
+            .toBe('https://raw.githubusercontent.com/Dans-Plugins/Medieval-Factions/HEAD/USER_GUIDE.md');
     });
 });

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import {Box, Typography, Paper, Grid} from '@mui/material';
+import {Box, Button, Typography, Paper, Grid, Stack} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import DownloadIcon from '@mui/icons-material/Download';
 import GamesIcon from '@mui/icons-material/Games';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 import {
     blurbBoxStyle,
@@ -22,7 +23,7 @@ const InfoCard: React.FC<{
 }> = ({icon, title, content, href}) => (
     <Grid item xs={12} md={4}>
         <Paper
-            elevation={3}
+            elevation={0}
             // When the card links somewhere, expose it as a focusable, keyboard-
             // operable control: a mouse-only onClick left keyboard and screen-
             // reader users unable to reach or activate these cards.
@@ -32,8 +33,9 @@ const InfoCard: React.FC<{
                 ...infoCardStyle(theme),
                 cursor: href ? 'pointer' : 'default',
                 '&:hover': href ? {
-                    transform: 'scale(1.02)',
-                    transition: 'transform 0.2s ease-in-out'
+                    transform: 'translateY(-2px)',
+                    boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+                    transition: 'transform 0.2s ease, box-shadow 0.2s ease'
                 } : {}
             })}
             onClick={() => href && window.open(href, '_blank', 'noopener,noreferrer')}
@@ -50,19 +52,57 @@ const InfoCard: React.FC<{
             <Typography variant="h6" gutterBottom sx={(theme) => infoCardTitleStyle()}>
                 {title}
             </Typography>
-            <Typography variant="body1">{content}</Typography>
+            <Typography variant="body1" color="text.secondary">{content}</Typography>
         </Paper>
     </Grid>
 );
 
 const Blurb: React.FC = () => (
     <Box sx={(theme) => blurbBoxStyle(theme)}>
+        <Box sx={{textAlign: 'center', py: {xs: 4, md: 8}}}>
+            <Typography
+                variant="h2"
+                gutterBottom
+                sx={(theme) => ({...blurbTitleStyle(theme), marginBottom: theme.spacing(2)})}
+            >
+                Dan&apos;s Plugins Community
+            </Typography>
+            <Typography
+                variant="h6"
+                color="text.secondary"
+                sx={{maxWidth: 640, mx: 'auto', fontWeight: 400}}
+            >
+                Free, open-source plugins for Minecraft servers — built in the open,
+                and easy to run, extend, and contribute to.
+            </Typography>
+            <Stack
+                direction={{xs: 'column', sm: 'row'}}
+                spacing={2}
+                justifyContent="center"
+                sx={{mt: 4}}
+            >
+                <Button variant="contained" size="large" href="#plugins">
+                    Browse Plugins
+                </Button>
+                <Button
+                    variant="outlined"
+                    size="large"
+                    href="https://github.com/Dans-Plugins"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    endIcon={<OpenInNewIcon fontSize="small"/>}
+                >
+                    View on GitHub
+                </Button>
+            </Stack>
+        </Box>
+
         <Typography
-            variant="h2"
-            gutterBottom
-            sx={(theme) => blurbTitleStyle(theme)}
+            variant="overline"
+            color="text.secondary"
+            sx={{display: 'block', textAlign: 'center', letterSpacing: '0.1em'}}
         >
-            Welcome to Dan&apos;s Plugins Community
+            Get involved
         </Typography>
 
         <Grid container spacing={4} sx={(theme) => blurbGridContainerStyle(theme)}>

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { Button, Card, CardActions, CardContent, Link, Typography } from '@mui/material';
+import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, Typography} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import DnsIcon from '@mui/icons-material/Dns';
 import {
     pluginCardStyle,
     pluginCardContentStyle,
     pluginCardActionsStyle,
-    pluginCardButtonStyle,
-    pluginCardTitleStyle,
-    pluginCardDescriptionStyle,
-    pluginCardServerCountStyle,
 } from '../styles/styles';
 
 interface PluginCardProps {
@@ -19,32 +17,95 @@ interface PluginCardProps {
     serverCount?: number | null;
 }
 
-const PluginCard: React.FC<PluginCardProps> = ({ 
-    title, 
-    description, 
-    githubLink, 
-    spigotmcLink, 
-    bStatsId, 
-    serverCount 
+// A small, fixed palette of muted brand-ish colours. Each plugin gets a stable
+// colour derived from its title so cards have a bit of visual identity without
+// being random on every render.
+const AVATAR_COLORS = ['#4263eb', '#7048e8', '#1098ad', '#f59f00', '#e8590c', '#0ca678'];
+
+const colorForTitle = (title: string): string => {
+    let hash = 0;
+    for (let i = 0; i < title.length; i++) {
+        hash = (hash * 31 + title.charCodeAt(i)) >>> 0;
+    }
+    return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+};
+
+const PluginCard: React.FC<PluginCardProps> = ({
+    title,
+    description,
+    githubLink,
+    spigotmcLink,
+    serverCount
 }) => {
     return (
         <Card sx={pluginCardStyle}>
             <CardContent sx={pluginCardContentStyle}>
-                <Typography {...pluginCardTitleStyle} component="div" variant="h5">{title}</Typography>
-                <Typography {...pluginCardDescriptionStyle} component="p" variant="body1">{description}</Typography>
-                {serverCount && serverCount > 0 ? (
-                    <Typography {...pluginCardServerCountStyle} component="span" variant="body2">
-                        <br />
-                        {serverCount} servers running
+                <Stack direction="row" spacing={1.5} alignItems="center" sx={{mb: 1.5}}>
+                    <Avatar
+                        variant="rounded"
+                        aria-hidden
+                        sx={{
+                            bgcolor: colorForTitle(title),
+                            width: 40,
+                            height: 40,
+                            fontFamily: '"Space Grotesk", sans-serif',
+                            fontWeight: 700,
+                        }}
+                    >
+                        {title.charAt(0).toUpperCase()}
+                    </Avatar>
+                    <Typography variant="h6" component="div" sx={{fontWeight: 600, lineHeight: 1.2}}>
+                        {title}
                     </Typography>
-                ) : null}
+                </Stack>
+                <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                        // Clamp to keep every card the same height regardless of
+                        // how long the plugin's description is.
+                        display: '-webkit-box',
+                        WebkitLineClamp: 3,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                    }}
+                >
+                    {description}
+                </Typography>
             </CardContent>
+
+            {serverCount && serverCount > 0 ? (
+                <Box sx={{px: 2, pb: 1}}>
+                    <Chip
+                        size="small"
+                        variant="outlined"
+                        icon={<DnsIcon/>}
+                        label={`${serverCount.toLocaleString()} servers`}
+                    />
+                </Box>
+            ) : null}
+
             <CardActions sx={pluginCardActionsStyle}>
-                <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={githubLink} target="_blank" rel="noopener noreferrer">
+                <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<GitHubIcon/>}
+                    component={Link}
+                    href={githubLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     GitHub
                 </Button>
                 {spigotmcLink ? (
-                    <Button sx={(theme) => pluginCardButtonStyle()} component={Link} href={spigotmcLink} target="_blank" rel="noopener noreferrer">
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        component={Link}
+                        href={spigotmcLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         SpigotMC
                     </Button>
                 ) : null}

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,0 +1,36 @@
+import Head from 'next/head';
+import React from 'react';
+
+// Shared per-page document metadata: title, description, and Open Graph /
+// Twitter card tags so browser tabs, search engines, and shared links (Discord,
+// social) all show meaningful information. Render once near the top of each page.
+const SITE_NAME = "Dan's Plugins Community";
+const DEFAULT_DESCRIPTION =
+    "Free, open-source plugins for Minecraft servers — Medieval Factions and a catalogue of complementary plugins, all developed in the open and free to use.";
+
+interface SeoProps {
+    // Page-specific title; the site name is appended automatically. Omit on the
+    // home page to use the site name alone.
+    title?: string;
+    description?: string;
+}
+
+const Seo: React.FC<SeoProps> = ({title, description}) => {
+    const fullTitle = title ? `${title} — ${SITE_NAME}` : SITE_NAME;
+    const desc = description ?? DEFAULT_DESCRIPTION;
+    return (
+        <Head>
+            <title>{fullTitle}</title>
+            <meta name="description" content={desc}/>
+            <meta property="og:title" content={fullTitle}/>
+            <meta property="og:description" content={desc}/>
+            <meta property="og:type" content="website"/>
+            <meta property="og:site_name" content={SITE_NAME}/>
+            <meta name="twitter:card" content="summary"/>
+            <meta name="twitter:title" content={fullTitle}/>
+            <meta name="twitter:description" content={desc}/>
+        </Head>
+    );
+};
+
+export default Seo;

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/AccountController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/AccountController.java
@@ -85,8 +85,7 @@ public class AccountController {
     @ApiResponse(responseCode = "200", description = "Profile retrieved")
     @ApiResponse(responseCode = "401", description = "Not authenticated")
     public ResponseEntity<AccountResponse> getProfile(Principal principal) {
-        Account account = accountService.findByUsername(principal.getName())
-                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+        Account account = getCurrentAccount(principal);
         List<ApiKey> keys = accountService.getApiKeys(account);
         return ResponseEntity.ok(accountMapper.toResponse(account, keys));
     }
@@ -103,8 +102,7 @@ public class AccountController {
     public ResponseEntity<CreateApiKeyResponse> createApiKey(
             Principal principal,
             @Valid @RequestBody CreateApiKeyRequest request) {
-        Account account = accountService.findByUsername(principal.getName())
-                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+        Account account = getCurrentAccount(principal);
         var apiKey = accountService.createApiKey(account, request.serverName());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CreateApiKeyResponse(apiKey.getId(), apiKey.getRawKey(),
@@ -121,11 +119,17 @@ public class AccountController {
     @ApiResponse(responseCode = "404", description = "API key not found or not owned by user")
     @ApiResponse(responseCode = "401", description = "Not authenticated")
     public ResponseEntity<Void> deleteApiKey(Principal principal, @PathVariable UUID keyId) {
-        Account account = accountService.findByUsername(principal.getName())
-                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
+        Account account = getCurrentAccount(principal);
         if (!accountService.deleteApiKey(account, keyId)) {
             throw new ResourceNotFoundException("API key not found");
         }
         return ResponseEntity.noContent().build();
+    }
+
+    // Resolves the authenticated principal to its Account, or 404s if the account
+    // backing a valid token no longer exists.
+    private Account getCurrentAccount(Principal principal) {
+        return accountService.findByUsername(principal.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found"));
     }
 }

--- a/dpc-api/src/test/java/com/dansplugins/api/config/GlobalExceptionHandlerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,158 @@
+package com.dansplugins.api.config;
+
+import com.dansplugins.api.exception.InvalidCredentialsException;
+import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.exception.UsernameAlreadyTakenException;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleValidation_returns400WithFieldErrors() {
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(
+                new FieldError("request", "username", "must not be blank"),
+                new FieldError("request", "password", "size must be between 8 and 64")));
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+
+        ProblemDetail problem = handler.handleValidation(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getTitle()).isEqualTo("Bad Request");
+        assertThat(problem.getProperties()).containsKey("errors");
+        @SuppressWarnings("unchecked")
+        var errors = (java.util.Map<String, String>) problem.getProperties().get("errors");
+        assertThat(errors)
+                .containsEntry("username", "must not be blank")
+                .containsEntry("password", "size must be between 8 and 64");
+    }
+
+    @Test
+    void handleMethodValidation_returns400() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+
+        ProblemDetail problem = handler.handleMethodValidation(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getTitle()).isEqualTo("Bad Request");
+        assertThat(problem.getDetail()).isEqualTo("Validation failed");
+    }
+
+    @Test
+    void handleConstraintViolation_returns400() {
+        ConstraintViolationException ex = new ConstraintViolationException(Collections.emptySet());
+
+        ProblemDetail problem = handler.handleConstraintViolation(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Validation failed");
+    }
+
+    @Test
+    void handleUnreadable_returns400() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        ProblemDetail problem = handler.handleUnreadable(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Malformed request body");
+    }
+
+    @Test
+    void handleTypeMismatch_returns400WithParameterName() {
+        MethodArgumentTypeMismatchException ex = mock(MethodArgumentTypeMismatchException.class);
+        when(ex.getName()).thenReturn("factionId");
+
+        ProblemDetail problem = handler.handleTypeMismatch(ex);
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Invalid value for parameter 'factionId'");
+    }
+
+    @Test
+    void handleUsernameAlreadyTaken_returns409WithMessage() {
+        ProblemDetail problem = handler.handleUsernameAlreadyTaken(
+                new UsernameAlreadyTakenException("alice"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(problem.getTitle()).isEqualTo("Conflict");
+        assertThat(problem.getDetail()).isEqualTo("Username already taken: alice");
+    }
+
+    @Test
+    void handleIllegalArgument_returns400WithMessage() {
+        ProblemDetail problem = handler.handleIllegalArgument(
+                new IllegalArgumentException("bad argument"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("bad argument");
+    }
+
+    @Test
+    void handleInvalidCredentials_returns401WithMessage() {
+        ProblemDetail problem = handler.handleInvalidCredentials(new InvalidCredentialsException());
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(problem.getTitle()).isEqualTo("Unauthorized");
+        assertThat(problem.getDetail()).isEqualTo("Invalid credentials");
+    }
+
+    @Test
+    void handleResourceNotFound_returns404WithMessage() {
+        ProblemDetail problem = handler.handleResourceNotFound(
+                new ResourceNotFoundException("Account not found"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(problem.getTitle()).isEqualTo("Not Found");
+        assertThat(problem.getDetail()).isEqualTo("Account not found");
+    }
+
+    @Test
+    void handleResponseStatus_propagatesStatusAndReason() {
+        ProblemDetail problem = handler.handleResponseStatus(
+                new ResponseStatusException(HttpStatus.FORBIDDEN, "no access"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(problem.getTitle()).isEqualTo(HttpStatus.FORBIDDEN.getReasonPhrase());
+        assertThat(problem.getDetail()).isEqualTo("no access");
+    }
+
+    @Test
+    void handleResponseStatus_fallsBackToReasonPhraseWhenReasonNull() {
+        ProblemDetail problem = handler.handleResponseStatus(
+                new ResponseStatusException(HttpStatus.FORBIDDEN));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(problem.getDetail()).isEqualTo(HttpStatus.FORBIDDEN.getReasonPhrase());
+    }
+
+    @Test
+    void handleGeneral_returns500GenericMessage() {
+        ProblemDetail problem = handler.handleGeneral(new RuntimeException("boom"));
+
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(problem.getTitle()).isEqualTo("Internal Server Error");
+        // The raw exception message is deliberately NOT leaked to the client.
+        assertThat(problem.getDetail()).isEqualTo("Internal server error");
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/filter/ApiKeyAuthFilterTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/filter/ApiKeyAuthFilterTest.java
@@ -1,0 +1,142 @@
+package com.dansplugins.api.filter;
+
+import com.dansplugins.api.service.ApiKeyService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.FilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApiKeyAuthFilterTest {
+
+    @Mock
+    private ApiKeyService apiKeyService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private ApiKeyAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        // Real ObjectMapper so the 401 error body is serialized exactly as in production.
+        filter = new ApiKeyAuthFilter(apiKeyService, new ObjectMapper());
+    }
+
+    private MockHttpServletRequest request(String method, String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod(method);
+        request.setRequestURI(uri);
+        return request;
+    }
+
+    @Test
+    void doFilterInternal_exemptRegisterPath_passesThroughWithoutKey() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/accounts/register");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_exemptLoginPath_passesThroughWithoutKey() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/accounts/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_accountManagementPath_passesThroughWithoutKey() throws Exception {
+        MockHttpServletRequest request = request("DELETE", "/api/v1/accounts/me/keys/abc");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_readMethod_isNotGatedByApiKey() throws Exception {
+        MockHttpServletRequest request = request("GET", "/api/v1/factions");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void doFilterInternal_writeWithValidKey_passesThrough() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/factions");
+        request.addHeader("X-API-Key", "valid-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(apiKeyService.isValidKey("valid-key")).thenReturn(true);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void doFilterInternal_writeWithMissingKey_returns401AndDoesNotProceed() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/factions");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.getContentAsString()).contains("Invalid or missing API key");
+    }
+
+    @Test
+    void doFilterInternal_writeWithInvalidKey_returns401AndDoesNotProceed() throws Exception {
+        MockHttpServletRequest request = request("POST", "/api/v1/factions");
+        request.addHeader("X-API-Key", "bogus");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(apiKeyService.isValidKey("bogus")).thenReturn(false);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    void doFilterInternal_writeWithWhitespacePaddedKey_isTrimmedBeforeValidation() throws Exception {
+        MockHttpServletRequest request = request("PUT", "/api/v1/factions");
+        request.addHeader("X-API-Key", "  valid-key  ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // Only the trimmed form is a valid key; the padded form must be trimmed first.
+        when(apiKeyService.isValidKey("valid-key")).thenReturn(true);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
@@ -1,0 +1,108 @@
+package com.dansplugins.api.filter;
+
+import com.dansplugins.api.service.JwtService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import jakarta.servlet.FilterChain;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthFilterTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthFilter filter;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void doFilterInternal_withValidBearerToken_setsAuthentication() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer good-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("alice");
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_withNoAuthHeader_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_withNonBearerHeader_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_whenTokenHasNoUsername_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer expired-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(jwtService.extractUsername("expired-token")).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_doesNotOverwriteExistingAuthentication() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer good-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        lenient().when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
+        var existing = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                "preexisting", null, java.util.List.of());
+        SecurityContextHolder.getContext().setAuthentication(existing);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(existing);
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/filter/JwtAuthFilterTest.java
@@ -17,7 +17,6 @@ import jakarta.servlet.FilterChain;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,7 +94,7 @@ class JwtAuthFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer good-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
-        lenient().when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
+        when(jwtService.extractUsername("good-token")).thenReturn(Optional.of("alice"));
         var existing = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
                 "preexisting", null, java.util.List.of());
         SecurityContextHolder.getContext().setAuthentication(existing);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.7",
+        "markdown-to-jsx": "^9.8.2",
         "next": "12.2.2",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -4152,6 +4153,33 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.8.2.tgz",
+      "integrity": "sha512-rWUuxKB5NsuJmSfUOuXkQ0O5qk0J/Lr3Lk6dzxKoKQI/jeHYlsVfz3zJdMLAhI46hHoXDYERWhtBOiqtWDZ4LA==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "react": ">= 16.0.0",
+        "solid-js": ">=1.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge-stream": {
@@ -8459,6 +8487,12 @@
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "markdown-to-jsx": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.8.2.tgz",
+      "integrity": "sha512-rWUuxKB5NsuJmSfUOuXkQ0O5qk0J/Lr3Lk6dzxKoKQI/jeHYlsVfz3zJdMLAhI46hHoXDYERWhtBOiqtWDZ4LA==",
+      "requires": {}
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dpc-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dpc-website",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dpc-website",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dpc-website",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.7",
+    "markdown-to-jsx": "^9.8.2",
     "next": "12.2.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,16 +34,59 @@ function MyApp({Component, pageProps}: AppProps) {
     );
 
     const theme = useMemo(
-        () => createTheme({
-            palette: {
-                mode
-            },
-            typography: {
-                button: {
-                    textTransform: 'none'
-                }
-            }
-        }),
+        () => {
+            const isDark = mode === 'dark';
+            const headingFont = '"Space Grotesk", system-ui, sans-serif';
+            return createTheme({
+                palette: {
+                    mode,
+                    primary: {main: isDark ? '#5c7cfa' : '#4263eb'},
+                    // Gold accent — used sparingly for emphasis (a nod to the
+                    // Minecraft/medieval audience without leaning faux-medieval).
+                    secondary: {main: '#f59f00'},
+                    background: isDark
+                        ? {default: '#0e1117', paper: '#161b22'}
+                        : {default: '#f6f8fa', paper: '#ffffff'},
+                },
+                shape: {borderRadius: 10},
+                typography: {
+                    fontFamily: '"Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+                    h1: {fontFamily: headingFont, fontWeight: 700, letterSpacing: '-0.02em'},
+                    h2: {fontFamily: headingFont, fontWeight: 700, letterSpacing: '-0.02em'},
+                    h3: {fontFamily: headingFont, fontWeight: 600, letterSpacing: '-0.01em'},
+                    h4: {fontFamily: headingFont, fontWeight: 600},
+                    h5: {fontFamily: headingFont, fontWeight: 600},
+                    h6: {fontFamily: headingFont, fontWeight: 600},
+                    button: {textTransform: 'none', fontWeight: 600},
+                },
+                components: {
+                    // Solid app bars instead of the old indigo gradient.
+                    MuiAppBar: {
+                        defaultProps: {elevation: 0},
+                        styleOverrides: {
+                            root: ({theme}) => ({
+                                backgroundImage: 'none',
+                                backgroundColor: isDark ? '#161b22' : theme.palette.primary.main,
+                                borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.16)'}`,
+                            }),
+                        },
+                    },
+                    // Flat surfaces with a hairline border rather than heavy MUI elevation.
+                    MuiPaper: {
+                        styleOverrides: {
+                            root: ({theme}) => ({
+                                backgroundImage: 'none',
+                                border: `1px solid ${theme.palette.divider}`,
+                            }),
+                        },
+                    },
+                    MuiButton: {
+                        defaultProps: {disableElevation: true},
+                        styleOverrides: {root: {borderRadius: 8}},
+                    },
+                },
+            });
+        },
         [mode]
     );
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,23 @@
+import {Html, Head, Main, NextScript} from 'next/document';
+
+// Load the brand fonts (Inter for body, Space Grotesk for headings) from Google
+// Fonts. Next 12 predates next/font, so they are linked here in the document
+// head; preconnect hints keep the extra round-trip cheap.
+export default function Document() {
+    return (
+        <Html>
+            <Head>
+                <link rel="preconnect" href="https://fonts.googleapis.com"/>
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous"/>
+                <link
+                    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+                    rel="stylesheet"
+                />
+            </Head>
+            <body>
+                <Main/>
+                <NextScript/>
+            </body>
+        </Html>
+    );
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,6 +2,7 @@ import {Box, Button, Container, Stack, Typography} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
@@ -13,6 +14,7 @@ const version = require('../package.json').version;
 
 const About: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="About Us" description="Learn about Dan's Plugins Community, an open-source community building plugins for Minecraft servers."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,11 +1,12 @@
-import {Box, Button, Container, Typography} from '@mui/material';
+import {Box, Button, Container, Stack, Typography} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
 // Import styles
-import {pageStyle, sectionHeaderStyle, pluginsBoxStyle, containerPaddingStyle} from '../styles/styles';
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
 
 // Pull version from package.json
 const version = require('../package.json').version;
@@ -13,7 +14,7 @@ const version = require('../package.json').version;
 const About: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 About Us
             </Typography>
@@ -31,38 +32,36 @@ const About: NextPage = () => (
                 Want to get involved? Join the conversation on Discord, support development on Patreon,
                 or browse the source on GitHub.
             </Typography>
-            <Box sx={pluginsBoxStyle}>
+            <Stack direction="row" spacing={2} sx={{mt: 3, flexWrap: 'wrap', rowGap: 1}}>
                 <Button
                     variant="contained"
                     color="primary"
+                    startIcon={<GitHubIcon/>}
                     href="https://github.com/Dans-Plugins"
                     target="_blank"
                     rel="noopener noreferrer"
-                    sx={{mr: 1, mb: 1}}
                 >
                     GitHub
                 </Button>
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     color="primary"
                     href="https://discord.gg/xXtuAQ2"
                     target="_blank"
                     rel="noopener noreferrer"
-                    sx={{mr: 1, mb: 1}}
                 >
                     Discord
                 </Button>
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     color="primary"
                     href="https://www.patreon.com/danspluginscommunity"
                     target="_blank"
                     rel="noopener noreferrer"
-                    sx={{mr: 1, mb: 1}}
                 >
                     Patreon
                 </Button>
-            </Box>
+            </Stack>
         </Container>
         <BottomBar version={version}/>
     </Box>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -19,6 +19,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
+import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 
@@ -223,6 +224,7 @@ const AccountPage: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Account" description="Manage your account and the API keys your Minecraft servers use to sync with the DPC community data API."/>
             <TopBar/>
             <Container maxWidth="md" sx={{py: 4}}>
                 <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -20,6 +20,7 @@ import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
 import BottomBar from '../components/BottomBar'
+import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 
 const version = require('../package.json').version
 
@@ -221,19 +222,22 @@ const AccountPage: NextPage = () => {
     }
 
     return (
-        <Box>
+        <Box sx={(theme) => pageStyle(theme)}>
             <TopBar/>
             <Container maxWidth="md" sx={{py: 4}}>
-                <Typography variant="h4" gutterBottom>
-                    Account Management
+                <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                    Account
+                </Typography>
+                <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
+                    Manage your account and the API keys your Minecraft servers use to sync with the DPC community data API.
                 </Typography>
 
                 {error && <Alert severity="error" sx={{mb: 2}} onClose={() => setError(null)}>{error}</Alert>}
                 {success && <Alert severity="success" sx={{mb: 2}} onClose={() => setSuccess(null)}>{success}</Alert>}
 
                 {!token ? (
-                    <>
-                        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{mb: 2}}>
+                    <Box sx={{maxWidth: 460, mx: 'auto', mt: 2}}>
+                        <Tabs value={tab} onChange={(_, v) => setTab(v)} centered sx={{mb: 2}}>
                             <Tab label="Login"/>
                             <Tab label="Register"/>
                         </Tabs>
@@ -291,7 +295,7 @@ const AccountPage: NextPage = () => {
                                 </CardContent>
                             </Card>
                         )}
-                    </>
+                    </Box>
                 ) : (
                     <>
                         {profile && (
@@ -321,9 +325,23 @@ const AccountPage: NextPage = () => {
                                 {newApiKey && (
                                     <Alert severity="warning" sx={{mb: 2}} onClose={() => setNewApiKey(null)}>
                                         <strong>Save this key now — it won&apos;t be shown again:</strong>
-                                        <Box sx={{display: 'flex', alignItems: 'center', mt: 1}}>
-                                            <code>{newApiKey}</code>
-                                            <IconButton size="small" onClick={() => copyToClipboard(newApiKey)} sx={{ml: 1}} aria-label="Copy API key to clipboard">
+                                        <Box sx={{display: 'flex', alignItems: 'center', gap: 1, mt: 1}}>
+                                            <Box
+                                                component="code"
+                                                sx={{
+                                                    flex: 1,
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.85rem',
+                                                    wordBreak: 'break-all',
+                                                    bgcolor: 'action.hover',
+                                                    px: 1,
+                                                    py: 0.5,
+                                                    borderRadius: 1,
+                                                }}
+                                            >
+                                                {newApiKey}
+                                            </Box>
+                                            <IconButton size="small" onClick={() => copyToClipboard(newApiKey)} aria-label="Copy API key to clipboard">
                                                 <ContentCopyIcon fontSize="small"/>
                                             </IconButton>
                                         </Box>
@@ -375,12 +393,15 @@ const AccountPage: NextPage = () => {
                                     Use these commands in your Minecraft server plugin to manage your account:
                                 </Typography>
                                 <Box component="pre" sx={{
-                                    bgcolor: 'grey.900',
-                                    color: 'grey.100',
+                                    bgcolor: '#0d1117',
+                                    color: '#c9d1d9',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
                                     p: 2,
-                                    borderRadius: 1,
+                                    borderRadius: 2,
                                     overflow: 'auto',
-                                    fontSize: '0.875rem'
+                                    fontSize: '0.85rem',
+                                    fontFamily: 'monospace',
                                 }}>
 {`# Register (creates account and returns JWT token)
 POST /api/v1/accounts/register

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -19,6 +19,7 @@ import {
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
@@ -50,6 +51,7 @@ const Commissions: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Commissions" description="Custom Minecraft plugin development by the creator of Dan's Plugins Community — pricing and availability."/>
             <TopBar/>
             <Container maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -5,6 +5,7 @@ import {
     Container,
     List,
     ListItem,
+    ListItemIcon,
     ListItemText,
     Paper,
     Table,
@@ -15,6 +16,7 @@ import {
     TableRow,
     Typography
 } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import React from 'react';
@@ -49,7 +51,7 @@ const Commissions: NextPage = () => {
     return (
         <Box sx={(theme) => pageStyle(theme)}>
             <TopBar/>
-            <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+            <Container maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>
                     <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                         Commissions
@@ -57,37 +59,51 @@ const Commissions: NextPage = () => {
                     <Chip
                         label={isOpen ? 'Open for commissions' : 'Currently closed'}
                         color={isOpen ? 'success' : 'default'}
+                        variant={isOpen ? 'filled' : 'outlined'}
                     />
                 </Box>
-                <Typography variant="body1" gutterBottom>
+                <Typography variant="body1" color="text.secondary" sx={{mb: 3, maxWidth: 760}}>
                     Custom Minecraft plugin development by the creator of the Dan&apos;s Plugins Community
                     catalogue. Whether you need an existing plugin fixed and extended or a brand-new plugin
                     built to your specification, the pricing options below cover one-time projects, monthly
                     retainers, and ad-hoc hourly work.
                 </Typography>
 
-                <TableContainer component={Paper} sx={{mt: 3, mb: 3}}>
+                <TableContainer component={Paper} sx={{mt: 3, mb: 4}}>
                     <Table aria-label="commission pricing">
                         <TableHead>
-                            <TableRow>
+                            <TableRow
+                                sx={{
+                                    '& th': {
+                                        bgcolor: 'action.hover',
+                                        borderBottom: 2,
+                                        borderColor: 'divider',
+                                        fontWeight: 600,
+                                        fontSize: '0.72rem',
+                                        textTransform: 'uppercase',
+                                        letterSpacing: '0.07em',
+                                        color: 'text.secondary',
+                                    },
+                                }}
+                            >
                                 <TableCell>Service</TableCell>
-                                <TableCell>One-time</TableCell>
-                                <TableCell>Monthly retainer</TableCell>
-                                <TableCell>Ad hoc</TableCell>
+                                <TableCell align="right">One-time</TableCell>
+                                <TableCell align="right">Monthly retainer</TableCell>
+                                <TableCell align="right">Ad hoc</TableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
                             {commissionsData.tiers.map((tier) => (
-                                <TableRow key={tier.name}>
+                                <TableRow key={tier.name} sx={{'&:hover': {bgcolor: 'action.hover'}}}>
                                     <TableCell>
-                                        <Typography variant="subtitle1">{tier.name}</Typography>
+                                        <Typography variant="subtitle1" fontWeight={600}>{tier.name}</Typography>
                                         <Typography variant="body2" color="text.secondary">
                                             {tier.description}
                                         </Typography>
                                     </TableCell>
-                                    <TableCell>{tier.oneTime}</TableCell>
-                                    <TableCell>{tier.retainer}</TableCell>
-                                    <TableCell>{tier.adHoc}</TableCell>
+                                    <TableCell align="right">{tier.oneTime}</TableCell>
+                                    <TableCell align="right">{tier.retainer}</TableCell>
+                                    <TableCell align="right">{tier.adHoc}</TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -95,21 +111,25 @@ const Commissions: NextPage = () => {
                 </TableContainer>
 
                 <Typography variant="h5" gutterBottom>What&apos;s included</Typography>
-                <List dense>
+                <List>
                     {commissionsData.included.map((item) => (
-                        <ListItem key={item} sx={{display: 'list-item', listStyleType: 'disc', ml: 3, py: 0}}>
+                        <ListItem key={item} disableGutters sx={{py: 0.25}}>
+                            <ListItemIcon sx={{minWidth: 36}}>
+                                <CheckCircleOutlineIcon color="primary" fontSize="small"/>
+                            </ListItemIcon>
                             <ListItemText primary={item}/>
                         </ListItem>
                     ))}
                 </List>
 
-                <Typography variant="body1" sx={{mt: 2}} gutterBottom>
+                <Typography variant="body1" color="text.secondary" sx={{mt: 3}} gutterBottom>
                     To discuss a commission, join the commissions Discord server:
                 </Typography>
                 <Box sx={pluginsBoxStyle}>
                     <Button
                         variant="contained"
                         color="primary"
+                        size="large"
                         href={commissionsData.discordInvite}
                         target="_blank"
                         rel="noopener"

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -1,11 +1,10 @@
 import {Box, Container, List, ListItem, ListItemButton, ListItemText, Paper, Typography} from '@mui/material';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
 import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
-import {userGuideUrl} from '../utils/guides';
 
 // Import styles
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
@@ -35,7 +34,7 @@ const Guides: NextPage = () => (
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 Each plugin&apos;s guide (its <code>USER_GUIDE.md</code>) lives in the plugin&apos;s
-                repository. Select a plugin below to open its guide in a new tab.
+                repository. Select a plugin below to read its guide.
             </Typography>
             <Paper elevation={0} sx={{maxWidth: 600, overflow: 'hidden'}}>
                 <List disablePadding>
@@ -43,12 +42,10 @@ const Guides: NextPage = () => (
                         <ListItem key={plugin.id} disablePadding divider={index < guides.length - 1}>
                             <ListItemButton
                                 component="a"
-                                href={userGuideUrl(plugin.githubLink)}
-                                target="_blank"
-                                rel="noopener noreferrer"
+                                href={`/guides/${plugin.id}`}
                             >
                                 <ListItemText primary={`${plugin.title} Guide`}/>
-                                <OpenInNewIcon fontSize="small" color="action"/>
+                                <ChevronRightIcon fontSize="small" color="action"/>
                             </ListItemButton>
                         </ListItem>
                     ))}

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -1,4 +1,4 @@
-import {Box, Container, List, ListItem, ListItemButton, ListItemText, Typography} from '@mui/material';
+import {Box, Container, List, ListItem, ListItemButton, ListItemText, Paper, Typography} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
@@ -27,29 +27,31 @@ const guides = [...pluginData.plugins].sort((a, b) => a.title.localeCompare(b.ti
 const Guides: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 Guides
             </Typography>
-            <Typography variant="body1" gutterBottom>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 Each plugin&apos;s guide (its <code>USER_GUIDE.md</code>) lives in the plugin&apos;s
                 repository. Select a plugin below to open its guide in a new tab.
             </Typography>
-            <List sx={{maxWidth: 600}}>
-                {guides.map((plugin) => (
-                    <ListItem key={plugin.id} disablePadding>
-                        <ListItemButton
-                            component="a"
-                            href={userGuideUrl(plugin.githubLink)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <ListItemText primary={`${plugin.title} Guide`}/>
-                            <OpenInNewIcon fontSize="small"/>
-                        </ListItemButton>
-                    </ListItem>
-                ))}
-            </List>
+            <Paper elevation={0} sx={{maxWidth: 600, overflow: 'hidden'}}>
+                <List disablePadding>
+                    {guides.map((plugin, index) => (
+                        <ListItem key={plugin.id} disablePadding divider={index < guides.length - 1}>
+                            <ListItemButton
+                                component="a"
+                                href={userGuideUrl(plugin.githubLink)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                <ListItemText primary={`${plugin.title} Guide`}/>
+                                <OpenInNewIcon fontSize="small" color="action"/>
+                            </ListItemButton>
+                        </ListItem>
+                    ))}
+                </List>
+            </Paper>
         </Container>
         <BottomBar version={version}/>
     </Box>

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -2,6 +2,7 @@ import {Box, Container, List, ListItem, ListItemButton, ListItemText, Paper, Typ
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 import {userGuideUrl} from '../utils/guides';
@@ -26,6 +27,7 @@ const guides = [...pluginData.plugins].sort((a, b) => a.title.localeCompare(b.ti
 
 const Guides: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="Guides" description="User guides for every Dan's Plugins Community plugin."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -1,0 +1,135 @@
+import {Alert, Box, Button, Container, Typography} from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import Markdown from 'markdown-to-jsx';
+import type {GetServerSideProps, NextPage} from 'next';
+import React from 'react';
+import TopBar from '../../components/TopBar';
+import Seo from '../../components/Seo';
+import BottomBar from '../../components/BottomBar';
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles';
+import {userGuideUrl, userGuideRawUrl} from '../../utils/guides';
+
+const version = require('../../package.json').version;
+
+interface GuidePlugin {
+    id: string;
+    title: string;
+    githubLink: string;
+}
+
+const pluginData = require('../data/plugins.json') as { plugins: GuidePlugin[] };
+
+interface GuidePageProps {
+    title: string;
+    githubLink: string;
+    // The fetched guide markdown, or null if it couldn't be loaded (the page then
+    // falls back to a link to GitHub).
+    markdown: string | null;
+}
+
+export const getServerSideProps: GetServerSideProps<GuidePageProps> = async ({params}) => {
+    const id = typeof params?.id === 'string' ? params.id : '';
+    const plugin = pluginData.plugins.find((p) => p.id === id);
+    if (!plugin) {
+        return {notFound: true};
+    }
+    let markdown: string | null = null;
+    try {
+        const res = await fetch(userGuideRawUrl(plugin.githubLink));
+        if (res.ok) {
+            markdown = await res.text();
+        }
+    } catch {
+        // Leave markdown null; the page renders a fallback link to GitHub.
+    }
+    return {props: {title: plugin.title, githubLink: plugin.githubLink, markdown}};
+};
+
+// Themed styling for the rendered markdown elements (markdown-to-jsx emits plain
+// HTML tags, so these are descendant-selector rules rather than component props).
+const guideBodyStyle = {
+    '& h1': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.8rem', fontWeight: 700, mt: 4, mb: 1.5},
+    '& h2': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.4rem', fontWeight: 600, mt: 4, mb: 1.5},
+    '& h3': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.15rem', fontWeight: 600, mt: 3, mb: 1},
+    '& p': {mb: 2, lineHeight: 1.7},
+    '& ul, & ol': {pl: 3, mb: 2},
+    '& li': {mb: 0.5},
+    '& a': {color: 'primary.main'},
+    '& code': {
+        bgcolor: 'action.hover',
+        px: 0.6,
+        py: 0.2,
+        borderRadius: 0.5,
+        fontFamily: 'monospace',
+        fontSize: '0.9em',
+    },
+    '& pre': {
+        bgcolor: '#0d1117',
+        color: '#c9d1d9',
+        border: '1px solid',
+        borderColor: 'divider',
+        p: 2,
+        borderRadius: 2,
+        overflow: 'auto',
+    },
+    '& pre code': {bgcolor: 'transparent', p: 0, color: 'inherit', fontSize: '0.85rem'},
+    '& blockquote': {borderLeft: '4px solid', borderColor: 'divider', pl: 2, ml: 0, color: 'text.secondary'},
+    '& img': {maxWidth: '100%'},
+    '& table': {borderCollapse: 'collapse', width: '100%'},
+    '& th, & td': {border: '1px solid', borderColor: 'divider', p: 1, textAlign: 'left'},
+};
+
+const GuidePage: NextPage<GuidePageProps> = ({title, githubLink, markdown}) => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title={`${title} Guide`} description={`User guide for the ${title} plugin from Dan's Plugins Community.`}/>
+        <TopBar/>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+            <Button href="/guides" startIcon={<ArrowBackIcon/>} sx={{mb: 2}}>
+                All guides
+            </Button>
+            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                {title} Guide
+            </Typography>
+
+            {markdown ? (
+                <Box sx={guideBodyStyle}>
+                    <Markdown>{markdown}</Markdown>
+                </Box>
+            ) : (
+                <Alert
+                    severity="info"
+                    action={
+                        <Button
+                            color="inherit"
+                            size="small"
+                            href={userGuideUrl(githubLink)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            endIcon={<OpenInNewIcon/>}
+                        >
+                            View on GitHub
+                        </Button>
+                    }
+                >
+                    This guide couldn&apos;t be loaded right now — you can read it on GitHub instead.
+                </Alert>
+            )}
+
+            <Box sx={{mt: 4}}>
+                <Button
+                    href={userGuideUrl(githubLink)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    endIcon={<OpenInNewIcon/>}
+                    size="small"
+                >
+                    View this guide on GitHub
+                </Button>
+            </Box>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default GuidePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import {Box, Container, Grid, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
 import type {NextPage} from 'next'
 import TopBar from '../components/TopBar'
+import Seo from '../components/Seo'
 import Blurb from '../components/Blurb'
 import PluginCard from '../components/PluginCard'
 import React from 'react';
@@ -178,6 +179,7 @@ export const getServerSideProps = async () => {
 const Home: NextPage<HomeProps> = ({ visits, startDate, pluginsWithCounts }) => {
     return (
         <Box sx={pageStyle}>
+            <Seo/>
             <TopBar/>
             <Container maxWidth="xl" sx={{py: 4}}>
                 <Blurb/>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -105,7 +105,7 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
     };
 
     return (
-        <Box sx={pluginsBoxStyle}>
+        <Box id="plugins" sx={pluginsBoxStyle}>
             <Typography variant="h3" component="div" gutterBottom sx={sectionHeaderStyle}>
                 Plugins
             </Typography>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
-import {Box, Container, Grid, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
+import {Box, Container, Grid, InputAdornment, TextField, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
 import type {NextPage} from 'next'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
@@ -72,6 +73,7 @@ interface PluginsSectionProps {
 
 const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
     const [sortBy, setSortBy] = React.useState<SortOption>('popularity');
+    const [query, setQuery] = React.useState('');
 
     const handleSortChange = (
         event: React.MouseEvent<HTMLElement>,
@@ -105,13 +107,35 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
         }
     };
 
+    const normalizedQuery = query.trim().toLowerCase();
+    const visiblePlugins = normalizedQuery
+        ? getSortedPlugins().filter((plugin) =>
+            plugin.title.toLowerCase().includes(normalizedQuery) ||
+            plugin.description.toLowerCase().includes(normalizedQuery))
+        : getSortedPlugins();
+
     return (
         <Box id="plugins" sx={pluginsBoxStyle}>
             <Typography variant="h3" component="div" gutterBottom sx={sectionHeaderStyle}>
                 Plugins
             </Typography>
-            
-            <Box sx={{ display: 'flex', justifyContent: 'center', marginBottom: 3 }}>
+
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, flexWrap: 'wrap', marginBottom: 3 }}>
+                <TextField
+                    size="small"
+                    placeholder="Search plugins…"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    aria-label="Search plugins"
+                    sx={{ minWidth: 240 }}
+                    InputProps={{
+                        startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon fontSize="small" />
+                            </InputAdornment>
+                        ),
+                    }}
+                />
                 <ToggleButtonGroup
                     value={sortBy}
                     exclusive
@@ -127,8 +151,14 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
                     </ToggleButton>
                 </ToggleButtonGroup>
             </Box>
-            
-            <PluginSection plugins={getSortedPlugins()} />
+
+            {visiblePlugins.length > 0 ? (
+                <PluginSection plugins={visiblePlugins} />
+            ) : (
+                <Typography color="text.secondary" align="center" sx={{ py: 4 }}>
+                    No plugins match your search.
+                </Typography>
+            )}
         </Box>
     );
 };

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -25,6 +25,7 @@ import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useState} from 'react'
 import TopBar from '../components/TopBar'
+import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles'
 
@@ -101,6 +102,7 @@ const LeaderboardPage: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Faction Leaderboard" description="Medieval Factions ranked by member count across all servers."/>
             <TopBar/>
             <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
                 <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -114,13 +114,26 @@ const LeaderboardPage: NextPage = () => {
                         <TableContainer>
                             <Table>
                                 <TableHead>
-                                    <TableRow>
-                                        <TableCell sx={{fontWeight: 'bold', width: 60}} align="center">
+                                    <TableRow
+                                        sx={{
+                                            '& th': {
+                                                bgcolor: 'action.hover',
+                                                borderBottom: 2,
+                                                borderColor: 'divider',
+                                                fontWeight: 600,
+                                                fontSize: '0.72rem',
+                                                textTransform: 'uppercase',
+                                                letterSpacing: '0.07em',
+                                                color: 'text.secondary',
+                                            },
+                                        }}
+                                    >
+                                        <TableCell sx={{width: 60}} align="center">
                                             Rank
                                         </TableCell>
-                                        <TableCell sx={{fontWeight: 'bold'}}>Faction</TableCell>
-                                        <TableCell sx={{fontWeight: 'bold'}}>Server</TableCell>
-                                        <TableCell sx={{fontWeight: 'bold'}} align="right">
+                                        <TableCell>Faction</TableCell>
+                                        <TableCell>Server</TableCell>
+                                        <TableCell align="right">
                                             <Box sx={{display: 'inline-flex', alignItems: 'center', gap: 0.5}}>
                                                 <GroupIcon fontSize="small"/>
                                                 Members

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -7,16 +7,21 @@ import {
     Chip,
     Container,
     Skeleton,
+    Snackbar,
+    Stack,
     Table,
     TableBody,
     TableCell,
     TableContainer,
     TableHead,
     TableRow,
+    Tooltip,
     Typography,
 } from '@mui/material'
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
 import GroupIcon from '@mui/icons-material/Group'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import type {NextPage} from 'next'
 import React, {useCallback, useEffect, useState} from 'react'
 import TopBar from '../components/TopBar'
@@ -57,6 +62,17 @@ const LeaderboardPage: NextPage = () => {
     const [factions, setFactions] = useState<Faction[]>([])
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [copied, setCopied] = useState(false)
+
+    const copyServerIp = useCallback(async (ip: string) => {
+        try {
+            await navigator.clipboard.writeText(ip)
+            setCopied(true)
+        } catch {
+            // Clipboard can be unavailable (older browsers, insecure origin); the
+            // address is still visible on the chip for manual copying.
+        }
+    }, [])
 
     const fetchFactions = useCallback(async () => {
         setLoading(true)
@@ -194,11 +210,37 @@ const LeaderboardPage: NextPage = () => {
                                                     )}
                                                 </TableCell>
                                                 <TableCell>
-                                                    <Chip
-                                                        label={faction.serverId}
-                                                        size="small"
-                                                        variant="outlined"
-                                                    />
+                                                    <Stack spacing={0.5} alignItems="flex-start">
+                                                        <Chip
+                                                            label={faction.serverId}
+                                                            size="small"
+                                                            variant="outlined"
+                                                        />
+                                                        {faction.serverIp && (
+                                                            <Tooltip title="Click to copy server address">
+                                                                <Chip
+                                                                    label={faction.serverIp}
+                                                                    size="small"
+                                                                    color="primary"
+                                                                    variant="outlined"
+                                                                    icon={<ContentCopyIcon/>}
+                                                                    onClick={() => copyServerIp(faction.serverIp as string)}
+                                                                    sx={{fontFamily: 'monospace', cursor: 'pointer'}}
+                                                                />
+                                                            </Tooltip>
+                                                        )}
+                                                        {faction.discordLink && (
+                                                            <Button
+                                                                size="small"
+                                                                startIcon={<ChatBubbleOutlineIcon/>}
+                                                                href={faction.discordLink}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                            >
+                                                                Discord
+                                                            </Button>
+                                                        )}
+                                                    </Stack>
                                                 </TableCell>
                                                 <TableCell align="right">
                                                     <Typography
@@ -217,6 +259,13 @@ const LeaderboardPage: NextPage = () => {
                     </CardContent>
                 </Card>
             </Container>
+            <Snackbar
+                open={copied}
+                autoHideDuration={2000}
+                onClose={() => setCopied(false)}
+                message="Server address copied to clipboard"
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+            />
             <BottomBar version={version}/>
         </Box>
     )

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -1,6 +1,7 @@
 import {Box, Chip, Container, Link, Paper, Typography} from '@mui/material';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 import {getNewsPosts, NewsPost, NewsSource} from '../utils/newsStorage';
@@ -63,6 +64,7 @@ const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
 
 const News: NextPage<NewsProps> = ({posts}) => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="News" description="Announcements and updates from Dan's Plugins Community."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -35,7 +35,15 @@ export const getServerSideProps = async () => ({
 const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
     const badge = SOURCE_BADGE[post.source];
     return (
-        <Paper elevation={3} sx={{p: 2, mb: 2}}>
+        <Paper
+            elevation={0}
+            sx={{
+                p: 2.5,
+                mb: 2,
+                transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+                '&:hover': {transform: 'translateY(-2px)', boxShadow: '0 6px 20px rgba(0,0,0,0.12)'},
+            }}
+        >
             <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
                 <Typography variant="h6">{post.title}</Typography>
                 <Chip label={badge.label} color={badge.color} size="small"/>
@@ -56,7 +64,7 @@ const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
 const News: NextPage<NewsProps> = ({posts}) => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 News
             </Typography>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -1,6 +1,7 @@
 import {Box, Chip, Container, Link, Paper, Typography} from '@mui/material';
 import type {NextPage} from 'next';
 import TopBar from '../components/TopBar';
+import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
 
@@ -51,6 +52,7 @@ const RoadmapCard: React.FC<{ item: RoadmapItem; color: 'success' | 'warning' | 
 
 const Roadmap: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title="Road Map" description="What's planned, in progress, and completed across Dan's Plugins Community."/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -30,23 +30,33 @@ const STATUS_ORDER: { status: RoadmapItem['status']; color: 'success' | 'warning
 ];
 
 const RoadmapCard: React.FC<{ item: RoadmapItem; color: 'success' | 'warning' | 'info' }> = ({item, color}) => (
-    <Paper elevation={3} sx={{p: 2, mb: 2}}>
+    <Paper
+        elevation={0}
+        sx={(theme) => ({
+            p: 2,
+            mb: 2,
+            // Status-coloured accent stripe down the left edge for quick scanning.
+            borderLeft: `4px solid ${theme.palette[color].main}`,
+            transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+            '&:hover': {transform: 'translateY(-2px)', boxShadow: '0 6px 20px rgba(0,0,0,0.12)'},
+        })}
+    >
         <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
             <Typography variant="h6">{item.title}</Typography>
             <Chip label={item.status} color={color} size="small"/>
         </Box>
-        <Typography variant="body2" sx={{mt: 1}}>{item.description}</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{mt: 1}}>{item.description}</Typography>
     </Paper>
 );
 
 const Roadmap: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <TopBar/>
-        <Container maxWidth="xl" sx={(theme) => containerPaddingStyle(theme)}>
+        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 Road Map
             </Typography>
-            <Typography variant="body1" gutterBottom>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 This page tracks where Dan&apos;s Plugins Community is headed. For the day-to-day detail,
                 see the{' '}
                 <Link href="https://github.com/Dans-Plugins/dansplugins-dot-com/issues" target="_blank" rel="noopener">
@@ -60,7 +70,10 @@ const Roadmap: NextPage = () => (
                 }
                 return (
                     <Box key={status} sx={{mt: 4}}>
-                        <Typography variant="h5" gutterBottom>{status}</Typography>
+                        <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5}}>
+                            <Typography variant="h5">{status}</Typography>
+                            <Chip label={items.length} color={color} size="small" variant="outlined"/>
+                        </Box>
                         {items.map((item) => (
                             <RoadmapCard key={item.title} item={item} color={color}/>
                         ))}

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -283,37 +283,3 @@ export const pluginCardContentStyle = {
 export const pluginCardActionsStyle = {
     flexGrow: 0,
 };
-
-/**
- * Standard button style for plugin cards
- */
-export const pluginCardButtonStyle = () => ({
-    variant: 'contained',
-    size: 'small',
-    textTransform: 'none',
-});
-
-/**
- * Title configuration for plugin cards
- */
-export const pluginCardTitleStyle = {
-    gutterBottom: true,
-    variant: 'h5',
-    component: 'div',
-};
-
-/**
- * Description text style for plugin cards
- */
-export const pluginCardDescriptionStyle = {
-    variant: 'body2',
-    color: 'text.secondary',
-};
-
-/**
- * Server count text style for plugin cards
- */
-export const pluginCardServerCountStyle = {
-    variant: 'body2',
-    color: 'text.secondary',
-};

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -46,8 +46,11 @@ export const gridContainerStyle = {spacing: {xs: 2, md: 3}, pb: 4};
  * Card wrapper with hover lift animation
  */
 export const cardWrapperStyle = {
-    ...commonTransition,
-    '&:hover': {transform: 'translateY(-4px)'},
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+    },
 };
 
 /**
@@ -63,14 +66,12 @@ export const sectionDividerStyle = (theme: Theme) => {
 };
 
 /**
- * Main page layout with adaptive grid background pattern
+ * Main page layout. Uses a clean themed background (the former 20px grid
+ * overlay was removed as part of the UI refresh).
  */
 export const pageStyle = (theme: Theme) => ({
     flexGrow: 1,
-    backgroundColor: theme.palette.mode === 'dark' ? theme.palette.background.default : '#f5f5f5',
-    backgroundImage: `linear-gradient(${theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.8)'} 1px, transparent 1px), 
-                   linear-gradient(90deg, ${theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.8)'} 1px, transparent 1px)`,
-    backgroundSize: '20px 20px',
+    backgroundColor: theme.palette.background.default,
     minHeight: '100vh',
 });
 
@@ -95,11 +96,12 @@ export const containerPaddingStyle = (theme: Theme) => ({
 });
 
 /**
- * App bar with gradient background based on theme mode
+ * App bar surface. Solid colour instead of the former indigo gradient (kept in
+ * sync with the MuiAppBar theme override in _app.tsx).
  */
 export const appBarStyle = (theme: Theme) => ({
-    background: `linear-gradient(45deg, ${theme.palette.mode === 'dark' ? '#1a237e 30%, #283593' : '#1976d2 30%, #2196f3'} 90%)`,
-    elevation: 4,
+    backgroundImage: 'none',
+    backgroundColor: theme.palette.mode === 'dark' ? '#161b22' : theme.palette.primary.main,
 });
 
 /**
@@ -121,12 +123,9 @@ export const navButtonStyle = (theme: Theme) => ({
 export const brandNameStyle = (theme: Theme) => ({
     display: 'inline',
     marginRight: theme.spacing(2),
-    fontWeight: 'bold',
-    background: 'linear-gradient(45deg, #fff 30%, rgba(255,255,255,0.8) 90%)',
-    backgroundClip: 'text',
-    textFillColor: 'transparent',
-    ...commonTransition,
-    '&:hover': {transform: 'scale(1.05)'},
+    fontWeight: 700,
+    letterSpacing: '-0.01em',
+    color: 'inherit',
 });
 
 /**
@@ -210,11 +209,9 @@ export const blurbBoxStyle = (theme: Theme) => ({
  * Gradient title style for blurb sections
  */
 export const blurbTitleStyle = (theme: Theme) => ({
-    fontWeight: 'bold',
+    fontWeight: 700,
+    letterSpacing: '-0.02em',
     marginBottom: theme.spacing(4),
-    background: 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
-    WebkitBackgroundClip: 'text',
-    textFillColor: 'transparent',
     textAlign: 'center',
 });
 
@@ -231,8 +228,11 @@ export const blurbGridContainerStyle = (theme: Theme) => ({
 export const infoCardStyle = (theme: Theme) => ({
     padding: theme.spacing(3),
     height: '100%',
-    ...commonTransition,
-    '&:hover': {transform: 'translateY(-4px)'},
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+    },
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -1,16 +1,6 @@
 import {Theme} from '@mui/material/styles';
 
 /**
- * Creates theme-aware gradient values for light/dark modes
- * Light mode: transparent black gradients
- * Dark mode: transparent white gradients
- */
-const getCommonGradient = (theme: Theme) => ({
-    light: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0)' : 'rgba(0,0,0,0)',
-    medium: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
-});
-
-/**
  * Standard animation transition for interactive elements
  */
 const commonTransition = {
@@ -27,14 +17,24 @@ const commonHoverBg = (theme: Theme) => ({
 });
 
 /**
- * Styles for section headers with underline accent
+ * Section headers: heading text in the standard text colour with a short
+ * primary-coloured accent bar underneath (replaces the former full-width blue
+ * underline).
  */
 export const sectionHeaderStyle = (theme: Theme) => ({
-    fontWeight: 'bold',
-    color: theme.palette.primary.main,
-    borderBottom: `2px solid ${theme.palette.primary.main}`,
-    paddingBottom: theme.spacing(1),
+    fontWeight: 700,
+    letterSpacing: '-0.01em',
+    display: 'inline-block',
     marginBottom: theme.spacing(3),
+    '&::after': {
+        content: '""',
+        display: 'block',
+        width: '44px',
+        height: '3px',
+        marginTop: theme.spacing(1),
+        borderRadius: '2px',
+        backgroundColor: theme.palette.primary.main,
+    },
 });
 
 /**
@@ -54,16 +54,14 @@ export const cardWrapperStyle = {
 };
 
 /**
- * Creates a responsive horizontal divider with fade effect
+ * Clean hairline section divider (replaces the former gradient-fade line).
  */
-export const sectionDividerStyle = (theme: Theme) => {
-    const gradient = getCommonGradient(theme);
-    return {
-        height: '2px',
-        background: `linear-gradient(to right, ${gradient.light}, ${gradient.medium}, ${gradient.light})`,
-        marginY: theme.spacing(4),
-    };
-};
+export const sectionDividerStyle = (theme: Theme) => ({
+    height: '1px',
+    border: 0,
+    backgroundColor: theme.palette.divider,
+    marginY: theme.spacing(6),
+});
 
 /**
  * Main page layout. Uses a clean themed background (the former 20px grid
@@ -84,7 +82,9 @@ export const pluginsBoxStyle = {flexGrow: 1, marginBottom: 2};
  * Responsive grid item configuration for different breakpoints
  */
 export const gridItemStyle = {
-    xs: 12, sm: 6, md: 4, lg: 3, xl: 2,
+    // Cap at 4 columns (lg) so cards stay readable on wide screens instead of
+    // squeezing to 6 across.
+    xs: 12, sm: 6, md: 4, lg: 3,
     sx: cardWrapperStyle,
 };
 

--- a/utils/atomicJson.ts
+++ b/utils/atomicJson.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+// Shared directory for server-persisted JSON (visits.json, news.json). Lives on
+// the ./data volume bind-mounted in compose.yml, so it survives container
+// restarts and can be edited in place.
+export const DATA_DIR = path.join(process.cwd(), 'data');
+
+// Write JSON atomically: ensure the parent directory exists, serialize, write to
+// a temp file in the same directory, then rename it into place. rename is atomic
+// on POSIX filesystems, so a crash or restart mid-write cannot leave a
+// partially-written (invalid) file behind.
+export const writeJsonAtomic = (
+    filePath: string,
+    value: unknown,
+    options: { pretty?: boolean } = {}
+): void => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const json = options.pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+    const tempFile = `${filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tempFile, json);
+    fs.renameSync(tempFile, filePath);
+};

--- a/utils/guides.ts
+++ b/utils/guides.ts
@@ -7,3 +7,9 @@
 // See https://github.com/Dans-Plugins/dpc-conventions (DOCUMENTATION_PRACTICES.md).
 export const userGuideUrl = (githubLink: string): string =>
     `${githubLink.replace(/\/+$/, '')}/blob/HEAD/USER_GUIDE.md`;
+
+// The raw (plain-text) URL for the same USER_GUIDE.md, used to fetch and render
+// the guide on-site. raw.githubusercontent.com accepts `HEAD` as the default
+// branch, so we don't need to know whether the repo uses main or master.
+export const userGuideRawUrl = (githubLink: string): string =>
+    `${githubLink.replace(/\/+$/, '').replace('https://github.com/', 'https://raw.githubusercontent.com/')}/HEAD/USER_GUIDE.md`;

--- a/utils/newsStorage.ts
+++ b/utils/newsStorage.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { DATA_DIR, writeJsonAtomic } from './atomicJson';
 
-const DATA_DIR = path.join(process.cwd(), 'data');
 const NEWS_FILE = path.join(DATA_DIR, 'news.json');
 
 // Where a post came from, so the UI can label its provenance.
@@ -71,16 +71,7 @@ const normalizePost = (raw: unknown): NewsPost | null => {
 const sortNewestFirst = (posts: NewsPost[]): NewsPost[] =>
     [...posts].sort((a, b) => b.date.localeCompare(a.date));
 
-// Write atomically: temp file + rename, so an interrupted write cannot leave a
-// partial/invalid news.json behind.
-const writeNewsData = (posts: NewsPost[]) => {
-    if (!fs.existsSync(DATA_DIR)) {
-        fs.mkdirSync(DATA_DIR, { recursive: true });
-    }
-    const tempFile = `${NEWS_FILE}.${process.pid}.tmp`;
-    fs.writeFileSync(tempFile, JSON.stringify({ posts }, null, 2));
-    fs.renameSync(tempFile, NEWS_FILE);
-};
+const writeNewsData = (posts: NewsPost[]) => writeJsonAtomic(NEWS_FILE, { posts }, { pretty: true });
 
 // Read the news posts, newest first. If the file is absent, seed it with the
 // default posts. If it is present but unreadable/invalid, log and serve the

--- a/utils/visitStorage.ts
+++ b/utils/visitStorage.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { DATA_DIR, writeJsonAtomic } from './atomicJson';
 
-const DATA_DIR = path.join(process.cwd(), 'data');
 const VISITS_FILE = path.join(DATA_DIR, 'visits.json');
 
 interface VisitData {
@@ -22,17 +22,7 @@ const isValidVisitData = (value: unknown): value is VisitData => {
     return typeof data.visits === 'number' && typeof data.startDate === 'string';
 };
 
-// Write atomically: write to a temp file in the same directory, then rename it
-// into place. rename is atomic on POSIX filesystems, so a crash or restart
-// mid-write cannot leave a partially-written (invalid) visits.json behind.
-const writeVisitData = (data: VisitData) => {
-    if (!fs.existsSync(DATA_DIR)) {
-        fs.mkdirSync(DATA_DIR, { recursive: true });
-    }
-    const tempFile = `${VISITS_FILE}.${process.pid}.tmp`;
-    fs.writeFileSync(tempFile, JSON.stringify(data));
-    fs.renameSync(tempFile, VISITS_FILE);
-};
+const writeVisitData = (data: VisitData) => writeJsonAtomic(VISITS_FILE, data);
 
 export const initializeVisitStorage = () => {
     if (!fs.existsSync(VISITS_FILE)) {


### PR DESCRIPTION
## Release develop → main

Brings `main` up to the deployed site: the v0.12.0 UI refresh plus the leaderboard server-IP/Discord (#158), per-page SEO/meta (#159), plugin search (#160), and on-site guides (#161). This reconciles `main` with what is already running on the gateway (`dpc-website` @ develop), so the deployment is on the tracked branch rather than a hand-pin.

Does **not** include the UserAuth backend change (#168 / PR #170) — that remains separate and pending.

CI (Build Website + Build & Test API) gates this.

_Opened by Claude to reconcile the gateway deploy onto the tracked branch._