### PR TITLE
Release 0.13.0 — community profiles, badges, Most-Liked sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).
 - The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.
 - Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.
 - A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.
 - Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.
 - A likes API in `dpc-api` (#169, backend): authenticated `POST`/`DELETE /api/v1/likes` to like/unlike a plugin or guide (idempotent), public `GET /api/v1/likes/counts?type=...` for aggregate counts, and `GET /api/v1/likes/me` for the current user's liked set.
 - Plugin guides now render on-site at `/guides/[id]` (fetched from each plugin's `USER_GUIDE.md` and rendered with `markdown-to-jsx`) instead of linking out to raw GitHub markdown; the Guides page links to these in-site pages, and each guide keeps a "View on GitHub" link and falls back to GitHub if the content can't be loaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- The plugin catalogue gains a **"Most Liked"** sort option alongside "By Popularity" (server count) and "Alphabetical", ranking plugins by their like count (#201, epic #167 phase 2). The sort logic was extracted into a unit-tested `utils/sortPlugins.ts`.
 - Earned **badges now also appear on the signed-in user's own Account page** (not just the public profile), and the badge-label map is shared between the two pages (`utils/badges.ts`). The authenticated `GET /api/v1/profile/me` response gains a `badges` array (#194, epic #167 phase 3).
 - **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.
 - **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.
 - **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).
 - The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.
 - Plugin cards and guide pages now show a **like button with a count** (#169, frontend). Signed-in users can like/unlike (the count updates live); logged-out visitors see counts and are sent to the Account page to sign in. Backed by the likes API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.13.0] – 2026-06-14
+
 ### Changed
 
 - Authentication is now provided by the shared UserAuth service instead of dpc-api's own accounts (epic #167, phase 1). dpc-api proxies registration/login/logout to UserAuth and validates its tokens; a local profile mirror owns each user's API keys. The Account page now signs in via UserAuth and supports a profile (display name, avatar, bio). API paths moved from `/api/v1/accounts/*` to `/api/v1/auth/*` and `/api/v1/profile/*`. The Docker Compose stack now bundles the UserAuth service (and its database) so `docker compose up` runs end-to-end; `JWT_SECRET` (used by UserAuth to sign tokens) is now required when starting the stack.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Custom, MUI-styled **404 and 500 error pages** (a shared `components/ErrorPage`), so a missing or failed route keeps the site's theme and navigation and offers a link home, instead of Next.js's unstyled default page.
 - The plugin catalogue gains a **"Most Liked"** sort option alongside "By Popularity" (server count) and "Alphabetical", ranking plugins by their like count (#201, epic #167 phase 2). The sort logic was extracted into a unit-tested `utils/sortPlugins.ts`.
 - Earned **badges now also appear on the signed-in user's own Account page** (not just the public profile), and the badge-label map is shared between the two pages (`utils/badges.ts`). The authenticated `GET /api/v1/profile/me` response gains a `badges` array (#194, epic #167 phase 3).
 - **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Earned **badges now also appear on the signed-in user's own Account page** (not just the public profile), and the badge-label map is shared between the two pages (`utils/badges.ts`). The authenticated `GET /api/v1/profile/me` response gains a `badges` array (#194, epic #167 phase 3).
 - **Profile badges** (#194, epic #167 phase 3). Public profiles now show earned badges, starting with **Server Owner** (awarded to any user who owns at least one API key — i.e. runs a server that syncs with DPC). Badges are *derived* from existing state rather than stored, so they stay accurate automatically; the public `GET /api/v1/profile/{username}` response gains a `badges` array.
 - **Public profile pages** (#181, epic #167 phase 3). A new public `GET /api/v1/profile/{username}` returns a user's public profile — display name, avatar, bio, join date, and the plugins/guides they've liked — deliberately **excluding** the internal id and API keys (which stay on the authenticated `GET /api/v1/profile/me`). The website renders these at `/u/{username}`, and the Account page links to your own public profile. This is the foundation for the social layer (following, activity, comment author links).
 - The Account page now shows a **"My likes"** section listing the plugins and guides the signed-in user has liked — a personal toolbox linking to each item (#180, epic #167 phase 3). Frontend-only: it reads the existing `GET /api/v1/likes/me` and resolves ids against the plugin catalogue.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -59,7 +59,7 @@ No special software is required to use the website. Simply visit [https://danspl
 2. Register a new account, or log in with an existing username and password.
 3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
 4. The **My likes** section lists the plugins and guides you've liked, linking to each one — your personal toolbox.
-5. Click **View your public profile** to see your profile as other people see it (display name, avatar, bio, join date, and likes). Anyone can view a user's public profile at `/u/<username>`.
+5. Click **View your public profile** to see your profile as other people see it (display name, avatar, bio, join date, badges, and likes). Anyone can view a user's public profile at `/u/<username>`. Badges are earned automatically — for example, **Server Owner** appears once you have created an API key for a server.
 
 ### Getting Support
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -58,6 +58,7 @@ No special software is required to use the website. Simply visit [https://danspl
 1. Click **Account** in the top navigation bar (or visit `/account`).
 2. Register a new account, or log in with an existing username and password.
 3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
+4. The **My likes** section lists the plugins and guides you've liked, linking to each one — your personal toolbox.
 
 ### Getting Support
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -59,6 +59,7 @@ No special software is required to use the website. Simply visit [https://danspl
 2. Register a new account, or log in with an existing username and password.
 3. Once logged in, create or delete the API keys used to connect a server to the DPC community data API.
 4. The **My likes** section lists the plugins and guides you've liked, linking to each one — your personal toolbox.
+5. Click **View your public profile** to see your profile as other people see it (display name, avatar, bio, join date, and likes). Anyone can view a user's public profile at `/u/<username>`.
 
 ### Getting Support
 

--- a/__tests__/likeService.test.ts
+++ b/__tests__/likeService.test.ts
@@ -1,0 +1,83 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getLikeCounts, getMyLikes, likeTarget, unlikeTarget} from '../services/likeService';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+const rejectFetch = () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getLikeCounts', () => {
+    it('returns the counts map on a 200 response', async () => {
+        stubFetch({ok: true, json: async () => ({mf: 3, fiefs: 1})});
+        expect(await getLikeCounts('plugin')).toEqual({mf: 3, fiefs: 1});
+    });
+
+    it('returns an empty map on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500});
+        expect(await getLikeCounts('plugin')).toEqual({});
+    });
+
+    it('returns an empty map when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getLikeCounts('plugin')).toEqual({});
+    });
+});
+
+describe('getMyLikes', () => {
+    it('returns the liked targets on a 200 response', async () => {
+        const likes = [{targetType: 'plugin', targetId: 'mf'}];
+        stubFetch({ok: true, json: async () => likes});
+        expect(await getMyLikes('token')).toEqual(likes);
+    });
+
+    it('sends the bearer token', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => []} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getMyLikes('my-token');
+        expect(fetchMock.mock.calls[0][1]).toMatchObject({headers: {Authorization: 'Bearer my-token'}});
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 401});
+        expect(await getMyLikes('token')).toEqual([]);
+    });
+
+    it('returns an empty array when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getMyLikes('token')).toEqual([]);
+    });
+});
+
+describe('likeTarget / unlikeTarget', () => {
+    it('resolves to the new count from the response', async () => {
+        stubFetch({ok: true, json: async () => ({count: 5})});
+        expect(await likeTarget('token', 'plugin', 'mf')).toBe(5);
+    });
+
+    it('returns null on a non-ok response', async () => {
+        stubFetch({ok: false, status: 400});
+        expect(await likeTarget('token', 'plugin', 'mf')).toBeNull();
+    });
+
+    it('returns null when the response omits a numeric count', async () => {
+        stubFetch({ok: true, json: async () => ({})});
+        expect(await unlikeTarget('token', 'plugin', 'mf')).toBeNull();
+    });
+
+    it('returns null when fetch rejects', async () => {
+        rejectFetch();
+        expect(await unlikeTarget('token', 'plugin', 'mf')).toBeNull();
+    });
+});

