### PR TITLE
fix(ux): user-facing error messages (#207, #211, #208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Sign-in, registration, and leaderboard error messages now use plain, user-facing language instead of developer-speak like "Is the API running?" (#207, #211). A failed registration no longer speculatively blames the username; it points at both the username and the password requirements (#208).
+
 ### Fixed
 
 - The `<html>` element now sets `lang="en"`, so assistive technology and translation tools can identify the page language (WCAG 3.1.1) (#217).

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -157,10 +157,10 @@ const AccountPage: NextPage = () => {
                 setPassword('')
                 returnAfterAuth()
             } else {
-                setError('Registration failed. Username may already be taken.')
+                setError('Registration failed. Make sure your username is available and your password meets the requirements (8–128 characters).')
             }
         } catch {
-            setError('Connection error. Is the API running?')
+            setError('We couldn’t reach the server. Please check your connection and try again.')
         }
     }
 
@@ -186,7 +186,7 @@ const AccountPage: NextPage = () => {
                 setError('Invalid credentials.')
             }
         } catch {
-            setError('Connection error. Is the API running?')
+            setError('We couldn’t reach the server. Please check your connection and try again.')
         }
     }
 

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -90,7 +90,7 @@ const LeaderboardPage: NextPage = () => {
             }
         } catch (e) {
             console.error('Failed to fetch factions:', e)
-            setError('Failed to connect to API. Is the server running?')
+            setError('We couldn’t load the leaderboard right now. Please try again.')
         } finally {
             setLoading(false)
         }


### PR DESCRIPTION
## Summary
Replaces developer-facing error copy with plain language:
- **#207** — `account.tsx` login/register connection errors no longer say "Is the API running?".
- **#211** — `leaderboard.tsx` load failure no longer says "Is the server running?".
- **#208** — registration failure no longer speculatively blames the username; it names both the username (availability) and the password requirements.

## Test plan
- [x] `npm run lint` clean, `npm run build` succeeds.
- [x] Manual trace: each `setError(...)` path now shows the new copy; technical detail stays in `console.error`.

Note: the profile/API-key handlers use a plainer "Connection error." — not developer-speak and outside the named issues, so left unchanged.

Closes #207
Closes #211
Closes #208

---

_drafted by Claude on behalf of Daniel Stephenson_