### PR TITLE
feat(account): show earned badges on the Account page too (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Earned **badges now also appear on the signed-in user's own Account page** (not just the public profile), and the badge-label map is shared between the two pages (`utils/badges.ts`). The authenticated `GET /api/v1/profile/me` response gains a `badges` array (#194, epic #167 phase 3).
 - **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.
 - **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).
 - The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
@@ -50,7 +50,8 @@ public class ProfileController {
     @Operation(summary = "Get the current user's profile", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<ProfileResponse> getProfile(Principal principal) {
         User user = currentUser(principal);
-        return ResponseEntity.ok(ProfileResponse.from(user, userService.getApiKeys(user)));
+        return ResponseEntity.ok(ProfileResponse.from(
+                user, badgeService.badgesFor(user), userService.getApiKeys(user)));
     }
 
     @GetMapping("/{username}")
@@ -71,7 +72,8 @@ public class ProfileController {
                                                          @Valid @RequestBody UpdateProfileRequest request) {
         User user = currentUser(principal);
         userService.updateProfile(user, request.displayName(), request.avatarUrl(), request.bio());
-        return ResponseEntity.ok(ProfileResponse.from(user, userService.getApiKeys(user)));
+        return ResponseEntity.ok(ProfileResponse.from(
+                user, badgeService.badgesFor(user), userService.getApiKeys(user)));
     }
 
     @PostMapping("/me/api-keys")

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/ProfileResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/ProfileResponse.java
@@ -28,6 +28,9 @@ public record ProfileResponse(
         @Schema(description = "Profile creation timestamp")
         Instant createdAt,
 
+        @Schema(description = "Badges this user has earned")
+        List<Badge> badges,
+
         @Schema(description = "API keys owned by this user")
         List<ApiKeyInfo> apiKeys
 ) {
@@ -41,7 +44,7 @@ public record ProfileResponse(
     ) {
     }
 
-    public static ProfileResponse from(User user, List<ApiKey> keys) {
+    public static ProfileResponse from(User user, List<Badge> badges, List<ApiKey> keys) {
         return new ProfileResponse(
                 user.getId(),
                 user.getUserauthUsername(),
@@ -49,6 +52,7 @@ public record ProfileResponse(
                 user.getAvatarUrl(),
                 user.getBio(),
                 user.getCreatedAt(),
+                badges,
                 keys.stream()
                         .map(k -> new ApiKeyInfo(k.getId(), k.getKeyPrefix(), k.getServerName(), k.getCreatedAt()))
                         .toList()

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -74,7 +74,9 @@ class ProfileAuthIntegrationTest {
         mockMvc.perform(get("/api/v1/profile/me").header("Authorization", BEARER))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("alice"))
-                .andExpect(jsonPath("$.apiKeys").isArray());
+                .andExpect(jsonPath("$.apiKeys").isArray())
+                .andExpect(jsonPath("$.badges").isArray())
+                .andExpect(jsonPath("$.badges").isEmpty());
     }
 
     @Test
@@ -89,7 +91,8 @@ class ProfileAuthIntegrationTest {
 
         mockMvc.perform(get("/api/v1/profile/me").header("Authorization", BEARER))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.apiKeys.length()").value(1));
+                .andExpect(jsonPath("$.apiKeys.length()").value(1))
+                .andExpect(jsonPath("$.badges[0]").value("SERVER_OWNER"));
     }
 
     @Test

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -27,6 +27,7 @@ import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 import {getMyLikes, type LikedTarget} from '../services/likeService'
 import {resolveLikedItems} from '../utils/likedItems'
+import {badgeLabel} from '../utils/badges'
 import pluginData from './data/plugins.json'
 
 const version = require('../package.json').version
@@ -47,6 +48,7 @@ interface AccountProfile {
     avatarUrl: string | null
     bio: string | null
     createdAt: string
+    badges: string[]
     apiKeys: ApiKeyInfo[]
 }
 
@@ -391,6 +393,13 @@ const AccountPage: NextPage = () => {
                                             View your public profile
                                         </Box>
                                     </Typography>
+                                    {profile.badges.length > 0 && (
+                                        <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1}}>
+                                            {profile.badges.map((badge) => (
+                                                <Chip key={badge} label={badgeLabel(badge)} size="small" color="primary"/>
+                                            ))}
+                                        </Box>
+                                    )}
                                     <Box component="form" onSubmit={handleUpdateProfile}
                                          sx={{display: 'flex', flexDirection: 'column', gap: 2, mt: 2}}>
                                         <Typography variant="subtitle2" color="text.secondary">Profile</Typography>

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -22,15 +22,10 @@ import BottomBar from '../../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../../styles/styles'
 import {getPublicProfile, type PublicProfile} from '../../services/profileService'
 import {resolveLikedItems} from '../../utils/likedItems'
+import {badgeLabel} from '../../utils/badges'
 import pluginData from '../data/plugins.json'
 
 const version = require('../../package.json').version
-
-// Human-readable labels for the badge codes returned by the API. Unknown codes
-// fall back to the raw value so a newly-added badge still renders.
-const BADGE_LABELS: Record<string, string> = {
-    SERVER_OWNER: 'Server Owner',
-}
 
 const PublicProfilePage: NextPage = () => {
     const router = useRouter()
@@ -94,7 +89,7 @@ const PublicProfilePage: NextPage = () => {
                                                 {profile.badges.map((badge) => (
                                                     <Chip
                                                         key={badge}
-                                                        label={BADGE_LABELS[badge] ?? badge}
+                                                        label={badgeLabel(badge)}
                                                         size="small"
                                                         color="primary"
                                                     />

--- a/utils/badges.ts
+++ b/utils/badges.ts
@@ -1,0 +1,8 @@
+// Human-readable labels for the badge codes returned by the dpc-api profile
+// endpoints. Unknown codes fall back to the raw value so a newly-added badge
+// still renders before this map is updated.
+export const BADGE_LABELS: Record<string, string> = {
+    SERVER_OWNER: 'Server Owner',
+}
+
+export const badgeLabel = (code: string): string => BADGE_LABELS[code] ?? code


### PR DESCRIPTION
## Summary

Follows the public-profile badges from #197 — the signed-in user now sees their own badges on the **Account page**, not only on their public profile. Also de-duplicates the badge-label map.

- **Backend:** `ProfileResponse` (authenticated `GET /api/v1/profile/me`) gains a `badges` array, computed by the existing `BadgeService`; both `/me` handlers (`getProfile`, `updateProfile`) pass it. No security or schema change.
- **Frontend:** `account.tsx` renders badges as MUI `Chip`s; the label map is extracted to **`utils/badges.ts`** and shared with `pages/u/[username].tsx` (the previously-inline map is removed).

## Test plan

- [x] Backend `./mvnw test` — **119 pass** (1 Testcontainers skip locally; runs in CI). Integration test now asserts `/me` `badges` is empty before an API key and contains `SERVER_OWNER` after.
- [x] Frontend `npm test` (44), `npm run lint` (clean), `npm run build` (succeeds).

## Scope

**Part of #194** (kept open for assigned/other badges). No `Closes`.

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._