--- a/__tests__/likedItems.test.ts
+++ b/__tests__/likedItems.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest'
+import {resolveLikedItems} from '../utils/likedItems'
+import type {LikedTarget} from '../services/likeService'
+
+const catalogue = [
+    {id: 'fiefs', title: 'Fiefs'},
+    {id: 'medieval-factions', title: 'Medieval Factions'},
+]
+
+describe('resolveLikedItems', () => {
+    it('labels a liked plugin with its catalogue title and links to the home catalogue', () => {
+        const likes: LikedTarget[] = [{targetType: 'plugin', targetId: 'fiefs'}]
+        expect(resolveLikedItems(likes, catalogue)).toEqual([
+            {key: 'plugin:fiefs', targetType: 'plugin', targetId: 'fiefs', title: 'Fiefs', href: '/#plugins'},
+        ])
+    })
+
+    it('labels a liked guide as "<title> Guide" and links to its guide page', () => {
+        const likes: LikedTarget[] = [{targetType: 'guide', targetId: 'medieval-factions'}]
+        expect(resolveLikedItems(likes, catalogue)).toEqual([
+            {
+                key: 'guide:medieval-factions',
+                targetType: 'guide',
+                targetId: 'medieval-factions',
+                title: 'Medieval Factions Guide',
+                href: '/guides/medieval-factions',
+            },
+        ])
+    })
+
+    it('falls back to the raw id when the target is not in the catalogue', () => {
+        const likes: LikedTarget[] = [{targetType: 'plugin', targetId: 'retired-plugin'}]
+        expect(resolveLikedItems(likes, catalogue)).toEqual([
+            {
+                key: 'plugin:retired-plugin',
+                targetType: 'plugin',
+                targetId: 'retired-plugin',
+                title: 'retired-plugin',
+                href: '/#plugins',
+            },
+        ])
+    })
+
+    it('sorts the resolved items by title', () => {
+        const likes: LikedTarget[] = [
+            {targetType: 'guide', targetId: 'medieval-factions'},
+            {targetType: 'plugin', targetId: 'fiefs'},
+            {targetType: 'plugin', targetId: 'medieval-factions'},
+        ]
+        expect(resolveLikedItems(likes, catalogue).map((i) => i.key)).toEqual([
+            'plugin:fiefs',
+            'plugin:medieval-factions',
+            'guide:medieval-factions',
+        ])
+    })
+
+    it('returns an empty array when there are no likes', () => {
+        expect(resolveLikedItems([], catalogue)).toEqual([])
+    })
+})

--- a/__tests__/profileService.test.ts
+++ b/__tests__/profileService.test.ts
@@ -1,0 +1,50 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getPublicProfile} from '../services/profileService';
+
+// Minimal fetch Response stub for the public-profile endpoint.
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getPublicProfile', () => {
+    it('returns the parsed profile on a 200 response', async () => {
+        const profile = {
+            username: 'alice',
+            displayName: 'Alice',
+            avatarUrl: null,
+            bio: null,
+            createdAt: '2026-01-01T00:00:00Z',
+            badges: ['SERVER_OWNER'],
+            likes: [],
+        };
+        stubFetch({ok: true, json: async () => profile});
+        expect(await getPublicProfile('alice')).toEqual(profile);
+    });
+
+    it('returns null on a 404 (unknown user)', async () => {
+        stubFetch({ok: false, status: 404});
+        expect(await getPublicProfile('nobody')).toBeNull();
+    });
+
+    it('returns null when fetch rejects', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+        expect(await getPublicProfile('alice')).toBeNull();
+    });
+
+    it('URL-encodes the username in the request path', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => ({})} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getPublicProfile('a b/c');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toContain('/api/v1/profile/a%20b%2Fc');
+    });
+});

