### PR TITLE
Release: like-action usability fixes (#186)

### DIFF
--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -50,6 +50,12 @@ const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, lik
         if (result !== null) {
             setIsLiked(!isLiked);
             setCurrentCount(result);
+        } else {
+            // The request failed — a network error, or an expired/invalid token.
+            // Previously the heart just didn't move and the user got no explanation:
+            // the classic "nothing happens" dead end (Nielsen #1 visibility of system
+            // status; #9 help users recognize and recover from errors).
+            setNotice({message: 'Couldn’t save your like — please try again.'});
         }
         setBusy(false);
     };

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Box, IconButton, Tooltip, Typography} from '@mui/material';
+import {Box, Button, IconButton, Snackbar, Tooltip, Typography} from '@mui/material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import {likeTarget, unlikeTarget, LikeTargetType} from '../services/likeService';
@@ -17,14 +17,27 @@ const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, lik
     const [currentCount, setCurrentCount] = useState(count);
     const [isLiked, setIsLiked] = useState(liked);
     const [busy, setBusy] = useState(false);
+    // A transient message shown after a click that can't complete (signed out, or a
+    // failed request). signIn flips the Snackbar's action to a "Sign in" button.
+    const [notice, setNotice] = useState<{message: string; signIn?: boolean} | null>(null);
 
     // Sync when the parent supplies loaded data (counts/likes are fetched on mount).
     useEffect(() => setCurrentCount(count), [count]);
     useEffect(() => setIsLiked(liked), [liked]);
 
+    // Send a signed-out user to the account page, but remember where they were so
+    // they land back here after authenticating (see pages/account.tsx returnTo).
+    const goSignIn = () => {
+        const returnTo = window.location.pathname + window.location.search;
+        window.location.href = `/account?returnTo=${encodeURIComponent(returnTo)}`;
+    };
+
     const handleClick = async () => {
         if (!token) {
-            window.location.href = '/account';
+            // Don't silently yank the user to a login page — say why first, and let
+            // them choose to go (Nielsen #3 user control & freedom; Krug: answer the
+            // obvious question before acting).
+            setNotice({message: 'Sign in to like plugins and guides.', signIn: true});
             return;
         }
         if (busy) {
@@ -44,25 +57,37 @@ const LikeButton: React.FC<LikeButtonProps> = ({targetType, targetId, count, lik
     const tooltip = token ? (isLiked ? 'Unlike' : 'Like') : 'Sign in to like';
 
     return (
-        <Box sx={{display: 'inline-flex', alignItems: 'center'}}>
-            <Tooltip title={tooltip}>
-                <span>
-                    <IconButton
-                        size="small"
-                        onClick={handleClick}
-                        disabled={busy}
-                        color={isLiked ? 'error' : 'default'}
-                        aria-label={isLiked ? 'Unlike' : 'Like'}
-                        aria-pressed={isLiked}
-                    >
-                        {isLiked ? <FavoriteIcon fontSize="small"/> : <FavoriteBorderIcon fontSize="small"/>}
-                    </IconButton>
-                </span>
-            </Tooltip>
-            <Typography variant="body2" color="text.secondary" sx={{minWidth: 16}}>
-                {currentCount}
-            </Typography>
-        </Box>
+        <>
+            <Box sx={{display: 'inline-flex', alignItems: 'center'}}>
+                <Tooltip title={tooltip}>
+                    <span>
+                        <IconButton
+                            size="small"
+                            onClick={handleClick}
+                            disabled={busy}
+                            color={isLiked ? 'error' : 'default'}
+                            aria-label={isLiked ? 'Unlike' : 'Like'}
+                            aria-pressed={isLiked}
+                        >
+                            {isLiked ? <FavoriteIcon fontSize="small"/> : <FavoriteBorderIcon fontSize="small"/>}
+                        </IconButton>
+                    </span>
+                </Tooltip>
+                <Typography variant="body2" color="text.secondary" sx={{minWidth: 16}}>
+                    {currentCount}
+                </Typography>
+            </Box>
+            <Snackbar
+                open={notice !== null}
+                autoHideDuration={4000}
+                onClose={() => setNotice(null)}
+                message={notice?.message}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+                action={notice?.signIn
+                    ? <Button color="secondary" size="small" onClick={goSignIn}>Sign in</Button>
+                    : undefined}
+            />
+        </>
     );
 };
 

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -17,6 +17,7 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import type {NextPage} from 'next'
+import {useRouter} from 'next/router'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
@@ -45,6 +46,7 @@ interface AccountProfile {
 }
 
 const AccountPage: NextPage = () => {
+    const router = useRouter()
     const [tab, setTab] = useState(0)
     const [token, setToken] = useState<string | null>(null)
     const [profile, setProfile] = useState<AccountProfile | null>(null)
@@ -114,6 +116,17 @@ const AccountPage: NextPage = () => {
         }
     }, [token, fetchProfile])
 
+    // After authenticating, send the user back to wherever they came from — e.g. a
+    // plugin whose like button bounced them here (LikeButton sets ?returnTo=...).
+    // Only internal paths are honored, never an absolute URL, to avoid an open redirect.
+    const returnAfterAuth = () => {
+        const returnTo = router.query.returnTo
+        const path = typeof returnTo === 'string' ? returnTo : null
+        if (path && path.startsWith('/') && !path.startsWith('//')) {
+            router.push(path)
+        }
+    }
+
     const handleRegister = async (e: React.FormEvent) => {
         e.preventDefault()
         setError(null)
@@ -131,6 +144,7 @@ const AccountPage: NextPage = () => {
                 setSuccess('Account created successfully!')
                 setUsername('')
                 setPassword('')
+                returnAfterAuth()
             } else {
                 setError('Registration failed. Username may already be taken.')
             }
@@ -156,6 +170,7 @@ const AccountPage: NextPage = () => {
                 setSuccess('Logged in!')
                 setUsername('')
                 setPassword('')
+                returnAfterAuth()
             } else {
                 setError('Invalid credentials.')
             }


### PR DESCRIPTION
Frontend-only usability pass for the like action (signed-out prompt + Sign in returnTo, failed-like feedback, return-to-page after auth). No migration or backend changes — migration chain unchanged at V10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_