### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.13.0] – 2026-06-14
+
 ### Changed
 
 - Authentication is now provided by the shared UserAuth service instead of dpc-api's own accounts (epic #167, phase 1). dpc-api proxies registration/login/logout to UserAuth and validates its tokens; a local profile mirror owns each user's API keys. The Account page now signs in via UserAuth and supports a profile (display name, avatar, bio). API paths moved from `/api/v1/accounts/*` to `/api/v1/auth/*` and `/api/v1/profile/*`. The Docker Compose stack now bundles the UserAuth service (and its database) so `docker compose up` runs end-to-end; `JWT_SECRET` (used by UserAuth to sign tokens) is now required when starting the stack.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Release prep for **0.13.0**. Rolls the CHANGELOG `[Unreleased]` section into `[0.13.0] – 2026-06-14` and bumps `package.json` to `0.13.0`.

This is the community-profiles batch on top of 0.12.0: My Likes (#180), public profiles (#181), derived badges (#194), the Most Liked sort (#201), MUI 404/500 pages, the dpc-api public-profile endpoint, plus service-layer characterization tests and Likes-API docs.

(Note: `0.11.0` was skipped historically; `0.12.0` was just backfilled as a tag/release.)

## Test plan

- [x] `npm run lint` (clean), `npm run build` (succeeds).

_Drafted by Claude on behalf of Daniel Stephenson._