--- a/__tests__/sortPlugins.test.ts
+++ b/__tests__/sortPlugins.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest'
+import {sortPlugins} from '../utils/sortPlugins'
+
+const plugins = [
+    {id: 'a', title: 'Apple', serverCount: 10},
+    {id: 'b', title: 'Banana', serverCount: 50},
+    {id: 'c', title: 'Cherry', serverCount: null},
+]
+
+describe('sortPlugins', () => {
+    it('sorts alphabetically by title', () => {
+        expect(sortPlugins(plugins, 'alphabetical').map((p) => p.id)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('sorts by server count descending, count-less plugins last', () => {
+        expect(sortPlugins(plugins, 'popularity').map((p) => p.id)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('breaks a server-count tie of two count-less plugins alphabetically', () => {
+        const countless = [
+            {id: 'z', title: 'Zeta', serverCount: null},
+            {id: 'm', title: 'Mu', serverCount: null},
+        ]
+        expect(sortPlugins(countless, 'popularity').map((p) => p.id)).toEqual(['m', 'z'])
+    })
+
+    it('sorts by like count descending, ties alphabetical', () => {
+        const likeCounts = {a: 1, b: 5, c: 5}
+        expect(sortPlugins(plugins, 'most-liked', likeCounts).map((p) => p.id)).toEqual(['b', 'c', 'a'])
+    })
+
+    it('treats a missing like count as zero', () => {
+        const likeCounts = {a: 3}
+        expect(sortPlugins(plugins, 'most-liked', likeCounts).map((p) => p.id)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('does not mutate the input array', () => {
+        const input = [...plugins]
+        sortPlugins(input, 'alphabetical')
+        expect(input.map((p) => p.id)).toEqual(['a', 'b', 'c'])
+    })
+})

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {Box, Button, Container, Typography} from '@mui/material';
+import HomeIcon from '@mui/icons-material/Home';
+import TopBar from './TopBar';
+import Seo from './Seo';
+import BottomBar from './BottomBar';
+import {pageStyle, sectionHeaderStyle} from '../styles/styles';
+
+const version = require('../package.json').version;
+
+/**
+ * Shared layout for the site's error pages (404 / 500). Renders the standard
+ * page chrome (TopBar/BottomBar) around a centred message and a link home, so a
+ * thrown or missing route still looks like the rest of the MUI-themed site
+ * instead of Next.js's unstyled default.
+ */
+const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({code, title, message}) => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title={`${code} — ${title}`} description={message}/>
+        <TopBar/>
+        <Container maxWidth="sm" sx={{py: 8, textAlign: 'center'}}>
+            <Typography variant="h1" color="primary" sx={{fontWeight: 700}}>
+                {code}
+            </Typography>
+            <Typography variant="h4" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                {title}
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
+                {message}
+            </Typography>
+            <Button variant="contained" startIcon={<HomeIcon/>} href="/">
+                Back to home
+            </Button>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default ErrorPage;

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -97,6 +97,7 @@ keeps a local profile mirror that owns each user's API keys.
 | `POST` | `/api/v1/auth/login` | Public | Login (proxied to UserAuth) and return a token |
 | `POST` | `/api/v1/auth/logout` | Bearer | Revoke the current token |
 | `GET` | `/api/v1/profile/me` | Bearer | Get the current user's profile and API keys |
+| `GET` | `/api/v1/profile/{username}` | Public | Get a user's public profile (display name, avatar, bio, join date, liked plugins/guides; no id or API keys) |
 | `PATCH` | `/api/v1/profile/me` | Bearer | Update display name / avatar / bio |
 | `POST` | `/api/v1/profile/me/api-keys` | Bearer | Create a new API key |
 | `DELETE` | `/api/v1/profile/me/api-keys/{id}` | Bearer | Delete an API key |

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -150,6 +150,21 @@ Response:
 Save the returned `apiKey` — it is shown only once and stored as a SHA-256 hash.
 The `keyPrefix` (first 8 characters) can be used to identify the key later.
 
+### Likes
+
+Likes on plugins and guides. A target is keyed by the plugin `id` from the
+website's `plugins.json` (a guide's id is its plugin's id). Liking is
+idempotent; counts are public.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/api/v1/likes` | Bearer | Like a plugin or guide (idempotent); returns the new count |
+| `DELETE` | `/api/v1/likes` | Bearer | Unlike a plugin or guide; returns the new count |
+| `GET` | `/api/v1/likes/counts?type=plugin\|guide` | Public | Aggregate like counts for a target type (`targetId` → count) |
+| `GET` | `/api/v1/likes/me` | Bearer | The current user's liked targets |
+
+The `POST`/`DELETE` body is `{ "targetType": "plugin" | "guide", "targetId": "<id>" }`.
+
 ### Factions
 
 | Method | Path | Auth | Description |

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -97,7 +97,7 @@ keeps a local profile mirror that owns each user's API keys.
 | `POST` | `/api/v1/auth/login` | Public | Login (proxied to UserAuth) and return a token |
 | `POST` | `/api/v1/auth/logout` | Bearer | Revoke the current token |
 | `GET` | `/api/v1/profile/me` | Bearer | Get the current user's profile and API keys |
-| `GET` | `/api/v1/profile/{username}` | Public | Get a user's public profile (display name, avatar, bio, join date, liked plugins/guides; no id or API keys) |
+| `GET` | `/api/v1/profile/{username}` | Public | Get a user's public profile (display name, avatar, bio, join date, badges, liked plugins/guides; no id or API keys) |
 | `PATCH` | `/api/v1/profile/me` | Bearer | Update display name / avatar / bio |
 | `POST` | `/api/v1/profile/me/api-keys` | Bearer | Create a new API key |
 | `DELETE` | `/api/v1/profile/me/api-keys/{id}` | Bearer | Delete an API key |

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -74,6 +74,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/factions/**").permitAll()
                         // Public like counts (must precede the authenticated /likes rule below)
                         .requestMatchers(HttpMethod.GET, "/api/v1/likes/counts").permitAll()
+                        // Public single-user profile (GET /api/v1/profile/{username}). The /me rule
+                        // is listed first so the authenticated self-profile (which exposes API keys)
+                        // is never served by the public path; the single-segment glob then permits
+                        // any other username, while the /** rule below still guards PATCH /me and
+                        // the /me/api-keys routes.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/profile/me").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/profile/*").permitAll()
                         // Swagger/OpenAPI
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // Profile, likes, and logout require a valid UserAuth token

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
@@ -3,9 +3,11 @@ package com.dansplugins.api.controller;
 import com.dansplugins.api.dto.CreateApiKeyRequest;
 import com.dansplugins.api.dto.CreateApiKeyResponse;
 import com.dansplugins.api.dto.ProfileResponse;
+import com.dansplugins.api.dto.PublicProfileResponse;
 import com.dansplugins.api.dto.UpdateProfileRequest;
 import com.dansplugins.api.entity.User;
 import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.service.LikeService;
 import com.dansplugins.api.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -40,12 +42,24 @@ import java.util.UUID;
 public class ProfileController {
 
     private final UserService userService;
+    private final LikeService likeService;
 
     @GetMapping("/me")
     @Operation(summary = "Get the current user's profile", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<ProfileResponse> getProfile(Principal principal) {
         User user = currentUser(principal);
         return ResponseEntity.ok(ProfileResponse.from(user, userService.getApiKeys(user)));
+    }
+
+    @GetMapping("/{username}")
+    @Operation(summary = "Get a user's public profile (no authentication required)")
+    public ResponseEntity<PublicProfileResponse> getPublicProfile(@PathVariable String username) {
+        // Public, read-only: resolve an existing mirror but never create one (unlike
+        // /me), and return only the public projection — no internal id, no API keys.
+        // The literal /me mapping above takes precedence, so it is never reachable here.
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        return ResponseEntity.ok(PublicProfileResponse.from(user, likeService.likedByUser(user)));
     }
 
     @PatchMapping("/me")

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
@@ -7,6 +7,7 @@ import com.dansplugins.api.dto.PublicProfileResponse;
 import com.dansplugins.api.dto.UpdateProfileRequest;
 import com.dansplugins.api.entity.User;
 import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.service.BadgeService;
 import com.dansplugins.api.service.LikeService;
 import com.dansplugins.api.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,6 +44,7 @@ public class ProfileController {
 
     private final UserService userService;
     private final LikeService likeService;
+    private final BadgeService badgeService;
 
     @GetMapping("/me")
     @Operation(summary = "Get the current user's profile", security = @SecurityRequirement(name = "bearerAuth"))
@@ -59,7 +61,8 @@ public class ProfileController {
         // The literal /me mapping above takes precedence, so it is never reachable here.
         User user = userService.findByUsername(username)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
-        return ResponseEntity.ok(PublicProfileResponse.from(user, likeService.likedByUser(user)));
+        return ResponseEntity.ok(PublicProfileResponse.from(
+                user, badgeService.badgesFor(user), likeService.likedByUser(user)));
     }
 
     @PatchMapping("/me")

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ProfileController.java
@@ -50,7 +50,8 @@ public class ProfileController {
     @Operation(summary = "Get the current user's profile", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<ProfileResponse> getProfile(Principal principal) {
         User user = currentUser(principal);
-        return ResponseEntity.ok(ProfileResponse.from(user, userService.getApiKeys(user)));
+        return ResponseEntity.ok(ProfileResponse.from(
+                user, badgeService.badgesFor(user), userService.getApiKeys(user)));
     }
 
     @GetMapping("/{username}")
@@ -71,7 +72,8 @@ public class ProfileController {
                                                          @Valid @RequestBody UpdateProfileRequest request) {
         User user = currentUser(principal);
         userService.updateProfile(user, request.displayName(), request.avatarUrl(), request.bio());
-        return ResponseEntity.ok(ProfileResponse.from(user, userService.getApiKeys(user)));
+        return ResponseEntity.ok(ProfileResponse.from(
+                user, badgeService.badgesFor(user), userService.getApiKeys(user)));
     }
 
     @PostMapping("/me/api-keys")

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/Badge.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/Badge.java
@@ -1,0 +1,15 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * A badge a user can earn, shown on their public profile. Badges are
+ * <em>derived</em> from existing state (see {@code BadgeService}) rather than
+ * stored, so they stay correct automatically.
+ */
+@Schema(description = "A badge shown on a user's public profile")
+public enum Badge {
+
+    /** The user owns at least one API key — i.e. runs a server that syncs with DPC. */
+    SERVER_OWNER
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/ProfileResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/ProfileResponse.java
@@ -28,6 +28,9 @@ public record ProfileResponse(
         @Schema(description = "Profile creation timestamp")
         Instant createdAt,
 
+        @Schema(description = "Badges this user has earned")
+        List<Badge> badges,
+
         @Schema(description = "API keys owned by this user")
         List<ApiKeyInfo> apiKeys
 ) {
@@ -41,7 +44,7 @@ public record ProfileResponse(
     ) {
     }
 
-    public static ProfileResponse from(User user, List<ApiKey> keys) {
+    public static ProfileResponse from(User user, List<Badge> badges, List<ApiKey> keys) {
         return new ProfileResponse(
                 user.getId(),
                 user.getUserauthUsername(),
@@ -49,6 +52,7 @@ public record ProfileResponse(
                 user.getAvatarUrl(),
                 user.getBio(),
                 user.getCreatedAt(),
+                badges,
                 keys.stream()
                         .map(k -> new ApiKeyInfo(k.getId(), k.getKeyPrefix(), k.getServerName(), k.getCreatedAt()))
                         .toList()

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
@@ -1,0 +1,53 @@
+package com.dansplugins.api.dto;
+
+import com.dansplugins.api.entity.Like;
+import com.dansplugins.api.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A user's <em>public</em> community profile, safe to expose without
+ * authentication. Deliberately omits the internal user UUID and the user's API
+ * keys (both present on {@link ProfileResponse}); it carries only the fields any
+ * visitor may see plus the plugins/guides the user has liked.
+ */
+@Schema(description = "A user's public community profile (no internal id or API keys)")
+public record PublicProfileResponse(
+        @Schema(description = "UserAuth username")
+        String username,
+
+        @Schema(description = "Display name (optional)")
+        String displayName,
+
+        @Schema(description = "Avatar URL (optional)")
+        String avatarUrl,
+
+        @Schema(description = "Bio (optional)")
+        String bio,
+
+        @Schema(description = "Profile creation timestamp")
+        Instant createdAt,
+
+        @Schema(description = "Plugins and guides this user has liked")
+        List<LikedTarget> likes
+) {
+
+    @Schema(description = "A plugin or guide the user has liked")
+    public record LikedTarget(String targetType, String targetId) {
+    }
+
+    public static PublicProfileResponse from(User user, List<Like> likes) {
+        return new PublicProfileResponse(
+                user.getUserauthUsername(),
+                user.getDisplayName(),
+                user.getAvatarUrl(),
+                user.getBio(),
+                user.getCreatedAt(),
+                likes.stream()
+                        .map(like -> new LikedTarget(like.getTargetType(), like.getTargetId()))
+                        .toList()
+        );
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/PublicProfileResponse.java
@@ -30,6 +30,9 @@ public record PublicProfileResponse(
         @Schema(description = "Profile creation timestamp")
         Instant createdAt,
 
+        @Schema(description = "Badges this user has earned")
+        List<Badge> badges,
+
         @Schema(description = "Plugins and guides this user has liked")
         List<LikedTarget> likes
 ) {
@@ -38,13 +41,14 @@ public record PublicProfileResponse(
     public record LikedTarget(String targetType, String targetId) {
     }
 
-    public static PublicProfileResponse from(User user, List<Like> likes) {
+    public static PublicProfileResponse from(User user, List<Badge> badges, List<Like> likes) {
         return new PublicProfileResponse(
                 user.getUserauthUsername(),
                 user.getDisplayName(),
                 user.getAvatarUrl(),
                 user.getBio(),
                 user.getCreatedAt(),
+                badges,
                 likes.stream()
                         .map(like -> new LikedTarget(like.getTargetType(), like.getTargetId()))
                         .toList()

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/ApiKeyRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/ApiKeyRepository.java
@@ -11,5 +11,7 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
 
     boolean existsByKeyHash(String keyHash);
 
+    boolean existsByOwner(User owner);
+
     List<ApiKey> findByOwner(User owner);
 }

--- a/dpc-api/src/main/java/com/dansplugins/api/service/BadgeService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/BadgeService.java
@@ -1,0 +1,34 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.dto.Badge;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.ApiKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Computes the badges a user has earned. Badges are <em>derived</em> from
+ * existing state rather than stored, so they cannot drift out of sync. Today the
+ * only badge is {@link Badge#SERVER_OWNER} (the user owns at least one API key,
+ * i.e. runs a server that syncs with DPC); additional derived or assigned badges
+ * plug in here.
+ */
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private final ApiKeyRepository apiKeyRepository;
+
+    @Transactional(readOnly = true)
+    public List<Badge> badgesFor(User user) {
+        List<Badge> badges = new ArrayList<>();
+        if (apiKeyRepository.existsByOwner(user)) {
+            badges.add(Badge.SERVER_OWNER);
+        }
+        return badges;
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -74,7 +74,9 @@ class ProfileAuthIntegrationTest {
         mockMvc.perform(get("/api/v1/profile/me").header("Authorization", BEARER))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("alice"))
-                .andExpect(jsonPath("$.apiKeys").isArray());
+                .andExpect(jsonPath("$.apiKeys").isArray())
+                .andExpect(jsonPath("$.badges").isArray())
+                .andExpect(jsonPath("$.badges").isEmpty());
     }
 
     @Test
@@ -89,7 +91,8 @@ class ProfileAuthIntegrationTest {
 
         mockMvc.perform(get("/api/v1/profile/me").header("Authorization", BEARER))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.apiKeys.length()").value(1));
+                .andExpect(jsonPath("$.apiKeys.length()").value(1))
+                .andExpect(jsonPath("$.badges[0]").value("SERVER_OWNER"));
     }
 
     @Test

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -157,8 +157,31 @@ class ProfileAuthIntegrationTest {
                 .andExpect(jsonPath("$.displayName").value("Alice the Brave"))
                 .andExpect(jsonPath("$.bio").value("hi"))
                 .andExpect(jsonPath("$.likes").isArray())
+                .andExpect(jsonPath("$.badges").isArray())
+                .andExpect(jsonPath("$.badges").isEmpty())
                 .andExpect(jsonPath("$.apiKeys").doesNotExist())
                 .andExpect(jsonPath("$.id").doesNotExist());
+    }
+
+    @Test
+    void publicProfile_showsServerOwnerBadge_onceTheUserHasAnApiKey() throws Exception {
+        // No key yet → no badge.
+        mockMvc.perform(get("/api/v1/profile/me").header("Authorization", BEARER))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.badges").isEmpty());
+
+        // Creating an API key makes alice a server owner.
+        mockMvc.perform(post("/api/v1/profile/me/api-keys")
+                        .header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"serverName\":\"survival-1\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.badges[0]").value("SERVER_OWNER"));
     }
 
     @Test

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.dansplugins.api.controller;
 
 import com.dansplugins.api.repository.ApiKeyRepository;
+import com.dansplugins.api.repository.LikeRepository;
 import com.dansplugins.api.repository.UserRepository;
 import com.dansplugins.api.service.UserAuthClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,12 +48,17 @@ class ProfileAuthIntegrationTest {
     @Autowired
     private ApiKeyRepository apiKeyRepository;
 
+    @Autowired
+    private LikeRepository likeRepository;
+
     @MockBean
     private UserAuthClient userAuthClient;
 
     @BeforeEach
     void setUp() {
+        // Delete children (api keys, likes) before users — both FK to users.
         apiKeyRepository.deleteAll();
+        likeRepository.deleteAll();
         userRepository.deleteAll();
         when(userAuthClient.validate("good-token")).thenReturn(Optional.of("alice"));
     }
@@ -133,5 +139,46 @@ class ProfileAuthIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.registered").value(true))
                 .andExpect(jsonPath("$.tokenIssued").value(false));
+    }
+
+    @Test
+    void publicProfile_isReadableWithoutToken_andOmitsApiKeys() throws Exception {
+        // Create alice's mirror and set public fields via the authenticated route.
+        mockMvc.perform(patch("/api/v1/profile/me")
+                        .header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"displayName\":\"Alice the Brave\",\"bio\":\"hi\"}"))
+                .andExpect(status().isOk());
+
+        // Anyone — no token — can read the public projection, but it must not leak API keys.
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.displayName").value("Alice the Brave"))
+                .andExpect(jsonPath("$.bio").value("hi"))
+                .andExpect(jsonPath("$.likes").isArray())
+                .andExpect(jsonPath("$.apiKeys").doesNotExist())
+                .andExpect(jsonPath("$.id").doesNotExist());
+    }
+
+    @Test
+    void publicProfile_unknownUser_returns404() throws Exception {
+        mockMvc.perform(get("/api/v1/profile/nobody"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void publicProfile_includesTheUsersLikedTargets() throws Exception {
+        // Liking creates alice's mirror and a like in one authenticated call.
+        mockMvc.perform(post("/api/v1/likes")
+                        .header("Authorization", BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"targetType\":\"plugin\",\"targetId\":\"mf\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/profile/alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.likes[0].targetType").value("plugin"))
+                .andExpect(jsonPath("$.likes[0].targetId").value("mf"));
     }
 }

--- a/dpc-api/src/test/java/com/dansplugins/api/service/BadgeServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/BadgeServiceTest.java
@@ -1,0 +1,39 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.dto.Badge;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BadgeServiceTest {
+
+    @Mock
+    private ApiKeyRepository apiKeyRepository;
+
+    @InjectMocks
+    private BadgeService badgeService;
+
+    @Test
+    void awardsServerOwner_whenTheUserOwnsAnApiKey() {
+        User user = new User("alice");
+        when(apiKeyRepository.existsByOwner(user)).thenReturn(true);
+
+        assertThat(badgeService.badgesFor(user)).containsExactly(Badge.SERVER_OWNER);
+    }
+
+    @Test
+    void awardsNothing_whenTheUserOwnsNoApiKey() {
+        User user = new User("bob");
+        when(apiKeyRepository.existsByOwner(user)).thenReturn(false);
+
+        assertThat(badgeService.badgesFor(user)).isEmpty();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,13 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const NotFoundPage: NextPage = () => (
+    <ErrorPage
+        code="404"
+        title="Page not found"
+        message="The page you're looking for doesn't exist or may have moved."
+    />
+);
+
+export default NotFoundPage;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,13 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const ServerErrorPage: NextPage = () => (
+    <ErrorPage
+        code="500"
+        title="Something went wrong"
+        message="An unexpected error occurred on our end. Please try again in a moment."
+    />
+);
+
+export default ServerErrorPage;

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -27,6 +27,7 @@ import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 import {getMyLikes, type LikedTarget} from '../services/likeService'
 import {resolveLikedItems} from '../utils/likedItems'
+import {badgeLabel} from '../utils/badges'
 import pluginData from './data/plugins.json'
 
 const version = require('../package.json').version
@@ -47,6 +48,7 @@ interface AccountProfile {
     avatarUrl: string | null
     bio: string | null
     createdAt: string
+    badges: string[]
     apiKeys: ApiKeyInfo[]
 }
 
@@ -391,6 +393,13 @@ const AccountPage: NextPage = () => {
                                             View your public profile
                                         </Box>
                                     </Typography>
+                                    {profile.badges.length > 0 && (
+                                        <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1}}>
+                                            {profile.badges.map((badge) => (
+                                                <Chip key={badge} label={badgeLabel(badge)} size="small" color="primary"/>
+                                            ))}
+                                        </Box>
+                                    )}
                                     <Box component="form" onSubmit={handleUpdateProfile}
                                          sx={{display: 'flex', flexDirection: 'column', gap: 2, mt: 2}}>
                                         <Typography variant="subtitle2" color="text.secondary">Profile</Typography>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -4,10 +4,12 @@ import {
     Button,
     Card,
     CardContent,
+    Chip,
     Container,
     IconButton,
     List,
     ListItem,
+    ListItemButton,
     ListItemText,
     Tab,
     Tabs,
@@ -23,6 +25,9 @@ import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
+import {getMyLikes, type LikedTarget} from '../services/likeService'
+import {resolveLikedItems} from '../utils/likedItems'
+import pluginData from './data/plugins.json'
 
 const version = require('../package.json').version
 
@@ -50,6 +55,7 @@ const AccountPage: NextPage = () => {
     const [tab, setTab] = useState(0)
     const [token, setToken] = useState<string | null>(null)
     const [profile, setProfile] = useState<AccountProfile | null>(null)
+    const [likes, setLikes] = useState<LikedTarget[]>([])
     const [error, setError] = useState<string | null>(null)
     const [success, setSuccess] = useState<string | null>(null)
     const [newApiKey, setNewApiKey] = useState<string | null>(null)
@@ -113,6 +119,9 @@ const AccountPage: NextPage = () => {
     useEffect(() => {
         if (token) {
             fetchProfile(token)
+            // The user's "toolbox" of liked plugins/guides. Best-effort: a likes
+            // fetch failure degrades to an empty list and never blocks the page.
+            getMyLikes(token).then(setLikes)
         }
     }, [token, fetchProfile])
 
@@ -190,6 +199,7 @@ const AccountPage: NextPage = () => {
         }
         setToken(null)
         setProfile(null)
+        setLikes([])
         localStorage.removeItem('dpc-token')
         setSuccess('Logged out.')
     }
@@ -284,6 +294,8 @@ const AccountPage: NextPage = () => {
             setError('Failed to copy — please select and copy the key manually.')
         }
     }
+
+    const likedItems = resolveLikedItems(likes, pluginData.plugins)
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
@@ -408,6 +420,40 @@ const AccountPage: NextPage = () => {
                                 </CardContent>
                             </Card>
                         )}
+
+                        <Card sx={{mb: 3}}>
+                            <CardContent>
+                                <Typography variant="h6" gutterBottom>My likes</Typography>
+                                <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+                                    The plugins and guides you&apos;ve liked — your personal toolbox.
+                                </Typography>
+                                {likedItems.length > 0 ? (
+                                    <List disablePadding>
+                                        {likedItems.map((item) => (
+                                            <ListItem key={item.key} disablePadding>
+                                                <ListItemButton component="a" href={item.href}>
+                                                    <ListItemText primary={item.title}/>
+                                                    <Chip
+                                                        label={item.targetType}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        sx={{textTransform: 'capitalize'}}
+                                                    />
+                                                </ListItemButton>
+                                            </ListItem>
+                                        ))}
+                                    </List>
+                                ) : (
+                                    <Typography variant="body2" color="text.secondary">
+                                        You haven&apos;t liked any plugins or guides yet. Browse the{' '}
+                                        <Box component="a" href="/#plugins" sx={{color: 'primary.main'}}>plugins</Box>
+                                        {' '}or{' '}
+                                        <Box component="a" href="/guides" sx={{color: 'primary.main'}}>guides</Box>
+                                        {' '}and tap the like button.
+                                    </Typography>
+                                )}
+                            </CardContent>
+                        </Card>
 
                         <Card sx={{mb: 3}}>
                             <CardContent>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -386,6 +386,10 @@ const AccountPage: NextPage = () => {
                                     </Box>
                                     <Typography variant="body2" color="text.secondary" gutterBottom>
                                         Member since {new Date(profile.createdAt).toLocaleDateString()}
+                                        {' · '}
+                                        <Box component="a" href={`/u/${profile.username}`} sx={{color: 'primary.main'}}>
+                                            View your public profile
+                                        </Box>
                                     </Typography>
                                     <Box component="form" onSubmit={handleUpdateProfile}
                                          sx={{display: 'flex', flexDirection: 'column', gap: 2, mt: 2}}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import BottomBar from '../components/BottomBar'
 import { getVisits, incrementVisits } from '../services/visitService';
 import { getServerCountsWithRateLimit } from '../utils/bstats';
 import { getLikeCounts, getMyLikes } from '../services/likeService';
+import { sortPlugins, type SortOption } from '../utils/sortPlugins';
 
 interface PluginData {
     mostPopular: string[];
@@ -77,8 +78,6 @@ const PluginSection: React.FC<PluginSectionProps> = ({ plugins, likeCounts, like
     </Grid>
 )
 
-type SortOption = 'popularity' | 'alphabetical';
-
 interface PluginsSectionProps {
     initialPlugins: PluginWithServerCount[];
 }
@@ -109,35 +108,14 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
         }
     };
 
-    const getSortedPlugins = (): PluginWithServerCount[] => {
-        if (sortBy === 'popularity') {
-            // Sort by server count (descending), with plugins without counts at the end
-            return [...initialPlugins].sort((a, b) => {
-                const hasCountA = a.serverCount != null;
-                const hasCountB = b.serverCount != null;
-                
-                // If both have counts, sort by count descending
-                if (hasCountA && hasCountB) {
-                    return (b.serverCount as number) - (a.serverCount as number);
-                }
-                // If only one has a count, prioritize it
-                if (hasCountA) return -1;
-                if (hasCountB) return 1;
-                // If neither has a count, sort alphabetically
-                return a.title.localeCompare(b.title);
-            });
-        } else {
-            // Sort all plugins alphabetically
-            return [...initialPlugins].sort((a, b) => a.title.localeCompare(b.title));
-        }
-    };
+    const sortedPlugins = sortPlugins(initialPlugins, sortBy, likeCounts);
 
     const normalizedQuery = query.trim().toLowerCase();
     const visiblePlugins = normalizedQuery
-        ? getSortedPlugins().filter((plugin) =>
+        ? sortedPlugins.filter((plugin) =>
             plugin.title.toLowerCase().includes(normalizedQuery) ||
             plugin.description.toLowerCase().includes(normalizedQuery))
-        : getSortedPlugins();
+        : sortedPlugins;
 
     return (
         <Box id="plugins" sx={pluginsBoxStyle}>
@@ -170,6 +148,9 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
                 >
                     <ToggleButton value="popularity" aria-label="sort by popularity">
                         By Popularity
+                    </ToggleButton>
+                    <ToggleButton value="most-liked" aria-label="sort by most liked">
+                        Most Liked
                     </ToggleButton>
                     <ToggleButton value="alphabetical" aria-label="sort alphabetically">
                         Alphabetical

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -22,15 +22,10 @@ import BottomBar from '../../components/BottomBar'
 import {pageStyle, sectionHeaderStyle} from '../../styles/styles'
 import {getPublicProfile, type PublicProfile} from '../../services/profileService'
 import {resolveLikedItems} from '../../utils/likedItems'
+import {badgeLabel} from '../../utils/badges'
 import pluginData from '../data/plugins.json'
 
 const version = require('../../package.json').version
-
-// Human-readable labels for the badge codes returned by the API. Unknown codes
-// fall back to the raw value so a newly-added badge still renders.
-const BADGE_LABELS: Record<string, string> = {
-    SERVER_OWNER: 'Server Owner',
-}
 
 const PublicProfilePage: NextPage = () => {
     const router = useRouter()
@@ -94,7 +89,7 @@ const PublicProfilePage: NextPage = () => {
                                                 {profile.badges.map((badge) => (
                                                     <Chip
                                                         key={badge}
-                                                        label={BADGE_LABELS[badge] ?? badge}
+                                                        label={badgeLabel(badge)}
                                                         size="small"
                                                         color="primary"
                                                     />

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -1,0 +1,130 @@
+import {
+    Alert,
+    Avatar,
+    Box,
+    Card,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Container,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemText,
+    Typography,
+} from '@mui/material'
+import type {NextPage} from 'next'
+import {useRouter} from 'next/router'
+import React, {useEffect, useState} from 'react'
+import TopBar from '../../components/TopBar'
+import Seo from '../../components/Seo'
+import BottomBar from '../../components/BottomBar'
+import {pageStyle, sectionHeaderStyle} from '../../styles/styles'
+import {getPublicProfile, type PublicProfile} from '../../services/profileService'
+import {resolveLikedItems} from '../../utils/likedItems'
+import pluginData from '../data/plugins.json'
+
+const version = require('../../package.json').version
+
+const PublicProfilePage: NextPage = () => {
+    const router = useRouter()
+    const username = typeof router.query.username === 'string' ? router.query.username : null
+    const [profile, setProfile] = useState<PublicProfile | null>(null)
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        if (!username) return
+        let active = true
+        setLoading(true)
+        getPublicProfile(username).then((data) => {
+            if (active) {
+                setProfile(data)
+                setLoading(false)
+            }
+        })
+        return () => {
+            active = false
+        }
+    }, [username])
+
+    const likedItems = profile ? resolveLikedItems(profile.likes, pluginData.plugins) : []
+    const heading = profile?.displayName || profile?.username || username || 'Profile'
+
+    return (
+        <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title={`${heading} — Profile`} description={`The public DPC community profile for ${heading}.`}/>
+            <TopBar/>
+            <Container maxWidth="md" sx={{py: 4}}>
+                {loading ? (
+                    <Box sx={{display: 'flex', justifyContent: 'center', py: 6}}>
+                        <CircularProgress/>
+                    </Box>
+                ) : !profile ? (
+                    <Alert severity="info">
+                        No profile found for <strong>{username}</strong>.
+                    </Alert>
+                ) : (
+                    <>
+                        <Card sx={{mb: 3}}>
+                            <CardContent>
+                                <Box sx={{display: 'flex', alignItems: 'center', gap: 2, mb: profile.bio ? 2 : 0}}>
+                                    <Avatar src={profile.avatarUrl ?? undefined} sx={{width: 64, height: 64}}>
+                                        {heading.charAt(0).toUpperCase()}
+                                    </Avatar>
+                                    <Box>
+                                        <Typography variant="h4" sx={(theme) => sectionHeaderStyle(theme)}>
+                                            {heading}
+                                        </Typography>
+                                        {profile.displayName && (
+                                            <Typography variant="body2" color="text.secondary">
+                                                @{profile.username}
+                                            </Typography>
+                                        )}
+                                        <Typography variant="body2" color="text.secondary">
+                                            Member since {new Date(profile.createdAt).toLocaleDateString()}
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                                {profile.bio && (
+                                    <Typography variant="body1" sx={{mt: 1}}>
+                                        {profile.bio}
+                                    </Typography>
+                                )}
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardContent>
+                                <Typography variant="h6" gutterBottom>Likes</Typography>
+                                {likedItems.length > 0 ? (
+                                    <List disablePadding>
+                                        {likedItems.map((item) => (
+                                            <ListItem key={item.key} disablePadding>
+                                                <ListItemButton component="a" href={item.href}>
+                                                    <ListItemText primary={item.title}/>
+                                                    <Chip
+                                                        label={item.targetType}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        sx={{textTransform: 'capitalize'}}
+                                                    />
+                                                </ListItemButton>
+                                            </ListItem>
+                                        ))}
+                                    </List>
+                                ) : (
+                                    <Typography variant="body2" color="text.secondary">
+                                        {heading} hasn&apos;t liked any plugins or guides yet.
+                                    </Typography>
+                                )}
+                            </CardContent>
+                        </Card>
+                    </>
+                )}
+            </Container>
+            <BottomBar version={version}/>
+        </Box>
+    )
+}
+
+export default PublicProfilePage

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -26,6 +26,12 @@ import pluginData from '../data/plugins.json'
 
 const version = require('../../package.json').version
 
+// Human-readable labels for the badge codes returned by the API. Unknown codes
+// fall back to the raw value so a newly-added badge still renders.
+const BADGE_LABELS: Record<string, string> = {
+    SERVER_OWNER: 'Server Owner',
+}
+
 const PublicProfilePage: NextPage = () => {
     const router = useRouter()
     const username = typeof router.query.username === 'string' ? router.query.username : null
@@ -83,6 +89,18 @@ const PublicProfilePage: NextPage = () => {
                                         <Typography variant="body2" color="text.secondary">
                                             Member since {new Date(profile.createdAt).toLocaleDateString()}
                                         </Typography>
+                                        {profile.badges.length > 0 && (
+                                            <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1}}>
+                                                {profile.badges.map((badge) => (
+                                                    <Chip
+                                                        key={badge}
+                                                        label={BADGE_LABELS[badge] ?? badge}
+                                                        size="small"
+                                                        color="primary"
+                                                    />
+                                                ))}
+                                            </Box>
+                                        )}
                                     </Box>
                                 </Box>
                                 {profile.bio && (

--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -1,0 +1,29 @@
+// Client-side calls to the dpc-api public profile endpoint. Same public API the
+// account/leaderboard pages use.
+import type {LikedTarget} from './likeService'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345'
+
+/** A user's public profile — no internal id and no API keys (see dpc-api PublicProfileResponse). */
+export interface PublicProfile {
+    username: string
+    displayName: string | null
+    avatarUrl: string | null
+    bio: string | null
+    createdAt: string
+    likes: LikedTarget[]
+}
+
+/**
+ * Fetch a user's public profile by username. Resolves to `null` when the user
+ * does not exist (404) or the request fails, so callers can render a
+ * not-found state without throwing.
+ */
+export const getPublicProfile = async (username: string): Promise<PublicProfile | null> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/profile/${encodeURIComponent(username)}`)
+        return res.ok ? await res.json() : null
+    } catch {
+        return null
+    }
+}

--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -11,6 +11,7 @@ export interface PublicProfile {
     avatarUrl: string | null
     bio: string | null
     createdAt: string
+    badges: string[]
     likes: LikedTarget[]
 }
 

--- a/utils/badges.ts
+++ b/utils/badges.ts
@@ -1,0 +1,8 @@
+// Human-readable labels for the badge codes returned by the dpc-api profile
+// endpoints. Unknown codes fall back to the raw value so a newly-added badge
+// still renders before this map is updated.
+export const BADGE_LABELS: Record<string, string> = {
+    SERVER_OWNER: 'Server Owner',
+}
+
+export const badgeLabel = (code: string): string => BADGE_LABELS[code] ?? code

--- a/utils/likedItems.ts
+++ b/utils/likedItems.ts
@@ -1,0 +1,62 @@
+import type {LikedTarget} from '../services/likeService'
+
+/** The minimal plugin-catalogue shape needed to label a liked item. */
+export interface CataloguePlugin {
+    id: string
+    title: string
+}
+
+/** A liked target resolved into something the UI can render and link to. */
+export interface ResolvedLikedItem {
+    /** Stable React key, unique across the plugin/guide types. */
+    key: string
+    targetType: LikedTarget['targetType']
+    targetId: string
+    /** Human-readable label (plugin/guide title, or the raw id if unknown). */
+    title: string
+    /** Internal href to view the item. */
+    href: string
+}
+
+/**
+ * Resolve a user's raw liked targets into displayable items by joining them
+ * against the plugin catalogue. Both plugin and guide likes key off the plugin
+ * id — a guide's id is its plugin's id (see `pages/guides/[id].tsx`). A like
+ * whose id is no longer in the catalogue still renders, using the raw id as a
+ * fallback label, so a stale like is never silently dropped.
+ *
+ * Plugins live on the home catalogue (`/#plugins`, there is no per-plugin
+ * route); guides have their own page at `/guides/{id}`. The result is sorted by
+ * title, with a stable tiebreaker on target type, so the rendered list is
+ * deterministic.
+ */
+export const resolveLikedItems = (
+    likes: LikedTarget[],
+    plugins: CataloguePlugin[]
+): ResolvedLikedItem[] => {
+    const byId = new Map(plugins.map((p) => [p.id, p]))
+    const resolved = likes.map((like): ResolvedLikedItem => {
+        const name = byId.get(like.targetId)?.title ?? like.targetId
+        if (like.targetType === 'guide') {
+            return {
+                key: `guide:${like.targetId}`,
+                targetType: 'guide',
+                targetId: like.targetId,
+                title: `${name} Guide`,
+                href: `/guides/${like.targetId}`,
+            }
+        }
+        return {
+            key: `plugin:${like.targetId}`,
+            targetType: 'plugin',
+            targetId: like.targetId,
+            title: name,
+            href: '/#plugins',
+        }
+    })
+    return resolved.sort((a, b) => {
+        const byTitle = a.title.localeCompare(b.title)
+        if (byTitle !== 0) return byTitle
+        return a.targetType.localeCompare(b.targetType)
+    })
+}

--- a/utils/sortPlugins.ts
+++ b/utils/sortPlugins.ts
@@ -1,0 +1,46 @@
+export type SortOption = 'popularity' | 'most-liked' | 'alphabetical'
+
+/** The minimal plugin shape the catalogue sort needs. */
+export interface SortablePlugin {
+    id: string
+    title: string
+    serverCount?: number | null
+}
+
+const byTitle = (a: SortablePlugin, b: SortablePlugin): number => a.title.localeCompare(b.title)
+
+/**
+ * Sort plugins for the catalogue. Pure — returns a new array, never mutates.
+ *
+ * - `popularity`: bStats server count descending; plugins with a count come
+ *   before plugins without one, and ties (or two count-less plugins) fall back
+ *   to alphabetical.
+ * - `most-liked`: like count descending (a missing count counts as 0), ties
+ *   alphabetical.
+ * - `alphabetical`: title ascending.
+ */
+export const sortPlugins = <T extends SortablePlugin>(
+    plugins: T[],
+    sortBy: SortOption,
+    likeCounts: Record<string, number> = {}
+): T[] => {
+    if (sortBy === 'alphabetical') {
+        return [...plugins].sort(byTitle)
+    }
+    if (sortBy === 'most-liked') {
+        return [...plugins].sort((a, b) => {
+            const likesA = likeCounts[a.id] ?? 0
+            const likesB = likeCounts[b.id] ?? 0
+            return likesB - likesA || byTitle(a, b)
+        })
+    }
+    // popularity (server count)
+    return [...plugins].sort((a, b) => {
+        const hasA = a.serverCount != null
+        const hasB = b.serverCount != null
+        if (hasA && hasB) return (b.serverCount as number) - (a.serverCount as number)
+        if (hasA) return -1
+        if (hasB) return 1
+        return byTitle(a, b)
+    })
+}


### PR DESCRIPTION
Release **0.13.0** to production (promote `develop` → `main`).

## What ships
- **My Likes** on the Account page (#180)
- **Public profile pages** at `/u/{username}` + public `GET /api/v1/profile/{username}` (#181)
- **Profile badges** (Server Owner) on public + account profiles (#194)
- **"Most Liked"** catalogue sort (#201)
- MUI-styled **404 / 500** error pages
- Service-layer characterization tests + Likes-API README docs

## Safety
- **No new DB migrations** (develop ↔ main migration sets are identical, V1–V11) — code-only deploy, no schema change, no faction-data surface.
- Clean release merge (develop is a content superset of main; three-dot diff empty apart from this batch).

_Drafted by Claude on behalf of Daniel Stephenson._