### PR TITLE
test: characterize service-layer error handling (likeService, profileService)

### DIFF
--- a/__tests__/likeService.test.ts
+++ b/__tests__/likeService.test.ts
@@ -1,0 +1,83 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getLikeCounts, getMyLikes, likeTarget, unlikeTarget} from '../services/likeService';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+const rejectFetch = () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getLikeCounts', () => {
+    it('returns the counts map on a 200 response', async () => {
+        stubFetch({ok: true, json: async () => ({mf: 3, fiefs: 1})});
+        expect(await getLikeCounts('plugin')).toEqual({mf: 3, fiefs: 1});
+    });
+
+    it('returns an empty map on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500});
+        expect(await getLikeCounts('plugin')).toEqual({});
+    });
+
+    it('returns an empty map when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getLikeCounts('plugin')).toEqual({});
+    });
+});
+
+describe('getMyLikes', () => {
+    it('returns the liked targets on a 200 response', async () => {
+        const likes = [{targetType: 'plugin', targetId: 'mf'}];
+        stubFetch({ok: true, json: async () => likes});
+        expect(await getMyLikes('token')).toEqual(likes);
+    });
+
+    it('sends the bearer token', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => []} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getMyLikes('my-token');
+        expect(fetchMock.mock.calls[0][1]).toMatchObject({headers: {Authorization: 'Bearer my-token'}});
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 401});
+        expect(await getMyLikes('token')).toEqual([]);
+    });
+
+    it('returns an empty array when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getMyLikes('token')).toEqual([]);
+    });
+});
+
+describe('likeTarget / unlikeTarget', () => {
+    it('resolves to the new count from the response', async () => {
+        stubFetch({ok: true, json: async () => ({count: 5})});
+        expect(await likeTarget('token', 'plugin', 'mf')).toBe(5);
+    });
+
+    it('returns null on a non-ok response', async () => {
+        stubFetch({ok: false, status: 400});
+        expect(await likeTarget('token', 'plugin', 'mf')).toBeNull();
+    });
+
+    it('returns null when the response omits a numeric count', async () => {
+        stubFetch({ok: true, json: async () => ({})});
+        expect(await unlikeTarget('token', 'plugin', 'mf')).toBeNull();
+    });
+
+    it('returns null when fetch rejects', async () => {
+        rejectFetch();
+        expect(await unlikeTarget('token', 'plugin', 'mf')).toBeNull();
+    });
+});

--- a/__tests__/profileService.test.ts
+++ b/__tests__/profileService.test.ts
@@ -1,0 +1,50 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getPublicProfile} from '../services/profileService';
+
+// Minimal fetch Response stub for the public-profile endpoint.
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getPublicProfile', () => {
+    it('returns the parsed profile on a 200 response', async () => {
+        const profile = {
+            username: 'alice',
+            displayName: 'Alice',
+            avatarUrl: null,
+            bio: null,
+            createdAt: '2026-01-01T00:00:00Z',
+            badges: ['SERVER_OWNER'],
+            likes: [],
+        };
+        stubFetch({ok: true, json: async () => profile});
+        expect(await getPublicProfile('alice')).toEqual(profile);
+    });
+
+    it('returns null on a 404 (unknown user)', async () => {
+        stubFetch({ok: false, status: 404});
+        expect(await getPublicProfile('nobody')).toBeNull();
+    });
+
+    it('returns null when fetch rejects', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+        expect(await getPublicProfile('alice')).toBeNull();
+    });
+
+    it('URL-encodes the username in the request path', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => ({})} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getPublicProfile('a b/c');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toContain('/api/v1/profile/a%20b%2Fc');
+    });
+});


### PR DESCRIPTION
## Summary

Stage B test expansion (no production code change). Locks in the current behavior of the two fetch-wrapper services whose error-handling branches had no coverage:

- **`likeService`** — `getLikeCounts`/`getMyLikes` degrade to `{}`/`[]` on a non-ok response and on a thrown fetch; `likeTarget`/`unlikeTarget` resolve the numeric `count` or `null`; the bearer token is sent on `getMyLikes`.
- **`profileService`** — `getPublicProfile` returns the parsed body on 200, `null` on 404 and on reject, and URL-encodes the username.

Follows the `vi.stubGlobal('fetch', …)` convention from `__tests__/bstats.test.ts`.

## Test plan

- [x] `npm test` — **59 pass** (15 new across the two files).
- [x] `npm run lint` — clean.

No CHANGELOG entry: test-only, no user-facing change.

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._