### PR TITLE
feat(likes): backend for liking plugins and guides (#169 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set. Backs the upcoming like buttons on plugin cards and guides.
 - Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.
 - The home-page plugin catalogue now has a search box that filters plugins by name or description (in addition to the existing sort), with an empty state when nothing matches.
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -72,10 +72,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/factions/**").permitAll()
+                        // Public like counts (must precede the authenticated /likes rule below)
+                        .requestMatchers(HttpMethod.GET, "/api/v1/likes/counts").permitAll()
                         // Swagger/OpenAPI
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
-                        // Profile and logout require a valid UserAuth token
+                        // Profile, likes, and logout require a valid UserAuth token
                         .requestMatchers("/api/v1/profile/**").authenticated()
+                        .requestMatchers("/api/v1/likes", "/api/v1/likes/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").authenticated()
                         // API key auth for faction writes is enforced by ApiKeyAuthFilter (returns 401
                         // before this authorization layer runs); permitAll here avoids a double-reject.

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/LikeController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/LikeController.java
@@ -1,0 +1,70 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.dto.LikeCountResponse;
+import com.dansplugins.api.dto.LikeRequest;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.service.LikeService;
+import com.dansplugins.api.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Likes on plugins and guides. Counts are public; liking/unliking and reading the
+ * current user's liked set require a UserAuth token.
+ */
+@RestController
+@RequestMapping("/api/v1/likes")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Likes", description = "Like plugins and guides")
+public class LikeController {
+
+    private final UserService userService;
+    private final LikeService likeService;
+
+    @PostMapping
+    @Operation(summary = "Like a plugin or guide", security = @SecurityRequirement(name = "bearerAuth"))
+    public LikeCountResponse like(Principal principal, @Valid @RequestBody LikeRequest request) {
+        User user = userService.getOrCreate(principal.getName());
+        long count = likeService.like(user, request.targetType(), request.targetId());
+        return new LikeCountResponse(request.targetType(), request.targetId(), count);
+    }
+
+    @DeleteMapping
+    @Operation(summary = "Unlike a plugin or guide", security = @SecurityRequirement(name = "bearerAuth"))
+    public LikeCountResponse unlike(Principal principal, @Valid @RequestBody LikeRequest request) {
+        User user = userService.getOrCreate(principal.getName());
+        long count = likeService.unlike(user, request.targetType(), request.targetId());
+        return new LikeCountResponse(request.targetType(), request.targetId(), count);
+    }
+
+    @GetMapping("/counts")
+    @Operation(summary = "Public like counts for a target type (targetId -> count)")
+    public Map<String, Long> counts(@RequestParam("type") String type) {
+        return likeService.countsForType(type);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "The current user's liked targets", security = @SecurityRequirement(name = "bearerAuth"))
+    public List<LikeRequest> myLikes(Principal principal) {
+        User user = userService.getOrCreate(principal.getName());
+        return likeService.likedByUser(user).stream()
+                .map(like -> new LikeRequest(like.getTargetType(), like.getTargetId()))
+                .toList();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/LikeCountResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/LikeCountResponse.java
@@ -1,0 +1,11 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A target's like count after a like/unlike")
+public record LikeCountResponse(
+        String targetType,
+        String targetId,
+        long count
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/LikeRequest.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/LikeRequest.java
@@ -1,0 +1,18 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "A like target: a plugin or guide, keyed by the plugin id")
+public record LikeRequest(
+        @NotBlank(message = "targetType is required")
+        @Schema(description = "'plugin' or 'guide'", example = "plugin")
+        String targetType,
+
+        @NotBlank(message = "targetId is required")
+        @Size(max = 64)
+        @Schema(description = "The plugin id from plugins.json", example = "medieval-factions")
+        String targetId
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/entity/Like.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/entity/Like.java
@@ -1,0 +1,65 @@
+package com.dansplugins.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A user's "like" of a target — a plugin or a guide, keyed by the plugin id from
+ * pages/data/plugins.json. The unique constraint enforces one like per
+ * (user, target_type, target_id), so liking is idempotent.
+ */
+// `LIKE` is a JPQL reserved word, so the JPQL entity name is "LikeRecord"
+// (the table is still `likes`); explicit @Query strings reference LikeRecord.
+@Entity(name = "LikeRecord")
+@Table(name = "likes", uniqueConstraints =
+        @UniqueConstraint(name = "uq_like", columnNames = {"user_id", "target_type", "target_id"}))
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(lombok.AccessLevel.NONE)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "target_type", nullable = false, length = 16)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false, length = 64)
+    private String targetId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private Instant createdAt;
+
+    public Like(User user, String targetType, String targetId) {
+        this.user = user;
+        this.targetType = targetType;
+        this.targetId = targetId;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/filter/ApiKeyAuthFilter.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/filter/ApiKeyAuthFilter.java
@@ -36,7 +36,8 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
             // Auth (proxied to UserAuth) and profile/API-key management authenticate via the
             // UserAuth bearer token, not an X-API-Key, so they are exempt from this filter.
             "/api/v1/auth/",
-            "/api/v1/profile/"
+            "/api/v1/profile/",
+            "/api/v1/likes"
     );
 
     private final ApiKeyService apiKeyService;

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/LikeRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/LikeRepository.java
@@ -1,0 +1,32 @@
+package com.dansplugins.api.repository;
+
+import com.dansplugins.api.entity.Like;
+import com.dansplugins.api.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface LikeRepository extends JpaRepository<Like, UUID> {
+
+    boolean existsByUserAndTargetTypeAndTargetId(User user, String targetType, String targetId);
+
+    long deleteByUserAndTargetTypeAndTargetId(User user, String targetType, String targetId);
+
+    long countByTargetTypeAndTargetId(String targetType, String targetId);
+
+    List<Like> findByUser(User user);
+
+    /** Aggregate like counts per target id for one target type. */
+    @Query("select l.targetId as targetId, count(l) as count "
+            + "from LikeRecord l where l.targetType = :targetType group by l.targetId")
+    List<TargetCount> countsByTargetType(@Param("targetType") String targetType);
+
+    interface TargetCount {
+        String getTargetId();
+
+        long getCount();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/LikeService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/LikeService.java
@@ -1,0 +1,73 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.entity.Like;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Likes on plugins and guides. A like is idempotent (the unique constraint on
+ * {@code (user, target_type, target_id)} means liking twice is a no-op), and
+ * counts are public. Targets are keyed by the plugin id from plugins.json.
+ */
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    static final Set<String> ALLOWED_TYPES = Set.of("plugin", "guide");
+
+    private final LikeRepository likeRepository;
+
+    /** Like a target (no-op if already liked). Returns the target's new like count. */
+    @Transactional
+    public long like(User user, String targetType, String targetId) {
+        validate(targetType, targetId);
+        if (!likeRepository.existsByUserAndTargetTypeAndTargetId(user, targetType, targetId)) {
+            likeRepository.save(new Like(user, targetType, targetId));
+        }
+        return likeRepository.countByTargetTypeAndTargetId(targetType, targetId);
+    }
+
+    /** Unlike a target (no-op if not liked). Returns the target's new like count. */
+    @Transactional
+    public long unlike(User user, String targetType, String targetId) {
+        validate(targetType, targetId);
+        likeRepository.deleteByUserAndTargetTypeAndTargetId(user, targetType, targetId);
+        return likeRepository.countByTargetTypeAndTargetId(targetType, targetId);
+    }
+
+    /** Public aggregate counts for one target type: targetId -> count. */
+    @Transactional(readOnly = true)
+    public Map<String, Long> countsForType(String targetType) {
+        validateType(targetType);
+        return likeRepository.countsByTargetType(targetType).stream()
+                .collect(Collectors.toMap(LikeRepository.TargetCount::getTargetId,
+                        LikeRepository.TargetCount::getCount));
+    }
+
+    /** The targets the given user has liked. */
+    @Transactional(readOnly = true)
+    public List<Like> likedByUser(User user) {
+        return likeRepository.findByUser(user);
+    }
+
+    private void validate(String targetType, String targetId) {
+        validateType(targetType);
+        if (targetId == null || targetId.isBlank()) {
+            throw new IllegalArgumentException("targetId is required");
+        }
+    }
+
+    private void validateType(String targetType) {
+        if (!ALLOWED_TYPES.contains(targetType)) {
+            throw new IllegalArgumentException("targetType must be one of " + ALLOWED_TYPES);
+        }
+    }
+}

--- a/dpc-api/src/main/resources/db/migration/V9__create_likes_table.sql
+++ b/dpc-api/src/main/resources/db/migration/V9__create_likes_table.sql
@@ -1,0 +1,14 @@
+-- Likes on plugins and guides (#169). One like per (user, target_type, target_id);
+-- targets are keyed by the plugin id from pages/data/plugins.json.
+
+CREATE TABLE likes (
+    id          UUID PRIMARY KEY,
+    user_id     UUID         NOT NULL REFERENCES users(id),
+    target_type VARCHAR(16)  NOT NULL,
+    target_id   VARCHAR(64)  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uq_like UNIQUE (user_id, target_type, target_id)
+);
+
+-- Supports the public per-target count aggregation.
+CREATE INDEX idx_likes_target ON likes (target_type, target_id);

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/LikeControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/LikeControllerTest.java
@@ -1,0 +1,122 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.repository.LikeRepository;
+import com.dansplugins.api.repository.UserRepository;
+import com.dansplugins.api.service.UserAuthClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class LikeControllerTest {
+
+    private static final String BEARER = "Bearer good-token";
+    private static final String LIKE_MF = "{\"targetType\":\"plugin\",\"targetId\":\"mf\"}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @MockBean
+    private UserAuthClient userAuthClient;
+
+    @BeforeEach
+    void setUp() {
+        likeRepository.deleteAll();
+        userRepository.deleteAll();
+        when(userAuthClient.validate("good-token")).thenReturn(Optional.of("alice"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        // The test H2 DB is shared across @SpringBootTest classes; clean up the rows
+        // (likes before users, FK order) so a leftover like can't block another
+        // class's userRepository.deleteAll().
+        likeRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void like_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/likes").contentType(MediaType.APPLICATION_JSON).content(LIKE_MF))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void like_returnsCount_andIsIdempotent() throws Exception {
+        mockMvc.perform(post("/api/v1/likes").header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(LIKE_MF))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(1));
+
+        // Liking again is a no-op — count stays 1.
+        mockMvc.perform(post("/api/v1/likes").header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(LIKE_MF))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(1));
+    }
+
+    @Test
+    void counts_arePublic_andReflectLikes() throws Exception {
+        mockMvc.perform(post("/api/v1/likes").header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(LIKE_MF)).andExpect(status().isOk());
+
+        // No token — counts are public.
+        mockMvc.perform(get("/api/v1/likes/counts").param("type", "plugin"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mf").value(1));
+    }
+
+    @Test
+    void unlike_decrementsCount() throws Exception {
+        mockMvc.perform(post("/api/v1/likes").header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(LIKE_MF)).andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/likes").header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(LIKE_MF))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(0));
+    }
+
+    @Test
+    void myLikes_returnsTheUsersLikedTargets() throws Exception {
+        mockMvc.perform(post("/api/v1/likes").header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(LIKE_MF)).andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/likes/me").header("Authorization", BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].targetType").value("plugin"))
+                .andExpect(jsonPath("$[0].targetId").value("mf"));
+    }
+
+    @Test
+    void like_invalidType_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/likes").header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"targetType\":\"bogus\",\"targetId\":\"mf\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/service/LikeServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/LikeServiceTest.java
@@ -1,0 +1,104 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.entity.Like;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.LikeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    private final User user = new User("alice");
+
+    @Test
+    void like_whenNotAlreadyLiked_savesAndReturnsCount() {
+        when(likeRepository.existsByUserAndTargetTypeAndTargetId(user, "plugin", "mf")).thenReturn(false);
+        when(likeRepository.countByTargetTypeAndTargetId("plugin", "mf")).thenReturn(1L);
+
+        assertThat(likeService.like(user, "plugin", "mf")).isEqualTo(1L);
+        verify(likeRepository).save(any(Like.class));
+    }
+
+    @Test
+    void like_whenAlreadyLiked_isIdempotent() {
+        when(likeRepository.existsByUserAndTargetTypeAndTargetId(user, "plugin", "mf")).thenReturn(true);
+        when(likeRepository.countByTargetTypeAndTargetId("plugin", "mf")).thenReturn(3L);
+
+        assertThat(likeService.like(user, "plugin", "mf")).isEqualTo(3L);
+        verify(likeRepository, never()).save(any(Like.class));
+    }
+
+    @Test
+    void like_invalidType_throws() {
+        assertThatThrownBy(() -> likeService.like(user, "bogus", "mf"))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(likeRepository, never()).save(any());
+    }
+
+    @Test
+    void like_blankTargetId_throws() {
+        assertThatThrownBy(() -> likeService.like(user, "plugin", "  "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void unlike_deletesAndReturnsCount() {
+        when(likeRepository.countByTargetTypeAndTargetId("guide", "mf")).thenReturn(0L);
+
+        assertThat(likeService.unlike(user, "guide", "mf")).isEqualTo(0L);
+        verify(likeRepository).deleteByUserAndTargetTypeAndTargetId(user, "guide", "mf");
+    }
+
+    @Test
+    void countsForType_mapsProjectionsToTargetIdCount() {
+        LikeRepository.TargetCount a = mock(LikeRepository.TargetCount.class, "a");
+        when(a.getTargetId()).thenReturn("mf");
+        when(a.getCount()).thenReturn(5L);
+        LikeRepository.TargetCount b = mock(LikeRepository.TargetCount.class, "b");
+        when(b.getTargetId()).thenReturn("fiefs");
+        when(b.getCount()).thenReturn(2L);
+        when(likeRepository.countsByTargetType("plugin")).thenReturn(List.of(a, b));
+
+        Map<String, Long> counts = likeService.countsForType("plugin");
+
+        assertThat(counts).containsEntry("mf", 5L).containsEntry("fiefs", 2L);
+    }
+
+    @Test
+    void countsForType_invalidType_throws() {
+        assertThatThrownBy(() -> likeService.countsForType("bogus"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void likedByUser_delegatesToRepository() {
+        Like like = new Like(user, "plugin", "mf");
+        when(likeRepository.findByUser(user)).thenReturn(List.of(like));
+
+        assertThat(likeService.likedByUser(user)).containsExactly(like);
+    }
+
+    private static <T> T mock(Class<T> type, String name) {
+        return org.mockito.Mockito.mock(type, name);
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 of the community-profiles epic (#167) — the **backend** half of #169. A second PR adds the frontend (like buttons + counts).

- **`Like` entity + V9 migration** — `likes(user_id FK → users, target_type, target_id, created_at)` with a `unique(user, target_type, target_id)` constraint (liking is idempotent) and a `(target_type, target_id)` index for the public count aggregation. (JPQL entity name `LikeRecord` to avoid the `LIKE` keyword.)
- **`LikeService` / `LikeRepository`** — `like`/`unlike` (return the fresh count), public per-type counts, the current user's liked set; `targetType` validated to `plugin|guide`, `targetId` required (→ 400).
- **`LikeController`** — `POST`/`DELETE /api/v1/likes` (auth), public `GET /api/v1/likes/counts?type=plugin`, `GET /api/v1/likes/me` (auth). `SecurityConfig` makes counts public + likes authenticated; `ApiKeyAuthFilter` exempts `/api/v1/likes` (auth is the UserAuth token, not `X-API-Key`).

## Test plan
- [x] `./mvnw test` → **113 run, 0 failures** (1 skipped = Docker-only migration test, validated in CI)
- [x] `LikeServiceTest` (8) — like new/idempotent, unlike, counts mapping, validation
- [x] `LikeControllerTest` (6) — 401 without token, count + idempotency, **public** counts, unlike decrement, `/me`, invalid type → 400; cleans up its shared-H2 rows in FK order
- [x] V9 migration validated against real Postgres by `FlywayMigrationTest` in CI

Part of #169 (kept open for the frontend PR). CHANGELOG `[Unreleased]` notes the API.

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_