### PR TITLE
feat(account): add "My likes" section to the account page (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.
 - Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.
 - A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set.
 - Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -58,6 +58,7 @@ No special software is required to use the website. Simply visit [https://danspl
 1. Click **Account** in the top navigation bar (or visit `/account`).
 2. Register a new account, or log in with an existing username and password.
 3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
+4. The **My likes** section lists the plugins and guides you've liked, linking to each one — your personal toolbox.
 
 ### Getting Support
 

--- a/__tests__/likedItems.test.ts
+++ b/__tests__/likedItems.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest'
+import {resolveLikedItems} from '../utils/likedItems'
+import type {LikedTarget} from '../services/likeService'
+
+const catalogue = [
+    {id: 'fiefs', title: 'Fiefs'},
+    {id: 'medieval-factions', title: 'Medieval Factions'},
+]
+
+describe('resolveLikedItems', () => {
+    it('labels a liked plugin with its catalogue title and links to the home catalogue', () => {
+        const likes: LikedTarget[] = [{targetType: 'plugin', targetId: 'fiefs'}]
+        expect(resolveLikedItems(likes, catalogue)).toEqual([
+            {key: 'plugin:fiefs', targetType: 'plugin', targetId: 'fiefs', title: 'Fiefs', href: '/#plugins'},
+        ])
+    })
+
+    it('labels a liked guide as "<title> Guide" and links to its guide page', () => {
+        const likes: LikedTarget[] = [{targetType: 'guide', targetId: 'medieval-factions'}]
+        expect(resolveLikedItems(likes, catalogue)).toEqual([
+            {
+                key: 'guide:medieval-factions',
+                targetType: 'guide',
+                targetId: 'medieval-factions',
+                title: 'Medieval Factions Guide',
+                href: '/guides/medieval-factions',
+            },
+        ])
+    })
+
+    it('falls back to the raw id when the target is not in the catalogue', () => {
+        const likes: LikedTarget[] = [{targetType: 'plugin', targetId: 'retired-plugin'}]
+        expect(resolveLikedItems(likes, catalogue)).toEqual([
+            {
+                key: 'plugin:retired-plugin',
+                targetType: 'plugin',
+                targetId: 'retired-plugin',
+                title: 'retired-plugin',
+                href: '/#plugins',
+            },
+        ])
+    })
+
+    it('sorts the resolved items by title', () => {
+        const likes: LikedTarget[] = [
+            {targetType: 'guide', targetId: 'medieval-factions'},
+            {targetType: 'plugin', targetId: 'fiefs'},
+            {targetType: 'plugin', targetId: 'medieval-factions'},
+        ]
+        expect(resolveLikedItems(likes, catalogue).map((i) => i.key)).toEqual([
+            'plugin:fiefs',
+            'plugin:medieval-factions',
+            'guide:medieval-factions',
+        ])
+    })
+
+    it('returns an empty array when there are no likes', () => {
+        expect(resolveLikedItems([], catalogue)).toEqual([])
+    })
+})

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -4,10 +4,12 @@ import {
     Button,
     Card,
     CardContent,
+    Chip,
     Container,
     IconButton,
     List,
     ListItem,
+    ListItemButton,
     ListItemText,
     Tab,
     Tabs,
@@ -23,6 +25,9 @@ import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
+import {getMyLikes, type LikedTarget} from '../services/likeService'
+import {resolveLikedItems} from '../utils/likedItems'
+import pluginData from './data/plugins.json'
 
 const version = require('../package.json').version
 
@@ -50,6 +55,7 @@ const AccountPage: NextPage = () => {
     const [tab, setTab] = useState(0)
     const [token, setToken] = useState<string | null>(null)
     const [profile, setProfile] = useState<AccountProfile | null>(null)
+    const [likes, setLikes] = useState<LikedTarget[]>([])
     const [error, setError] = useState<string | null>(null)
     const [success, setSuccess] = useState<string | null>(null)
     const [newApiKey, setNewApiKey] = useState<string | null>(null)
@@ -113,6 +119,9 @@ const AccountPage: NextPage = () => {
     useEffect(() => {
         if (token) {
             fetchProfile(token)
+            // The user's "toolbox" of liked plugins/guides. Best-effort: a likes
+            // fetch failure degrades to an empty list and never blocks the page.
+            getMyLikes(token).then(setLikes)
         }
     }, [token, fetchProfile])
 
@@ -190,6 +199,7 @@ const AccountPage: NextPage = () => {
         }
         setToken(null)
         setProfile(null)
+        setLikes([])
         localStorage.removeItem('dpc-token')
         setSuccess('Logged out.')
     }
@@ -284,6 +294,8 @@ const AccountPage: NextPage = () => {
             setError('Failed to copy — please select and copy the key manually.')
         }
     }
+
+    const likedItems = resolveLikedItems(likes, pluginData.plugins)
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
@@ -408,6 +420,40 @@ const AccountPage: NextPage = () => {
                                 </CardContent>
                             </Card>
                         )}
+
+                        <Card sx={{mb: 3}}>
+                            <CardContent>
+                                <Typography variant="h6" gutterBottom>My likes</Typography>
+                                <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+                                    The plugins and guides you&apos;ve liked — your personal toolbox.
+                                </Typography>
+                                {likedItems.length > 0 ? (
+                                    <List disablePadding>
+                                        {likedItems.map((item) => (
+                                            <ListItem key={item.key} disablePadding>
+                                                <ListItemButton component="a" href={item.href}>
+                                                    <ListItemText primary={item.title}/>
+                                                    <Chip
+                                                        label={item.targetType}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        sx={{textTransform: 'capitalize'}}
+                                                    />
+                                                </ListItemButton>
+                                            </ListItem>
+                                        ))}
+                                    </List>
+                                ) : (
+                                    <Typography variant="body2" color="text.secondary">
+                                        You haven&apos;t liked any plugins or guides yet. Browse the{' '}
+                                        <Box component="a" href="/#plugins" sx={{color: 'primary.main'}}>plugins</Box>
+                                        {' '}or{' '}
+                                        <Box component="a" href="/guides" sx={{color: 'primary.main'}}>guides</Box>
+                                        {' '}and tap the like button.
+                                    </Typography>
+                                )}
+                            </CardContent>
+                        </Card>
 
                         <Card sx={{mb: 3}}>
                             <CardContent>

--- a/utils/likedItems.ts
+++ b/utils/likedItems.ts
@@ -1,0 +1,62 @@
+import type {LikedTarget} from '../services/likeService'
+
+/** The minimal plugin-catalogue shape needed to label a liked item. */
+export interface CataloguePlugin {
+    id: string
+    title: string
+}
+
+/** A liked target resolved into something the UI can render and link to. */
+export interface ResolvedLikedItem {
+    /** Stable React key, unique across the plugin/guide types. */
+    key: string
+    targetType: LikedTarget['targetType']
+    targetId: string
+    /** Human-readable label (plugin/guide title, or the raw id if unknown). */
+    title: string
+    /** Internal href to view the item. */
+    href: string
+}
+
+/**
+ * Resolve a user's raw liked targets into displayable items by joining them
+ * against the plugin catalogue. Both plugin and guide likes key off the plugin
+ * id — a guide's id is its plugin's id (see `pages/guides/[id].tsx`). A like
+ * whose id is no longer in the catalogue still renders, using the raw id as a
+ * fallback label, so a stale like is never silently dropped.
+ *
+ * Plugins live on the home catalogue (`/#plugins`, there is no per-plugin
+ * route); guides have their own page at `/guides/{id}`. The result is sorted by
+ * title, with a stable tiebreaker on target type, so the rendered list is
+ * deterministic.
+ */
+export const resolveLikedItems = (
+    likes: LikedTarget[],
+    plugins: CataloguePlugin[]
+): ResolvedLikedItem[] => {
+    const byId = new Map(plugins.map((p) => [p.id, p]))
+    const resolved = likes.map((like): ResolvedLikedItem => {
+        const name = byId.get(like.targetId)?.title ?? like.targetId
+        if (like.targetType === 'guide') {
+            return {
+                key: `guide:${like.targetId}`,
+                targetType: 'guide',
+                targetId: like.targetId,
+                title: `${name} Guide`,
+                href: `/guides/${like.targetId}`,
+            }
+        }
+        return {
+            key: `plugin:${like.targetId}`,
+            targetType: 'plugin',
+            targetId: like.targetId,
+            title: name,
+            href: '/#plugins',
+        }
+    })
+    return resolved.sort((a, b) => {
+        const byTitle = a.title.localeCompare(b.title)
+        if (byTitle !== 0) return byTitle
+        return a.targetType.localeCompare(b.targetType)
+    })
+}


### PR DESCRIPTION
## Summary

Phase 3 of the community-profiles epic (#167). The Account page now surfaces the signed-in user's liked plugins and guides as a personal **"My likes"** toolbox — the smallest, most-grounded Phase 3 item, and the shared rendering that the public-profile work (#181) will reuse.

- **`utils/likedItems.ts`** (new, pure) — joins the user's raw liked targets (`GET /api/v1/likes/me`, already implemented) against the plugin catalogue. Both plugin and guide likes key off the plugin id (a guide's id is its plugin's id), so each resolves a title from `pages/data/plugins.json`. An id no longer in the catalogue still renders, using the raw id as a fallback label, so a stale like is never silently dropped. Output is sorted by title for a deterministic list.
- **`pages/account.tsx`** — renders a "My likes" MUI `Card` between the profile and API-keys cards: each item is a `ListItemButton` linking to `/#plugins` (plugins have no per-plugin route) or `/guides/{id}` (guides), with a small type `Chip`. Includes an empty state pointing at the catalogue/guides. Likes are fetched best-effort on sign-in and cleared on logout.
- **`__tests__/likedItems.test.ts`** (new) — covers plugin labelling/link, guide labelling/route, the unknown-id fallback, sort order, and the empty case.
- **`CHANGELOG.md`** — `[Unreleased] > Added` entry.

Frontend-only: no backend change, and no new environment variables (reuses `likeService`, which already reads `NEXT_PUBLIC_API_URL`).

## Test plan

- [x] `npm test` — 44 pass (5 new in `likedItems.test.ts`)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds (`/account` builds)

## Closes

Closes #180

## Triage notes — issues deferred this cycle (auditability)

- **#181 (public profile pages)** — deferred deliberately: it depends on this PR's shared liked-item rendering, and adds a *backend* public `GET /api/v1/profile/{username}` endpoint plus `SecurityConfig` changes (sensitive — exposes user fields publicly). Kept out so this stays a clean frontend-only PR; #181 becomes the natural next cycle now that the rendering exists.
- **#162 (plugin version/MC-compatibility on cards)** — separate subsystem (plugin card schema + `plugins.json`); not complementary to profile work.
- **#167 (epic)** — tracking epic, not directly implementable.
- **#142 / #24 (Discord announcements)** — blocked on a future, rebased revival of the just-closed draft #141; the feature was retired on develop (table created in V8, dropped in V11).
- **#87 (edit plugin-cards JSON from the website)** — larger feature needing design (auth-gated write path); out of scope for a single cycle.
- **#57 (nginx/TLS proxy in compose.yml)** — deployment/infra change, separate subsystem.

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._