### PR TITLE
Release: fix V8 migration (preserve existing accounts/api_keys)

### DIFF
--- a/dpc-api/src/main/resources/db/migration/V8__replace_accounts_with_users.sql
+++ b/dpc-api/src/main/resources/db/migration/V8__replace_accounts_with_users.sql
@@ -1,7 +1,11 @@
 -- Consolidate site identity on UserAuth (epic #167, Option B). dpc-api no longer
 -- stores its own accounts/passwords; it keeps a lightweight local mirror of the
 -- UserAuth identity (keyed by username) that owns API keys and community state.
--- The API has no users yet, so there are no rows to migrate.
+--
+-- This migration preserves any existing rows. Even though the API has no human
+-- users yet, prod can hold service identities (e.g. the account that owns the
+-- MedievalFactions API key used to POST /api/v1/factions). Each account becomes a
+-- users row REUSING ITS UUID, so api_keys.owner_id stays valid and no key is lost.
 
 CREATE TABLE users (
     id                UUID PRIMARY KEY,
@@ -13,13 +17,30 @@ CREATE TABLE users (
     updated_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
 );
 
--- Repoint API-key ownership from the retired accounts table to users. Dropping the
--- column removes its foreign key to accounts and the owner index; both are recreated
--- against users. Safe because api_keys is empty.
-DROP INDEX IF EXISTS idx_api_keys_owner_id;
-ALTER TABLE api_keys DROP COLUMN owner_id;
+-- Carry existing identities over, keyed by username and keeping the same id so
+-- existing api_keys.owner_id references remain valid. The password_hash is dropped
+-- on purpose: authentication now lives in UserAuth, not dpc-api.
+INSERT INTO users (id, userauth_username, display_name, created_at, updated_at)
+SELECT id, username, username, created_at, now() FROM accounts;
+
+-- Repoint API-key ownership from the retired accounts table to users WITHOUT
+-- touching owner_id values (they already point at the carried-over ids). Drop only
+-- the foreign key to accounts (discovered by catalog, name-agnostic), then re-add it
+-- against users. The owner index is left in place.
+DO $$
+DECLARE fk_name text;
+BEGIN
+    SELECT conname INTO fk_name
+      FROM pg_constraint
+     WHERE conrelid = 'api_keys'::regclass
+       AND contype  = 'f'
+       AND confrelid = 'accounts'::regclass;
+    IF fk_name IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE api_keys DROP CONSTRAINT ' || quote_ident(fk_name);
+    END IF;
+END $$;
 
 DROP TABLE accounts;
 
-ALTER TABLE api_keys ADD COLUMN owner_id UUID NOT NULL REFERENCES users(id);
-CREATE INDEX idx_api_keys_owner_id ON api_keys (owner_id);
+ALTER TABLE api_keys
+    ADD CONSTRAINT api_keys_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users(id);


### PR DESCRIPTION
Hotfix for the develop→main release deployed in gateway #108, which failed its prod health check.

## Problem
V8 added `api_keys.owner_id` via `ADD COLUMN ... NOT NULL` (no default). Postgres rejects that on a non-empty table. Prod has the MedievalFactions service account + 2 API keys, so V8 aborted, dpc-api never booted, and the runner auto-rolled-back. Prod was unharmed (transactional DDL + pre-deploy pg_dump).

## Fix
Rewrite V8 to preserve data: copy each `accounts` row into `users` reusing its UUID, swap the `api_keys` FK from `accounts` to `users`, drop `accounts`. Final schema is identical to before.

## Verification
Ran V1–V7 + a prod-shape seed (1 account, 2 keys) + the new V8/V9 in a throwaway Postgres:
`users=1  api_keys_preserved=2  keys_valid_fk=2  accounts_gone=true  mirrored_username=mf-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_