### PR TITLE
feat(ui): add MUI-styled 404 and 500 error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Custom, MUI-styled **404 and 500 error pages** (a shared `components/ErrorPage`), so a missing or failed route keeps the site's theme and navigation and offers a link home, instead of Next.js's unstyled default page.
 - The plugin catalogue gains a **"Most Liked"** sort option alongside "By Popularity" (server count) and "Alphabetical", ranking plugins by their like count (#201, epic #167 phase 2). The sort logic was extracted into a unit-tested `utils/sortPlugins.ts`.
 - Earned **badges now also appear on the signed-in user's own Account page** (not just the public profile), and the badge-label map is shared between the two pages (`utils/badges.ts`). The authenticated `GET /api/v1/profile/me` response gains a `badges` array (#194, epic #167 phase 3).
 - **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {Box, Button, Container, Typography} from '@mui/material';
+import HomeIcon from '@mui/icons-material/Home';
+import TopBar from './TopBar';
+import Seo from './Seo';
+import BottomBar from './BottomBar';
+import {pageStyle, sectionHeaderStyle} from '../styles/styles';
+
+const version = require('../package.json').version;
+
+/**
+ * Shared layout for the site's error pages (404 / 500). Renders the standard
+ * page chrome (TopBar/BottomBar) around a centred message and a link home, so a
+ * thrown or missing route still looks like the rest of the MUI-themed site
+ * instead of Next.js's unstyled default.
+ */
+const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({code, title, message}) => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title={`${code} — ${title}`} description={message}/>
+        <TopBar/>
+        <Container maxWidth="sm" sx={{py: 8, textAlign: 'center'}}>
+            <Typography variant="h1" color="primary" sx={{fontWeight: 700}}>
+                {code}
+            </Typography>
+            <Typography variant="h4" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                {title}
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
+                {message}
+            </Typography>
+            <Button variant="contained" startIcon={<HomeIcon/>} href="/">
+                Back to home
+            </Button>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default ErrorPage;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,13 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const NotFoundPage: NextPage = () => (
+    <ErrorPage
+        code="404"
+        title="Page not found"
+        message="The page you're looking for doesn't exist or may have moved."
+    />
+);
+
+export default NotFoundPage;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,13 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const ServerErrorPage: NextPage = () => (
+    <ErrorPage
+        code="500"
+        title="Something went wrong"
+        message="An unexpected error occurred on our end. Please try again in a moment."
+    />
+);
+
+export default ServerErrorPage;


### PR DESCRIPTION
## Summary

The site had no custom error pages, so a missing or failed route fell back to **Next.js's unstyled default**, which clashes with the MUI dark theme and drops the site navigation. Adds:

- **`components/ErrorPage`** — a shared, MUI-styled layout (standard `TopBar`/`BottomBar` chrome, a large status code, a title/message, and a "Back to home" button).
- **`pages/404.tsx`** and **`pages/500.tsx`** — thin wrappers supplying the copy.

Addresses the "missing page-level error boundaries" improvement from the loop's triage checklist.

## Test plan

- [x] `npm run build` — **compiles**; statically generates `/404` and `/500`.
- [x] `npm run lint` (clean), `npm test` (65 pass).

Presentational components only — no logic to unit-test; the build verifies they render. No new env vars; MUI-only.

No tracking issue — improvement found during triage (skill checklist: page-level error boundaries).

_Drafted by Claude on behalf of Daniel Stephenson during an automated dev-loop pass._