### PR TITLE
ux: usability pass — 3 fixes (like-action feedback) from Nielsen + Don't Make Me Think

### DIFF
--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -50,6 +50,12 @@ const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, lik
         if (result !== null) {
             setIsLiked(!isLiked);
             setCurrentCount(result);
+        } else {
+            // The request failed — a network error, or an expired/invalid token.
+            // Previously the heart just didn't move and the user got no explanation:
+            // the classic "nothing happens" dead end (Nielsen #1 visibility of system
+            // status; #9 help users recognize and recover from errors).
+            setNotice({message: 'Couldn’t save your like — please try again.'});
         }
         setBusy(false);
     };

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Box, IconButton, Tooltip, Typography} from '@mui/material';
+import {Box, Button, IconButton, Snackbar, Tooltip, Typography} from '@mui/material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import {likeTarget, unlikeTarget, LikeTargetType} from '../services/likeService';
@@ -17,14 +17,27 @@ const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, lik
     const [currentCount, setCurrentCount] = useState(count);
     const [isLiked, setIsLiked] = useState(liked);
     const [busy, setBusy] = useState(false);
+    // A transient message shown after a click that can't complete (signed out, or a
+    // failed request). signIn flips the Snackbar's action to a "Sign in" button.
+    const [notice, setNotice] = useState<{message: string; signIn?: boolean} | null>(null);
 
     // Sync when the parent supplies loaded data (counts/likes are fetched on mount).
     useEffect(() => setCurrentCount(count), [count]);
     useEffect(() => setIsLiked(liked), [liked]);
 
+    // Send a signed-out user to the account page, but remember where they were so
+    // they land back here after authenticating (see pages/account.tsx returnTo).
+    const goSignIn = () => {
+        const returnTo = window.location.pathname + window.location.search;
+        window.location.href = `/account?returnTo=${encodeURIComponent(returnTo)}`;
+    };
+
     const handleClick = async () => {
         if (!token) {
-            window.location.href = '/account';
+            // Don't silently yank the user to a login page — say why first, and let
+            // them choose to go (Nielsen #3 user control & freedom; Krug: answer the
+            // obvious question before acting).
+            setNotice({message: 'Sign in to like plugins and guides.', signIn: true});
             return;
         }
         if (busy) {
@@ -44,25 +57,37 @@ const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, lik
     const tooltip = token ? (isLiked ? 'Unlike' : 'Like') : 'Sign in to like';
 
     return (
-        <Box sx={{display: 'inline-flex', alignItems: 'center'}}>
-            <Tooltip title={tooltip}>
-                <span>
-                    <IconButton
-                        size="small"
-                        onClick={handleClick}
-                        disabled={busy}
-                        color={isLiked ? 'error' : 'default'}
-                        aria-label={isLiked ? 'Unlike' : 'Like'}
-                        aria-pressed={isLiked}
-                    >
-                        {isLiked ? <FavoriteIcon fontSize="small"/> : <FavoriteBorderIcon fontSize="small"/>}
-                    </IconButton>
-                </span>
-            </Tooltip>
-            <Typography variant="body2" color="text.secondary" sx={{minWidth: 16}}>
-                {currentCount}
-            </Typography>
-        </Box>
+        <>
+            <Box sx={{display: 'inline-flex', alignItems: 'center'}}>
+                <Tooltip title={tooltip}>
+                    <span>
+                        <IconButton
+                            size="small"
+                            onClick={handleClick}
+                            disabled={busy}
+                            color={isLiked ? 'error' : 'default'}
+                            aria-label={isLiked ? 'Unlike' : 'Like'}
+                            aria-pressed={isLiked}
+                        >
+                            {isLiked ? <FavoriteIcon fontSize="small"/> : <FavoriteBorderIcon fontSize="small"/>}
+                        </IconButton>
+                    </span>
+                </Tooltip>
+                <Typography variant="body2" color="text.secondary" sx={{minWidth: 16}}>
+                    {currentCount}
+                </Typography>
+            </Box>
+            <Snackbar
+                open={notice !== null}
+                autoHideDuration={4000}
+                onClose={() => setNotice(null)}
+                message={notice?.message}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+                action={notice?.signIn
+                    ? <Button color="secondary" size="small" onClick={goSignIn}>Sign in</Button>
+                    : undefined}
+            />
+        </>
     );
 };
 

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -17,6 +17,7 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import type {NextPage} from 'next'
+import {useRouter} from 'next/router'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
@@ -45,6 +46,7 @@ interface AccountProfile {
 }
 
 const AccountPage: NextPage = () => {
+    const router = useRouter()
     const [tab, setTab] = useState(0)
     const [token, setToken] = useState<string | null>(null)
     const [profile, setProfile] = useState<AccountProfile | null>(null)
@@ -114,6 +116,17 @@ const AccountPage: NextPage = () => {
         }
     }, [token, fetchProfile])
 
+    // After authenticating, send the user back to wherever they came from — e.g. a
+    // plugin whose like button bounced them here (LikeButton sets ?returnTo=...).
+    // Only internal paths are honored, never an absolute URL, to avoid an open redirect.
+    const returnAfterAuth = () => {
+        const returnTo = router.query.returnTo
+        const path = typeof returnTo === 'string' ? returnTo : null
+        if (path && path.startsWith('/') && !path.startsWith('//')) {
+            router.push(path)
+        }
+    }
+
     const handleRegister = async (e: React.FormEvent) => {
         e.preventDefault()
         setError(null)
@@ -131,6 +144,7 @@ const AccountPage: NextPage = () => {
                 setSuccess('Account created successfully!')
                 setUsername('')
                 setPassword('')
+                returnAfterAuth()
             } else {
                 setError('Registration failed. Username may already be taken.')
             }
@@ -156,6 +170,7 @@ const AccountPage: NextPage = () => {
                 setSuccess('Logged in!')
                 setUsername('')
                 setPassword('')
+                returnAfterAuth()
             } else {
                 setError('Invalid credentials.')
             }


### PR DESCRIPTION
## Summary
A focused usability-pass round triggered by a real report: *signed out, clicking a heart does nothing.* The theme is **feedback and continuity for the like action's non-happy paths** — the strongest UX smell being "nothing happens." Every commit is one self-contained Nielsen / Krug fix.

### Round 1 — feedback for the like action when not (properly) signed in
1. **`LikeButton` (signed-out)** — replaced the silent `window.location='/account'` redirect with a brief "Sign in to like plugins and guides." message and a **Sign in** action that carries a `returnTo` (Nielsen #3 user control & freedom; Krug: answer the obvious question before acting).
2. **`LikeButton` (failed request)** — a like that came back `null` (network error, or an expired/invalid token the page still held) left the heart unmoved with zero feedback; it now reports "Couldn't save your like — please try again." (Nielsen #1 visibility of system status; #9 recover from errors).
3. **`account.tsx` (post-sign-in)** — login/registration now honor the `?returnTo=` param and send the user back to the plugin/guide they came from instead of stranding them on the account page; only internal `/…` paths are accepted, so it can't be used as an open redirect (Krug: close the loop; Nielsen #3).

## Test plan
- [ ] Signed out, click a heart on a plugin card → a message appears with a **Sign in** button (no silent jump).
- [ ] Click **Sign in**, log in → you're returned to the page you were on.
- [ ] Signed in with an expired token, click a heart → an error message appears (heart doesn't silently freeze).
- [ ] Signed in normally, click a heart → it toggles and the count updates (unchanged happy path).
- [ ] Same behaviors on a guide page's like button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_