### PR TITLE
feat(profile): public profile pages at /u/{username} (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).
 - The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.
 - Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.
 - A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -59,6 +59,7 @@ No special software is required to use the website. Simply visit [https://danspl
 2. Register a new account, or log in with an existing username and password.
 3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
 4. The **My likes** section lists the plugins and guides you've liked, linking to each one — your personal toolbox.
+5. Click **View your public profile** to see your profile as other people see it (display name, avatar, bio, join date, and likes). Anyone can view a user's public profile at `/u/<username>`.
 
 ### Getting Support
 

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -97,6 +97,7 @@ keeps a local profile mirror that owns each user's API keys.
 | `POST` | `/api/v1/auth/login` | Public | Login (proxied to UserAuth) and return a token |
 | `POST` | `/api/v1/auth/logout` | Bearer | Revoke the current token |
 | `GET` | `/api/v1/profile/me` | Bearer | Get the current user's profile and API keys |
+| `GET` | `/api/v1/profile/{username}` | Public | Get a user's public profile (display name, avatar, bio, join date, liked plugins/guides; no id or API keys) |
 | `PATCH` | `/api/v1/profile/me` | Bearer | Update display name / avatar / bio |
 | `POST` | `/api/v1/profile/me/api-keys` | Bearer | Create a new API key |
 | `DELETE` | `/api/v1/profile/me/api-keys/{id}` | Bearer | Delete an API key |

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -74,6 +74,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/factions/**").permitAll()
                         // Public like counts (must precede the authenticated /likes rule below)
                         .requestMatchers(HttpMethod.GET, "/api/v1/likes/counts").permitAll()
+                        // Public single-user profile (GET /api/v1/profile/{username}). The /me rule
+                        // is listed first so the authenticated self-profile (which exposes API keys)
+                        // is never served by the public path; the single-segment glob then permits
+                        // any other username, while the /** rule below still guards PATCH /me and
+                        // the /me/api-keys routes.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/profile/me").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/profile/*").permitAll()
                         // Swagger/OpenAPI
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // Profile, likes, and logout require a valid UserAuth token

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
@@ -3,9 +3,11 @@ package com.dansplugins.api.controller;
 import com.dansplugins.api.dto.CreateApiKeyRequest;
 import com.dansplugins.api.dto.CreateApiKeyResponse;
 import com.dansplugins.api.dto.ProfileResponse;
+import com.dansplugins.api.dto.PublicProfileResponse;
 import com.dansplugins.api.dto.UpdateProfileRequest;
 import com.dansplugins.api.entity.User;
 import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.service.LikeService;
 import com.dansplugins.api.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -40,12 +42,24 @@ import java.util.UUID;
 public class ProfileController {
 
     private final UserService userService;
+    private final LikeService likeService;
 
     @GetMapping("/me")
     @Operation(summary = "Get the current user's profile", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<ProfileResponse> getProfile(Principal principal) {
         User user = currentUser(principal);
         return ResponseEntity.ok(ProfileResponse.from(user, userService.getApiKeys(user)));
+    }
+
+    @GetMapping("/{username}")
+    @Operation(summary = "Get a user's public profile (no authentication required)")
+    public ResponseEntity<PublicProfileResponse> getPublicProfile(@PathVariable String username) {
+        // Public, read-only: resolve an existing mirror but never create one (unlike
+        // /me), and return only the public projection — no internal id, no API keys.
+        // The literal /me mapping above takes precedence, so it is never reachable here.
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        return ResponseEntity.ok(PublicProfileResponse.from(user, likeService.likedByUser(user)));
     }
 
     @PatchMapping("/me")

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
@@ -1,0 +1,53 @@
+package com.dansplugins.api.dto;
+
+import com.dansplugins.api.entity.Like;
+import com.dansplugins.api.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A user's <em>public</em> community profile, safe to expose without
+ * authentication. Deliberately omits the internal user UUID and the user's API
+ * keys (both present on {@link ProfileResponse}); it carries only the fields any
+ * visitor may see plus the plugins/guides the user has liked.
+ */
+@Schema(description = "A user's public community profile (no internal id or API keys)")
+public record PublicProfileResponse(
+        @Schema(description = "UserAuth username")
+        String username,
+
+        @Schema(description = "Display name (optional)")
+        String displayName,
+
+        @Schema(description = "Avatar URL (optional)")
+        String avatarUrl,
+
+        @Schema(description = "Bio (optional)")
+        String bio,
+
+        @Schema(description = "Profile creation timestamp")
+        Instant createdAt,
+
+        @Schema(description = "Plugins and guides this user has liked")
+        List<LikedTarget> likes
+) {
+
+    @Schema(description = "A plugin or guide the user has liked")
+    public record LikedTarget(String targetType, String targetId) {
+    }
+
+    public static PublicProfileResponse from(User user, List<Like> likes) {
+        return new PublicProfileResponse(
+                user.getUserauthUsername(),
+                user.getDisplayName(),
+                user.getAvatarUrl(),
+                user.getBio(),
+                user.getCreatedAt(),
+                likes.stream()
+                        .map(like -> new LikedTarget(like.getTargetType(), like.getTargetId()))
+                        .toList()
+        );
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.dansplugins.api.controller;
 
 import com.dansplugins.api.repository.ApiKeyRepository;
+import com.dansplugins.api.repository.LikeRepository;
 import com.dansplugins.api.repository.UserRepository;
 import com.dansplugins.api.service.UserAuthClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,12 +48,17 @@ class ProfileAuthIntegrationTest {
     @Autowired
     private ApiKeyRepository apiKeyRepository;
 
+    @Autowired
+    private LikeRepository likeRepository;
+
     @MockBean
     private UserAuthClient userAuthClient;
 
     @BeforeEach
     void setUp() {
+        // Delete children (api keys, likes) before users — both FK to users.
         apiKeyRepository.deleteAll();
+        likeRepository.deleteAll();
         userRepository.deleteAll();
         when(userAuthClient.validate("good-token")).thenReturn(Optional.of("alice"));
     }
@@ -133,5 +139,46 @@ class ProfileAuthIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.registered").value(true))
                 .andExpect(jsonPath("$.tokenIssued").value(false));
+    }
+
+    @Test
+    void publicProfile_isReadableWithoutToken_andOmitsApiKeys() throws Exception {
+        // Create alice's mirror and set public fields via the authenticated route.
+        mockMvc.perform(patch("/api/v1/profile/me")
+                        .header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"displayName\":\"Alice the Brave\",\"bio\":\"hi\"}"))
+                .andExpect(status().isOk());
+
+        // Anyone — no token — can read the public projection, but it must not leak API keys.
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.displayName").value("Alice the Brave"))
+                .andExpect(jsonPath("$.bio").value("hi"))
+                .andExpect(jsonPath("$.likes").isArray())
+                .andExpect(jsonPath("$.apiKeys").doesNotExist())
+                .andExpect(jsonPath("$.id").doesNotExist());
+    }
+
+    @Test
+    void publicProfile_unknownUser_returns404() throws Exception {
+        mockMvc.perform(get("/api/v1/profile/nobody"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void publicProfile_includesTheUsersLikedTargets() throws Exception {
+        // Liking creates alice's mirror and a like in one authenticated call.
+        mockMvc.perform(post("/api/v1/likes")
+                        .header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"targetType\":\"plugin\",\"targetId\":\"mf\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.likes[0].targetType").value("plugin"))
+                .andExpect(jsonPath("$.likes[0].targetId").value("mf"));
     }
 }

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -386,6 +386,10 @@ const AccountPage: NextPage = () => {
                                     </Box>
                                     <Typography variant="body2" color="text.secondary" gutterBottom>
                                         Member since {new Date(profile.createdAt).toLocaleDateString()}
+                                        {' · '}
+                                        <Box component="a" href={`/u/${profile.username}`} sx={{color: 'primary.main'}}>
+                                            View your public profile
+                                        </Box>
                                     </Typography>
                                     <Box component="form" onSubmit={handleUpdateProfile}
                                          sx={{display: 'flex', flexDirection: 'column', gap: 2, mt: 2}}>

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -1,0 +1,130 @@
+import {
+    Alert,
+    Avatar,
+    Box,
+    Card,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Container,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemText,
+    Typography,
+} from '@mui/material'
+import type {NextPage} from 'next'
+import {useRouter} from 'next/router'
+import React, {useEffect, useState} from 'react'
+import TopBar from '../../components/TopBar'
+import Seo from '../../components/Seo'
+import BottomBar from '../../components/BottomBar'
+import {pageStyle, sectionHeaderStyle} from '../../styles/styles'
+import {getPublicProfile, type PublicProfile} from '../../services/profileService'
+import {resolveLikedItems} from '../../utils/likedItems'
+import pluginData from '../data/plugins.json'
+
+const version = require('../../package.json').version
+
+const PublicProfilePage: NextPage = () => {
+    const router = useRouter()
+    const username = typeof router.query.username === 'string' ? router.query.username : null
+    const [profile, setProfile] = useState<PublicProfile | null>(null)
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        if (!username) return
+        let active = true
+        setLoading(true)
+        getPublicProfile(username).then((data) => {
+            if (active) {
+                setProfile(data)
+                setLoading(false)
+            }
+        })
+        return () => {
+            active = false
+        }
+    }, [username])
+
+    const likedItems = profile ? resolveLikedItems(profile.likes, pluginData.plugins) : []
+    const heading = profile?.displayName || profile?.username || username || 'Profile'
+
+    return (
+        <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title={`${heading} — Profile`} description={`The public DPC community profile for ${heading}.`}/>
+            <TopBar/>
+            <Container maxWidth="md" sx={{py: 4}}>
+                {loading ? (
+                    <Box sx={{display: 'flex', justifyContent: 'center', py: 6}}>
+                        <CircularProgress/>
+                    </Box>
+                ) : !profile ? (
+                    <Alert severity="info">
+                        No profile found for <strong>{username}</strong>.
+                    </Alert>
+                ) : (
+                    <>
+                        <Card sx={{mb: 3}}>
+                            <CardContent>
+                                <Box sx={{display: 'flex', alignItems: 'center', gap: 2, mb: profile.bio ? 2 : 0}}>
+                                    <Avatar src={profile.avatarUrl ?? undefined} sx={{width: 64, height: 64}}>
+                                        {heading.charAt(0).toUpperCase()}
+                                    </Avatar>
+                                    <Box>
+                                        <Typography variant="h4" sx={(theme) => sectionHeaderStyle(theme)}>
+                                            {heading}
+                                        </Typography>
+                                        {profile.displayName && (
+                                            <Typography variant="body2" color="text.secondary">
+                                                @{profile.username}
+                                            </Typography>
+                                        )}
+                                        <Typography variant="body2" color="text.secondary">
+                                            Member since {new Date(profile.createdAt).toLocaleDateString()}
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                                {profile.bio && (
+                                    <Typography variant="body1" sx={{mt: 1}}>
+                                        {profile.bio}
+                                    </Typography>
+                                )}
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardContent>
+                                <Typography variant="h6" gutterBottom>Likes</Typography>
+                                {likedItems.length > 0 ? (
+                                    <List disablePadding>
+                                        {likedItems.map((item) => (
+                                            <ListItem key={item.key} disablePadding>
+                                                <ListItemButton component="a" href={item.href}>
+                                                    <ListItemText primary={item.title}/>
+                                                    <Chip
+                                                        label={item.targetType}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        sx={{textTransform: 'capitalize'}}
+                                                    />
+                                                </ListItemButton>
+                                            </ListItem>
+                                        ))}
+                                    </List>
+                                ) : (
+                                    <Typography variant="body2" color="text.secondary">
+                                        {heading} hasn&apos;t liked any plugins or guides yet.
+                                    </Typography>
+                                )}
+                            </CardContent>
+                        </Card>
+                    </>
+                )}
+            </Container>
+            <BottomBar version={version}/>
+        </Box>
+    )
+}
+
+export default PublicProfilePage

--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -1,0 +1,29 @@
+// Client-side calls to the dpc-api public profile endpoint. Same public API the
+// account/leaderboard pages use.
+import type {LikedTarget} from './likeService'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345'
+
+/** A user's public profile — no internal id and no API keys (see dpc-api PublicProfileResponse). */
+export interface PublicProfile {
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+    bio: string | null
+    createdAt: string
+    likes: LikedTarget[]
+}
+
+/**
+ * Fetch a user's public profile by username. Resolves to `null` when the user
+ * does not exist (404) or the request fails, so callers can render a
+ * not-found state without throwing.
+ */
+export const getPublicProfile = async (username: string): Promise<PublicProfile | null> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/profile/${encodeURIComponent(username)}`)
+        return res.ok ? await res.json() : null
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the community-profiles epic (#167). Adds **public profile pages** — the foundation the rest of the social layer (following, activity feed, comment author links) builds on. Reuses the `resolveLikedItems` helper added in #180 for the liked-items rendering.

### Backend (`dpc-api`)
- **New public `GET /api/v1/profile/{username}`** → `PublicProfileResponse` (username, display name, avatar, bio, join date, and the user's liked plugins/guides). **Deliberately omits the internal user UUID and API keys** — those stay on the authenticated `GET /api/v1/profile/me`. Resolves an *existing* mirror only (`findByUsername`), so a public read never creates a row (unlike `/me`).
- **`SecurityConfig`**: permits `GET /api/v1/profile/{username}` while keeping `/me` protected. The literal `GET /me` rule is ordered **before** the single-segment public glob (`/api/v1/profile/*`), and the existing `/api/v1/profile/**` rule still guards `PATCH /me` and the `/me/api-keys` routes — so the API-key-bearing self-profile is never reachable through the public path.

### Frontend (Next.js)
- `services/profileService.getPublicProfile()` — fetches the endpoint, degrades to `null` on 404/error.
- `pages/u/[username].tsx` — renders the profile header (avatar, name, `@username`, join date, bio) and a **Likes** section (reusing `resolveLikedItems`), with loading / not-found / empty states.
- The Account page links to **View your public profile**.

## Test plan

- [x] Backend `./mvnw test` — **116 pass, 0 fail** (1 Testcontainers test skipped locally — no Docker in sandbox — runs in CI). New `ProfileAuthIntegrationTest` cases: public read without a token (200), **404** for unknown user, **API keys + internal id omitted**, liked targets included. Pact provider test still passes (factions contract unaffected).
- [x] Frontend `npm test` (44 pass), `npm run lint` (clean), `npm run build` (succeeds; `/u/[username]` route present).

## Security note (why this needs human review)

This changes `SecurityConfig` — a do-not-auto-merge path. The key invariant: **`GET /api/v1/profile/me` (which exposes API keys) must never be served publicly.** That holds because (a) `/me` is matched by an `authenticated()` rule placed before the public glob, and (b) the controller's literal `/me` mapping takes routing precedence over `/{username}`, so even the response shape on `/me` is the full `ProfileResponse`, never the public projection. Covered by the existing `profile_withoutToken_returns401` test plus the new public-profile tests. Please sanity-check the matcher ordering.

## Carryover

- The page fetches **client-side** (mirroring `account.tsx`) rather than SSR. A follow-up could move it to `getServerSideProps` for SEO / link-preview metadata once the server-reachable API base is settled.

Closes #181

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._