### PR TITLE
fix(db): drop orphaned discord_announcements table (V11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Authentication is now provided by the shared UserAuth service instead of dpc-api's own accounts (epic #167, phase 1). dpc-api proxies registration/login/logout to UserAuth and validates its tokens; a local profile mirror owns each user's API keys. The Account page now signs in via UserAuth and supports a profile (display name, avatar, bio). API paths moved from `/api/v1/accounts/*` to `/api/v1/auth/*` and `/api/v1/profile/*`. The Docker Compose stack now bundles the UserAuth service (and its database) so `docker compose up` runs end-to-end; `JWT_SECRET` (used by UserAuth to sign tokens) is now required when starting the stack.
 
+### Removed
+
+- The orphaned `discord_announcements` table is dropped (migration V11). The Discord-ingestion feature (#24) was preview-deployed to production on 2026-06-06 — which created the table — but its PR was never merged, so no code referenced the table. It is dropped until the feature lands; the original create migration (V8) is retained because it is recorded in production's migration history.
+
 ### Fixed
 
 - `POST /api/v1/auth/register` no longer returns a 503 (which hid that the account was already created) when the automatic post-register login fails. It now returns `201` with `{ "registered": true, "tokenIssued": false }`, signalling the caller to log in rather than re-register.

--- a/dpc-api/src/main/resources/db/migration/V11__drop_discord_announcements_table.sql
+++ b/dpc-api/src/main/resources/db/migration/V11__drop_discord_announcements_table.sql
@@ -1,0 +1,16 @@
+-- Retire the orphaned discord_announcements table.
+--
+-- The Discord-ingestion feature (#24, PR #141) was preview-deployed to prod on
+-- 2026-06-06 -- which applied V8 and created this table -- but that PR was never
+-- merged, so no code in main reads or writes the table. Rather than carry dead
+-- schema (and a migration that creates an unused table on every fresh DB), drop it.
+--
+-- This is forward-only and idempotent: V8 still records that the table once
+-- existed (it is applied in prod history and must stay in the repo), and V11
+-- removes it. If #24 is revived later it should ship its own migration to
+-- recreate the table.
+--
+-- DROP TABLE also removes the table's indexes
+-- (idx_discord_announcements_message_id_unique, idx_discord_announcements_posted_at).
+-- Safe: nothing references this table (no foreign keys point at it).
+DROP TABLE IF EXISTS discord_announcements;


### PR DESCRIPTION
## Problem
While fixing the Flyway V8 collision during the UserAuth/likes deploy, an orphaned table surfaced: prod has `discord_announcements` (created by V8, applied 2026-06-06 via a **preview deploy of PR #141 / #24** that was never merged), but **no code in `main` references it**. The V8 migration also recreates this unused table on every fresh database.

## Fix
Add `V11__drop_discord_announcements_table.sql` — a forward, idempotent `DROP TABLE IF EXISTS`. V8 is intentionally **kept** (it is recorded in prod's `flyway_schema_history`; removing it would re-break validation). The table has no inbound foreign keys, so the drop is safe.

If #24 is revived later (it needs a Discord bot token + channel config, deliberately deferred), it should ship its own migration to recreate the table.

## Verification
- CI `FlywayMigrationTest` runs V1→V11 on a fresh Postgres (V8 creates, V11 drops).
- Confirmed no `discord_announcements` / `DiscordAnnouncement` reference exists anywhere in `main`.

Closes nothing — #24 / PR #141 stay open as deferred feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_