### PR TITLE
fix(a11y): <html lang> + complete external-link rel (#217, #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `<html>` element now sets `lang="en"`, so assistive technology and translation tools can identify the page language (WCAG 3.1.1) (#217).
+- External links on the News, Road Map, and Commissions pages now use `rel="noopener noreferrer"` (previously only `noopener`), matching the rest of the site and avoiding referrer leakage (#213).
+
 ## [0.13.0] – 2026-06-14
 
 ### Changed

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,7 +5,7 @@ import {Html, Head, Main, NextScript} from 'next/document';
 // head; preconnect hints keep the extra round-trip cheap.
 export default function Document() {
     return (
-        <Html>
+        <Html lang="en">
             <Head>
                 <link rel="preconnect" href="https://fonts.googleapis.com"/>
                 <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous"/>

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -134,7 +134,7 @@ const Commissions: NextPage = () => {
                         size="large"
                         href={commissionsData.discordInvite}
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                     >
                         Join the Commissions Discord
                     </Button>

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -55,7 +55,7 @@ const NewsCard: React.FC<{ post: NewsPost }> = ({post}) => {
             <Typography variant="body1">{post.body}</Typography>
             {post.sourceUrl && (
                 <Typography variant="body2" sx={{mt: 1}}>
-                    <Link href={post.sourceUrl} target="_blank" rel="noopener">View source</Link>
+                    <Link href={post.sourceUrl} target="_blank" rel="noopener noreferrer">View source</Link>
                 </Typography>
             )}
         </Paper>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -61,7 +61,7 @@ const Roadmap: NextPage = () => (
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 This page tracks where Dan&apos;s Plugins Community is headed. For the day-to-day detail,
                 see the{' '}
-                <Link href="https://github.com/Dans-Plugins/dansplugins-dot-com/issues" target="_blank" rel="noopener">
+                <Link href="https://github.com/Dans-Plugins/dansplugins-dot-com/issues" target="_blank" rel="noopener noreferrer">
                     issue tracker on GitHub
                 </Link>.
             </Typography>


### PR DESCRIPTION
## Summary
Two small correctness fixes:
- **#217** — `<Html lang="en">` in `_document.tsx` (WCAG 3.1.1, Level A).
- **#213** — `rel="noopener noreferrer"` on the News "View source", Road Map issue-tracker, and Commissions Discord links (were `noopener` only).

## Test plan
- [x] `npm run lint` clean, `npm run build` succeeds.
- [x] Manual: rendered `<html lang="en">`; the three links now carry both rel tokens.

## Deferred this batch (externally-directed run)
The rest of the open backlog is out of scope for this autonomous polish run: epic features #192–#196 (SecurityConfig/large, charter-gated), #162 (data-blocked), #142/#24 (blocked on Discord ingestion), #87 (large), #57 (infra).

Closes #217
Closes #213

---

_drafted by Claude on behalf of Daniel Stephenson_