### PR TITLE
feat(likes): like buttons + counts on plugin cards and guides (#169 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set. Backs the upcoming like buttons on plugin cards and guides.
+- Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.
+- A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set.
 - Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.
 - The home-page plugin catalogue now has a search box that filters plugins by name or description (in addition to the existing sort), with an empty state when nothing matches.
 - The faction leaderboard now shows each faction's server IP (as a click-to-copy chip) and a link to its Discord, when the faction has published them.

--- a/components/GuideLikeButton.tsx
+++ b/components/GuideLikeButton.tsx
@@ -1,0 +1,27 @@
+import React, {useEffect, useState} from 'react';
+import LikeButton from './LikeButton';
+import {getLikeCounts, getMyLikes} from '../services/likeService';
+
+/**
+ * Like button for a guide page. Fetches the guide's current like count (public)
+ * and the signed-in user's liked state on mount, then renders {@link LikeButton}.
+ */
+const GuideLikeButton: React.FC<{ guideId: string }> = ({guideId}) => {
+    const [count, setCount] = useState(0);
+    const [liked, setLiked] = useState(false);
+    const [token, setToken] = useState<string | null>(null);
+
+    useEffect(() => {
+        getLikeCounts('guide').then((counts) => setCount(counts[guideId] || 0));
+        const saved = typeof window !== 'undefined' ? window.localStorage.getItem('dpc-token') : null;
+        setToken(saved);
+        if (saved) {
+            getMyLikes(saved).then((likes) =>
+                setLiked(likes.some((l) => l.targetType === 'guide' && l.targetId === guideId)));
+        }
+    }, [guideId]);
+
+    return <LikeButton targetType="guide" targetId={guideId} count={count} liked={liked} token={token}/>;
+};
+
+export default GuideLikeButton;

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,0 +1,69 @@
+import React, {useEffect, useState} from 'react';
+import {Box, IconButton, Tooltip, Typography} from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import {likeTarget, unlikeTarget, LikeTargetType} from '../services/likeService';
+
+interface LikeButtonProps {
+    targetType: LikeTargetType;
+    targetId: string;
+    count: number;
+    liked: boolean;
+    // The signed-in user's token, or null when logged out (then the button links to /account).
+    token: string | null;
+}
+
+const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, liked, token}) => {
+    const [currentCount, setCurrentCount] = useState(count);
+    const [isLiked, setIsLiked] = useState(liked);
+    const [busy, setBusy] = useState(false);
+
+    // Sync when the parent supplies loaded data (counts/likes are fetched on mount).
+    useEffect(() => setCurrentCount(count), [count]);
+    useEffect(() => setIsLiked(liked), [liked]);
+
+    const handleClick = async () => {
+        if (!token) {
+            window.location.href = '/account';
+            return;
+        }
+        if (busy) {
+            return;
+        }
+        setBusy(true);
+        const result = isLiked
+            ? await unlikeTarget(token, targetType, targetId)
+            : await likeTarget(token, targetType, targetId);
+        if (result !== null) {
+            setIsLiked(!isLiked);
+            setCurrentCount(result);
+        }
+        setBusy(false);
+    };
+
+    const tooltip = token ? (isLiked ? 'Unlike' : 'Like') : 'Sign in to like';
+
+    return (
+        <Box sx={{display: 'inline-flex', alignItems: 'center'}}>
+            <Tooltip title={tooltip}>
+                <span>
+                    <IconButton
+                        size="small"
+                        onClick={handleClick}
+                        disabled={busy}
+                        color={isLiked ? 'error' : 'default'}
+                        aria-label={isLiked ? 'Unlike' : 'Like'}
+                        aria-pressed={isLiked}
+                    >
+                        {isLiked ? <FavoriteIcon fontSize="small"/> : <FavoriteBorderIcon fontSize="small"/>}
+                    </IconButton>
+                </span>
+            </Tooltip>
+            <Typography variant="body2" color="text.secondary" sx={{minWidth: 16}}>
+                {currentCount}
+            </Typography>
+        </Box>
+    );
+};
+
+export default LikeButton;

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, Typography} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import DnsIcon from '@mui/icons-material/Dns';
+import LikeButton from './LikeButton';
 import {
     pluginCardStyle,
     pluginCardContentStyle,
@@ -9,12 +10,16 @@ import {
 } from '../styles/styles';
 
 interface PluginCardProps {
+    id: string;
     title: string;
     description: string;
     githubLink: string;
     spigotmcLink?: string;
     bStatsId?: string;
     serverCount?: number | null;
+    likeCount: number;
+    liked: boolean;
+    token: string | null;
 }
 
 // A small, fixed palette of muted brand-ish colours. Each plugin gets a stable
@@ -31,11 +36,15 @@ const colorForTitle = (title: string): string => {
 };
 
 const PluginCard: React.FC<PluginCardProps> = ({
+    id,
     title,
     description,
     githubLink,
     spigotmcLink,
-    serverCount
+    serverCount,
+    likeCount,
+    liked,
+    token
 }) => {
     return (
         <Card sx={pluginCardStyle}>
@@ -86,6 +95,8 @@ const PluginCard: React.FC<PluginCardProps> = ({
             ) : null}
 
             <CardActions sx={pluginCardActionsStyle}>
+                <LikeButton targetType="plugin" targetId={id} count={likeCount} liked={liked} token={token}/>
+                <Box sx={{flexGrow: 1}}/>
                 <Button
                     variant="contained"
                     size="small"

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -6,6 +6,7 @@ import type {GetServerSideProps, NextPage} from 'next';
 import React from 'react';
 import TopBar from '../../components/TopBar';
 import Seo from '../../components/Seo';
+import GuideLikeButton from '../../components/GuideLikeButton';
 import BottomBar from '../../components/BottomBar';
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles';
 import {userGuideUrl, userGuideRawUrl} from '../../utils/guides';
@@ -21,6 +22,7 @@ interface GuidePlugin {
 const pluginData = require('../data/plugins.json') as { plugins: GuidePlugin[] };
 
 interface GuidePageProps {
+    id: string;
     title: string;
     githubLink: string;
     // The fetched guide markdown, or null if it couldn't be loaded (the page then
@@ -43,7 +45,7 @@ export const getServerSideProps: GetServerSideProps<GuidePageProps> = async ({pa
     } catch {
         // Leave markdown null; the page renders a fallback link to GitHub.
     }
-    return {props: {title: plugin.title, githubLink: plugin.githubLink, markdown}};
+    return {props: {id, title: plugin.title, githubLink: plugin.githubLink, markdown}};
 };
 
 // Themed styling for the rendered markdown elements (markdown-to-jsx emits plain
@@ -80,7 +82,7 @@ const guideBodyStyle = {
     '& th, & td': {border: '1px solid', borderColor: 'divider', p: 1, textAlign: 'left'},
 };
 
-const GuidePage: NextPage<GuidePageProps> = ({title, githubLink, markdown}) => (
+const GuidePage: NextPage<GuidePageProps> = ({id, title, githubLink, markdown}) => (
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo title={`${title} Guide`} description={`User guide for the ${title} plugin from Dan's Plugins Community.`}/>
         <TopBar/>
@@ -88,9 +90,12 @@ const GuidePage: NextPage<GuidePageProps> = ({title, githubLink, markdown}) => (
             <Button href="/guides" startIcon={<ArrowBackIcon/>} sx={{mb: 2}}>
                 All guides
             </Button>
-            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
-                {title} Guide
-            </Typography>
+            <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
+                <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                    {title} Guide
+                </Typography>
+                <GuideLikeButton guideId={id}/>
+            </Box>
 
             {markdown ? (
                 <Box sx={guideBodyStyle}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import BottomBar from '../components/BottomBar'
 import { getVisits, incrementVisits } from '../services/visitService';
 import { getServerCountsWithRateLimit } from '../utils/bstats';
+import { getLikeCounts, getMyLikes } from '../services/likeService';
 
 interface PluginData {
     mostPopular: string[];
@@ -48,17 +49,28 @@ interface PluginWithServerCount extends Plugin {
     serverCount?: number | null;
 }
 
-const PluginSection: React.FC<{ plugins: PluginWithServerCount[] }> = ({ plugins }) => (
+interface PluginSectionProps {
+    plugins: PluginWithServerCount[];
+    likeCounts: Record<string, number>;
+    likedSet: Set<string>;
+    token: string | null;
+}
+
+const PluginSection: React.FC<PluginSectionProps> = ({ plugins, likeCounts, likedSet, token }) => (
     <Grid container {...gridContainerStyle}>
         {plugins.map((plugin) => (
             <Grid item {...gridItemStyle} key={plugin.id}>
                 <PluginCard
+                    id={plugin.id}
                     title={plugin.title}
                     description={plugin.description}
                     githubLink={plugin.githubLink}
                     spigotmcLink={plugin.spigotmcLink}
                     bStatsId={plugin.bStatsId}
                     serverCount={plugin.serverCount}
+                    likeCount={likeCounts[plugin.id] || 0}
+                    liked={likedSet.has(plugin.id)}
+                    token={token}
                 />
             </Grid>
         ))}
@@ -74,6 +86,19 @@ interface PluginsSectionProps {
 const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
     const [sortBy, setSortBy] = React.useState<SortOption>('popularity');
     const [query, setQuery] = React.useState('');
+    const [likeCounts, setLikeCounts] = React.useState<Record<string, number>>({});
+    const [likedSet, setLikedSet] = React.useState<Set<string>>(new Set());
+    const [token, setToken] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        getLikeCounts('plugin').then(setLikeCounts);
+        const saved = typeof window !== 'undefined' ? window.localStorage.getItem('dpc-token') : null;
+        setToken(saved);
+        if (saved) {
+            getMyLikes(saved).then((likes) =>
+                setLikedSet(new Set(likes.filter((l) => l.targetType === 'plugin').map((l) => l.targetId))));
+        }
+    }, []);
 
     const handleSortChange = (
         event: React.MouseEvent<HTMLElement>,
@@ -153,7 +178,7 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
             </Box>
 
             {visiblePlugins.length > 0 ? (
-                <PluginSection plugins={visiblePlugins} />
+                <PluginSection plugins={visiblePlugins} likeCounts={likeCounts} likedSet={likedSet} token={token} />
             ) : (
                 <Typography color="text.secondary" align="center" sx={{ py: 4 }}>
                     No plugins match your search.

--- a/services/likeService.ts
+++ b/services/likeService.ts
@@ -1,0 +1,62 @@
+// Client-side calls to the dpc-api likes endpoints. The base URL is the same
+// public API the leaderboard/account pages use.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+
+export type LikeTargetType = 'plugin' | 'guide';
+
+export interface LikedTarget {
+    targetType: LikeTargetType;
+    targetId: string;
+}
+
+/** Public aggregate like counts for a target type: targetId -> count. */
+export const getLikeCounts = async (type: LikeTargetType): Promise<Record<string, number>> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/likes/counts?type=${type}`);
+        return res.ok ? await res.json() : {};
+    } catch {
+        return {};
+    }
+};
+
+/** The signed-in user's liked targets (requires a token). */
+export const getMyLikes = async (token: string): Promise<LikedTarget[]> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/likes/me`, {
+            headers: {Authorization: `Bearer ${token}`},
+        });
+        return res.ok ? await res.json() : [];
+    } catch {
+        return [];
+    }
+};
+
+const mutate = async (
+    method: 'POST' | 'DELETE',
+    token: string,
+    targetType: LikeTargetType,
+    targetId: string
+): Promise<number | null> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/likes`, {
+            method,
+            headers: {'Content-Type': 'application/json', Authorization: `Bearer ${token}`},
+            body: JSON.stringify({targetType, targetId}),
+        });
+        if (!res.ok) {
+            return null;
+        }
+        const data = await res.json();
+        return typeof data.count === 'number' ? data.count : null;
+    } catch {
+        return null;
+    }
+};
+
+/** Like a target; resolves to the new count, or null on failure. */
+export const likeTarget = (token: string, type: LikeTargetType, id: string) =>
+    mutate('POST', token, type, id);
+
+/** Unlike a target; resolves to the new count, or null on failure. */
+export const unlikeTarget = (token: string, type: LikeTargetType, id: string) =>
+    mutate('DELETE', token, type, id);


### PR DESCRIPTION
## Summary
Frontend half of #169, on top of the likes API (PR #178). Completes the feature.

- **`services/likeService.ts`** (client) — `getLikeCounts` (public), `getMyLikes`, `like`/`unlike`; all via `NEXT_PUBLIC_API_URL` (same pattern as the leaderboard/account pages).
- **`components/LikeButton.tsx`** — a heart toggle + live count. Reads the stored `dpc-token`; logged-out clicks go to `/account` ("Sign in to like"). Updates the count from the API response; syncs to loaded data via `useEffect`.
- **Plugin cards** — show a like button. `PluginsSection` fetches the public plugin counts and (if signed in) the user's liked set once on mount, and threads `count`/`liked`/`token` to each `PluginCard`.
- **Guide pages** (`/guides/[id]`) — show a like button; `GuideLikeButton` fetches the guide's count + liked state on mount.

## Test plan
- [x] `npx tsc --noEmit` clean; `npm run lint` clean
- [x] No new `any`; MUI-only (IconButton, Favorite icons, Tooltip); no new `NEXT_PUBLIC_*` var (reuses `NEXT_PUBLIC_API_URL`)
- [x] Production build verified by the **Build Website** CI check
- [ ] Manual: signed in, liking a plugin/guide increments + persists; unliking decrements; logged out, the heart routes to `/account`; counts visible to everyone

Out of scope (noted as a follow-up): an optional "Most liked" sort on the catalogue.

Closes #169

_Opened by Claude during an automated dev-loop cycle._

---

_drafted by Claude on behalf of Daniel Stephenson_