### PR TITLE
fix(auth): handle a failed auto-login after a successful register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Authentication is now provided by the shared UserAuth service instead of dpc-api's own accounts (epic #167, phase 1). dpc-api proxies registration/login/logout to UserAuth and validates its tokens; a local profile mirror owns each user's API keys. The Account page now signs in via UserAuth and supports a profile (display name, avatar, bio). API paths moved from `/api/v1/accounts/*` to `/api/v1/auth/*` and `/api/v1/profile/*`. The Docker Compose stack now bundles the UserAuth service (and its database) so `docker compose up` runs end-to-end; `JWT_SECRET` (used by UserAuth to sign tokens) is now required when starting the stack.
 
+### Fixed
+
+- `POST /api/v1/auth/register` no longer returns a 503 (which hid that the account was already created) when the automatic post-register login fails. It now returns `201` with `{ "registered": true, "tokenIssued": false }`, signalling the caller to log in rather than re-register.
+
 ### Added
 
 - Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/AuthController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -36,9 +37,20 @@ public class AuthController {
         String password = request.get("password");
         requireCredentials(username, password);
         userAuthClient.register(username.trim(), password);
-        // Log in immediately so the caller receives a token without a second round-trip.
-        Map<String, Object> auth = userAuthClient.login(username.trim(), password);
-        return ResponseEntity.status(HttpStatus.CREATED).body(auth);
+        // Log in immediately so the caller usually receives a token without a second
+        // round-trip. If that login fails (e.g. a transient UserAuth error) the account
+        // still exists — return 201 telling the caller to just log in, rather than
+        // surfacing a failure that would invite a re-register (which then 409s).
+        try {
+            Map<String, Object> auth = userAuthClient.login(username.trim(), password);
+            return ResponseEntity.status(HttpStatus.CREATED).body(auth);
+        } catch (ResponseStatusException e) {
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("registered", true);
+            body.put("tokenIssued", false);
+            body.put("message", "Account created, but automatic login failed. Please log in.");
+            return ResponseEntity.status(HttpStatus.CREATED).body(body);
+        }
     }
 
     @PostMapping("/login")

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -9,7 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -117,5 +119,19 @@ class ProfileAuthIntegrationTest {
                         .content("{\"username\":\"bob\",\"password\":\"pw\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").value("bob-token"));
+    }
+
+    @Test
+    void register_whenAutoLoginFails_returns201Registered() throws Exception {
+        when(userAuthClient.register(any(), any())).thenReturn(Map.of("id", 2, "username", "carol"));
+        when(userAuthClient.login("carol", "pw"))
+                .thenThrow(new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "down"));
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"carol\",\"password\":\"pw\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.registered").value(true))
+                .andExpect(jsonPath("$.tokenIssued").value(false));
     }
 }


### PR DESCRIPTION
## Summary
`AuthController.register` registers at UserAuth then auto-logs-in to return a token. If the **login** step fails after a **successful register** (transient UserAuth error → 503 from `UserAuthClient`), the caller saw a failure even though the account was created — and a retry then hit UserAuth's 409.

Now the auto-login is wrapped: on failure it returns **`201`** with `{ "registered": true, "tokenIssued": false, "message": ... }`, so the client simply logs in rather than re-registering. The happy path (token returned) is unchanged.

- `dpc-api/.../controller/AuthController.java:38-52`

## Test plan
- [x] `./mvnw -Dtest=ProfileAuthIntegrationTest test` → **7 run, 0 failures** (added `register_whenAutoLoginFails_returns201Registered`)
- [x] Full Java suite + website build in CI

Closes #175

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_