### PR TITLE
feat(catalogue): search clear + count, and card→guide link (#220, #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The plugin search box now has a clear (✕) button and, while searching, shows a "Showing N of M plugins" count (#220).
+- Each plugin card now links to that plugin's on-site **Guide** (`/guides/{id}`) alongside the GitHub and SpigotMC buttons (#221).
+
 ### Changed
 
 - The site wordmark in the top bar now links to the home page, matching the universal "click the logo to go home" convention (#209).

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, Typography} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import DnsIcon from '@mui/icons-material/Dns';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 import LikeButton from './LikeButton';
 import {
     pluginCardStyle,
@@ -97,6 +98,14 @@ const PluginCard: React.FC<PluginCardProps> = ({
             <CardActions sx={pluginCardActionsStyle}>
                 <LikeButton targetType="plugin" targetId={id} count={likeCount} liked={liked} token={token}/>
                 <Box sx={{flexGrow: 1}}/>
+                <Button
+                    size="small"
+                    startIcon={<MenuBookIcon/>}
+                    component={Link}
+                    href={`/guides/${id}`}
+                >
+                    Guide
+                </Button>
                 <Button
                     variant="contained"
                     size="small"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
-import {Box, Container, Grid, InputAdornment, TextField, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
+import {Box, Container, Grid, IconButton, InputAdornment, TextField, Typography, ToggleButton, ToggleButtonGroup} from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
+import ClearIcon from '@mui/icons-material/Clear'
 import type {NextPage} from 'next'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
@@ -137,6 +138,13 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
                                 <SearchIcon fontSize="small" />
                             </InputAdornment>
                         ),
+                        endAdornment: query ? (
+                            <InputAdornment position="end">
+                                <IconButton size="small" aria-label="Clear search" onClick={() => setQuery('')}>
+                                    <ClearIcon fontSize="small" />
+                                </IconButton>
+                            </InputAdornment>
+                        ) : undefined,
                     }}
                 />
                 <ToggleButtonGroup
@@ -157,6 +165,12 @@ const PluginsSection: React.FC<PluginsSectionProps> = ({ initialPlugins }) => {
                     </ToggleButton>
                 </ToggleButtonGroup>
             </Box>
+
+            {normalizedQuery && (
+                <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 2 }}>
+                    Showing {visiblePlugins.length} of {initialPlugins.length} plugins
+                </Typography>
+            )}
 
             {visiblePlugins.length > 0 ? (
                 <PluginSection plugins={visiblePlugins} likeCounts={likeCounts} likedSet={likedSet} token={token} />


### PR DESCRIPTION
## Summary
- **#220** — the catalogue search field gets a clear (✕) button (shown when non-empty) and a "Showing N of M plugins" count while searching.
- **#221** — each `PluginCard` gets a "Guide" button → `/guides/{id}` (internal link), connecting the catalogue to the on-site guides.

## Test plan
- [x] `npm run lint` clean, `npm run build` succeeds.
- [x] Manual trace: clear button resets `query`; count renders only when a query is active; Guide button targets `/guides/{id}` using the card's `id`.

Closes #220
Closes #221

---

_drafted by Claude on behalf of Daniel Stephenson_