### PR TITLE
feat(topbar): wordmark links home + signed-in state in nav (#209, #210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- The site wordmark in the top bar now links to the home page, matching the universal "click the logo to go home" convention (#209).
+- The top navigation now reflects your signed-in state: it shows your username when you're logged in and "Sign in" when you're not, instead of an always-identical "Account" link (#210).
 - Sign-in, registration, and leaderboard error messages now use plain, user-facing language instead of developer-speak like "Is the API running?" (#207, #211). A failed registration no longer speculatively blames the username; it points at both the username and the password requirements (#208).
 
 ### Fixed

--- a/__tests__/authToken.test.ts
+++ b/__tests__/authToken.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest'
+import {usernameFromToken} from '../utils/authToken'
+
+// Build an unsigned JWT-shaped string with the given payload (header.payload.sig).
+const makeToken = (payload: object): string => {
+    const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+    return `${b64({alg: 'HS256', typ: 'JWT'})}.${b64(payload)}.sig`
+}
+
+describe('usernameFromToken', () => {
+    it('returns the sub claim from a valid token', () => {
+        expect(usernameFromToken(makeToken({sub: 'alice', exp: 1}))).toBe('alice')
+    })
+
+    it('returns null for a null/empty token', () => {
+        expect(usernameFromToken(null)).toBeNull()
+        expect(usernameFromToken('')).toBeNull()
+        expect(usernameFromToken(undefined)).toBeNull()
+    })
+
+    it('returns null when there is no sub claim', () => {
+        expect(usernameFromToken(makeToken({foo: 'bar'}))).toBeNull()
+    })
+
+    it('returns null for a malformed token', () => {
+        expect(usernameFromToken('not-a-jwt')).toBeNull()
+        expect(usernameFromToken('a.b')).toBe(null) // payload "b" is not valid base64 JSON
+    })
+})

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,10 +1,11 @@
-import {AppBar, Box, Button, Toolbar, Typography, useTheme} from '@mui/material';
+import {AppBar, Box, Button, Link, Toolbar, Typography, useTheme} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {useRouter} from 'next/router';
-import React, {useContext} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
 import {isActiveNavLink} from '../utils/nav';
+import {usernameFromToken} from '../utils/authToken';
 
 import {
     appBarStyle,
@@ -45,20 +46,36 @@ const NavButton: React.FC<{ href: string; active?: boolean; children: React.Reac
 };
 
 const BrandName: React.FC = () => (
-    <Typography
-        variant="h6"
+    // The wordmark links home — the near-universal "click the logo to return to
+    // the home page" convention.
+    <Link
+        href="/"
+        underline="none"
         color="inherit"
-        component="div"
-        sx={(theme) => brandNameStyle(theme)}
+        sx={(theme) => ({...brandNameStyle(theme), display: 'inline-block'})}
     >
-        Dan&apos;s Plugins Community
-    </Typography>
+        <Typography variant="h6" color="inherit" component="span">
+            Dan&apos;s Plugins Community
+        </Typography>
+    </Link>
 );
 
 const TopBar: React.FC = () => {
     const colorMode = useContext(ColorModeContext);
     const theme = useTheme();
     const {pathname} = useRouter();
+
+    // Reflect the signed-in state in the nav. Read on the client only (after
+    // mount) so the server-rendered markup and the first client paint match —
+    // until then we show the neutral "Account" default (no hydration mismatch).
+    const [signedIn, setSignedIn] = useState<boolean | null>(null);
+    const [username, setUsername] = useState<string | null>(null);
+    useEffect(() => {
+        const token = window.localStorage.getItem('dpc-token');
+        setSignedIn(!!token);
+        setUsername(usernameFromToken(token));
+    }, []);
+    const accountLabel = signedIn === false ? 'Sign in' : (username ?? 'Account');
 
     return (
         <AppBar
@@ -77,7 +94,7 @@ const TopBar: React.FC = () => {
                         <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>
                         <NavButton href="/roadmap" active={isActiveNavLink(pathname, '/roadmap')}>Road Map</NavButton>
                         <NavButton href="/commissions" active={isActiveNavLink(pathname, '/commissions')}>Commissions</NavButton>
-                        <NavButton href="/account" active={isActiveNavLink(pathname, '/account')}>Account</NavButton>
+                        <NavButton href="/account" active={isActiveNavLink(pathname, '/account')}>{accountLabel}</NavButton>
                         <NavButton href="https://discord.gg/xXtuAQ2">Discord</NavButton>
                         <NavButton href="https://www.patreon.com/danspluginscommunity">Patreon</NavButton>
                         <NavButton href="https://www.linkedin.com/company/dansplugins">LinkedIn</NavButton>

--- a/utils/authToken.ts
+++ b/utils/authToken.ts
@@ -1,0 +1,19 @@
+// Read the username (the JWT `sub` claim) from a UserAuth token for *display*
+// only — this does NOT verify the signature and must never gate access. Returns
+// null when the token is absent or malformed.
+export const usernameFromToken = (token: string | null | undefined): string | null => {
+    if (!token) {
+        return null
+    }
+    try {
+        const payload = token.split('.')[1]
+        if (!payload) {
+            return null
+        }
+        const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
+        const data = JSON.parse(json) as Record<string, unknown>
+        return typeof data.sub === 'string' ? data.sub : null
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Summary
- **#209** — the "Dan's Plugins Community" wordmark is now a link to `/`.
- **#210** — the nav reflects auth state: shows the signed-in username (decoded from the token `sub`, display-only) or "Sign in" when logged out. Read in a client effect after mount so SSR and first paint match (neutral "Account" default) — no hydration mismatch, same pattern as the color-mode toggle.
- New `utils/authToken.usernameFromToken` with unit tests (valid sub, null/empty, no-sub, malformed).

## Test plan
- [x] `npm test` 69 pass (4 new), `npm run lint` clean, `npm run build` succeeds.

Closes #209
Closes #210

---

_drafted by Claude on behalf of Daniel Stephenson_