### PR TITLE
feat(profile): derived badges on public profiles — Server Owner (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.
 - **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).
 - The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.
 - Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -59,7 +59,7 @@ No special software is required to use the website. Simply visit [https://danspl
 2. Register a new account, or log in with an existing username and password.
 3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
 4. The **My likes** section lists the plugins and guides you've liked, linking to each one — your personal toolbox.
-5. Click **View your public profile** to see your profile as other people see it (display name, avatar, bio, join date, and likes). Anyone can view a user's public profile at `/u/<username>`.
+5. Click **View your public profile** to see your profile as other people see it (display name, avatar, bio, join date, badges, and likes). Anyone can view a user's public profile at `/u/<username>`. Badges are earned automatically — for example, **Server Owner** appears once you have created an API key for a server.
 
 ### Getting Support
 

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -97,7 +97,7 @@ keeps a local profile mirror that owns each user's API keys.
 | `POST` | `/api/v1/auth/login` | Public | Login (proxied to UserAuth) and return a token |
 | `POST` | `/api/v1/auth/logout` | Bearer | Revoke the current token |
 | `GET` | `/api/v1/profile/me` | Bearer | Get the current user's profile and API keys |
-| `GET` | `/api/v1/profile/{username}` | Public | Get a user's public profile (display name, avatar, bio, join date, liked plugins/guides; no id or API keys) |
+| `GET` | `/api/v1/profile/{username}` | Public | Get a user's public profile (display name, avatar, bio, join date, badges, liked plugins/guides; no id or API keys) |
 | `PATCH` | `/api/v1/profile/me` | Bearer | Update display name / avatar / bio |
 | `POST` | `/api/v1/profile/me/api-keys` | Bearer | Create a new API key |
 | `DELETE` | `/api/v1/profile/me/api-keys/{id}` | Bearer | Delete an API key |

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
@@ -7,6 +7,7 @@ import com.dansplugins.api.dto.PublicProfileResponse;
 import com.dansplugins.api.dto.UpdateProfileRequest;
 import com.dansplugins.api.entity.User;
 import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.service.BadgeService;
 import com.dansplugins.api.service.LikeService;
 import com.dansplugins.api.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,6 +44,7 @@ public class ProfileController {
 
     private final UserService userService;
     private final LikeService likeService;
+    private final BadgeService badgeService;
 
     @GetMapping("/me")
     @Operation(summary = "Get the current user's profile", security = @SecurityRequirement(name = "bearerAuth"))
@@ -59,7 +61,8 @@ public class ProfileController {
         // The literal /me mapping above takes precedence, so it is never reachable here.
         User user = userService.findByUsername(username)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
-        return ResponseEntity.ok(PublicProfileResponse.from(user, likeService.likedByUser(user)));
+        return ResponseEntity.ok(PublicProfileResponse.from(
+                user, badgeService.badgesFor(user), likeService.likedByUser(user)));
     }
 
     @PatchMapping("/me")

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/Badge.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/Badge.java
@@ -1,0 +1,15 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * A badge a user can earn, shown on their public profile. Badges are
+ * <em>derived</em> from existing state (see {@code BadgeService}) rather than
+ * stored, so they stay correct automatically.
+ */
+@Schema(description = "A badge shown on a user's public profile")
+public enum Badge {
+
+    /** The user owns at least one API key — i.e. runs a server that syncs with DPC. */
+    SERVER_OWNER
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
@@ -30,6 +30,9 @@ public record PublicProfileResponse(
         @Schema(description = "Profile creation timestamp")
         Instant createdAt,
 
+        @Schema(description = "Badges this user has earned")
+        List<Badge> badges,
+
         @Schema(description = "Plugins and guides this user has liked")
         List<LikedTarget> likes
 ) {
@@ -38,13 +41,14 @@ public record PublicProfileResponse(
     public record LikedTarget(String targetType, String targetId) {
     }
 
-    public static PublicProfileResponse from(User user, List<Like> likes) {
+    public static PublicProfileResponse from(User user, List<Badge> badges, List<Like> likes) {
         return new PublicProfileResponse(
                 user.getUserauthUsername(),
                 user.getDisplayName(),
                 user.getAvatarUrl(),
                 user.getBio(),
                 user.getCreatedAt(),
+                badges,
                 likes.stream()
                         .map(like -> new LikedTarget(like.getTargetType(), like.getTargetId()))
                         .toList()

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/ApiKeyRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/ApiKeyRepository.java
@@ -11,5 +11,7 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
 
     boolean existsByKeyHash(String keyHash);
 
+    boolean existsByOwner(User owner);
+
     List<ApiKey> findByOwner(User owner);
 }

--- a/dpc-api/src/main/java/com/dansplugins/api/service/BadgeService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/BadgeService.java
@@ -1,0 +1,34 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.dto.Badge;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.ApiKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Computes the badges a user has earned. Badges are <em>derived</em> from
+ * existing state rather than stored, so they cannot drift out of sync. Today the
+ * only badge is {@link Badge#SERVER_OWNER} (the user owns at least one API key,
+ * i.e. runs a server that syncs with DPC); additional derived or assigned badges
+ * plug in here.
+ */
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private final ApiKeyRepository apiKeyRepository;
+
+    @Transactional(readOnly = true)
+    public List<Badge> badgesFor(User user) {
+        List<Badge> badges = new ArrayList<>();
+        if (apiKeyRepository.existsByOwner(user)) {
+            badges.add(Badge.SERVER_OWNER);
+        }
+        return badges;
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -157,8 +157,31 @@ class ProfileAuthIntegrationTest {
                 .andExpect(jsonPath("$.displayName").value("Alice the Brave"))
                 .andExpect(jsonPath("$.bio").value("hi"))
                 .andExpect(jsonPath("$.likes").isArray())
+                .andExpect(jsonPath("$.badges").isArray())
+                .andExpect(jsonPath("$.badges").isEmpty())
                 .andExpect(jsonPath("$.apiKeys").doesNotExist())
                 .andExpect(jsonPath("$.id").doesNotExist());
+    }
+
+    @Test
+    void publicProfile_showsServerOwnerBadge_onceTheUserHasAnApiKey() throws Exception {
+        // No key yet → no badge.
+        mockMvc.perform(get("/api/v1/profile/me").header("Authorization", BEARER))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.badges").isEmpty());
+
+        // Creating an API key makes alice a server owner.
+        mockMvc.perform(post("/api/v1/profile/me/api-keys")
+                        .header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"serverName\":\"survival-1\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.badges[0]").value("SERVER_OWNER"));
     }
 
     @Test

--- a/dpc-api/src/test/java/com/dansplugins/api/service/BadgeServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/BadgeServiceTest.java
@@ -1,0 +1,39 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.dto.Badge;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BadgeServiceTest {
+
+    @Mock
+    private ApiKeyRepository apiKeyRepository;
+
+    @InjectMocks
+    private BadgeService badgeService;
+
+    @Test
+    void awardsServerOwner_whenTheUserOwnsAnApiKey() {
+        User user = new User("alice");
+        when(apiKeyRepository.existsByOwner(user)).thenReturn(true);
+
+        assertThat(badgeService.badgesFor(user)).containsExactly(Badge.SERVER_OWNER);
+    }
+
+    @Test
+    void awardsNothing_whenTheUserOwnsNoApiKey() {
+        User user = new User("bob");
+        when(apiKeyRepository.existsByOwner(user)).thenReturn(false);
+
+        assertThat(badgeService.badgesFor(user)).isEmpty();
+    }
+}

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -26,6 +26,12 @@ import pluginData from '../data/plugins.json'
 
 const version = require('../../package.json').version
 
+// Human-readable labels for the badge codes returned by the API. Unknown codes
+// fall back to the raw value so a newly-added badge still renders.
+const BADGE_LABELS: Record<string, string> = {
+    SERVER_OWNER: 'Server Owner',
+}
+
 const PublicProfilePage: NextPage = () => {
     const router = useRouter()
     const username = typeof router.query.username === 'string' ? router.query.username : null
@@ -83,6 +89,18 @@ const PublicProfilePage: NextPage = () => {
                                         <Typography variant="body2" color="text.secondary">
                                             Member since {new Date(profile.createdAt).toLocaleDateString()}
                                         </Typography>
+                                        {profile.badges.length > 0 && (
+                                            <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1}}>
+                                                {profile.badges.map((badge) => (
+                                                    <Chip
+                                                        key={badge}
+                                                        label={BADGE_LABELS[badge] ?? badge}
+                                                        size="small"
+                                                        color="primary"
+                                                    />
+                                                ))}
+                                            </Box>
+                                        )}
                                     </Box>
                                 </Box>
                                 {profile.bio && (

--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -11,6 +11,7 @@ export interface PublicProfile {
     avatarUrl: string | null
     bio: string | null
     createdAt: string
+    badges: string[]
     likes: LikedTarget[]
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of the community-profiles epic (#167). Establishes the **badge mechanism** and ships the first fully-derivable badge, building on the public profiles from #181.

### Backend (`dpc-api`)
- **`Badge` enum + `BadgeService.badgesFor(user)`** — badges are **derived** from existing state rather than stored, so they can't drift out of sync. First badge **`SERVER_OWNER`** = the user owns at least one API key (`ApiKeyRepository.existsByOwner`), i.e. runs a server that syncs with DPC.
- **`PublicProfileResponse`** gains a `badges` array; the public `GET /api/v1/profile/{username}` returns it. **No `SecurityConfig` change and no schema/migration** — it reads existing data on an existing endpoint.

### Frontend (Next.js)
- `pages/u/[username].tsx` renders badges as MUI `Chip`s, with a label map (`SERVER_OWNER` → "Server Owner"); unknown codes fall back to the raw value so a future badge still renders.

## Test plan

- [x] Backend `./mvnw test` — **119 pass, 0 fail** (1 Testcontainers test skipped locally; runs in CI). New `BadgeServiceTest` (owner / no-owner) + integration assertion that the badge is absent before an API key exists and present after.
- [x] Frontend `npm test` (44 pass), `npm run lint` (clean), `npm run build` (succeeds; `/u/[username]`).

## Scope note

This is a **partial of #194**, not a close: it ships the mechanism + the one badge that is 100% objective and needs no admin system or configured cutoff (avoiding inventing data). Remaining on #194: admin-**assigned** badges (contributor, plugin author) and any further derived badges (e.g. early adopter, which needs a configurable join-date cutoff). Referenced as **Part of #194**, which stays open.

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._