### PR TITLE
docs(dpc-api): document the Likes API endpoints in the README

### DIFF
--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -150,6 +150,21 @@ Response:
 Save the returned `apiKey` — it is shown only once and stored as a SHA-256 hash.
 The `keyPrefix` (first 8 characters) can be used to identify the key later.
 
+### Likes
+
+Likes on plugins and guides. A target is keyed by the plugin `id` from the
+website's `plugins.json` (a guide's id is its plugin's id). Liking is
+idempotent; counts are public.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/api/v1/likes` | Bearer | Like a plugin or guide (idempotent); returns the new count |
+| `DELETE` | `/api/v1/likes` | Bearer | Unlike a plugin or guide; returns the new count |
+| `GET` | `/api/v1/likes/counts?type=plugin\|guide` | Public | Aggregate like counts for a target type (`targetId` → count) |
+| `GET` | `/api/v1/likes/me` | Bearer | The current user's liked targets |
+
+The `POST`/`DELETE` body is `{ "targetType": "plugin" | "guide", "targetId": "<id>" }`.
+
 ### Factions
 
 | Method | Path | Auth | Description |


### PR DESCRIPTION
## Summary

Stage A documentation accuracy sweep. The dpc-api README endpoints listed only **Auth/Profile** and **Factions** — the **Likes API** (`LikeController`, shipped in #169) was entirely missing. Adds a **Likes** section documenting `POST`/`DELETE /api/v1/likes`, `GET /api/v1/likes/counts`, and `GET /api/v1/likes/me`, verified against the controller.

The rest of the sweep found **no drift**:
- frontend `NEXT_PUBLIC_*` reads (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_BASE_URL`) ↔ `CONFIG.md` — both documented.
- dpc-api `@Value` props (`dpc.cors.allowed-origins`, `userauth.url`) ↔ the README config table — documented.
- the Profile and Factions endpoint tables match their controllers.

## Test plan

- [x] Docs-only (`dpc-api/README.md`); CI build/lint unaffected.

No CHANGELOG entry: documentation fix, no user-facing behavior change.

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._