### PR TITLE
feat(leaderboard): per-faction data freshness (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Each faction row on the leaderboard now shows how recently its data was synced ("Updated N days ago"), so visitors can tell whether a member count is current or stale (#212). Backed by a tested `utils/relativeTime` helper.
 - The Account page's Login, Register, Save-profile, and Create-key buttons now show a spinner and disable while the request is in flight, giving feedback on slow actions and preventing accidental double-submits (#206).
 - The plugin search box now has a clear (✕) button and, while searching, shows a "Showing N of M plugins" count (#220).
 - Each plugin card now links to that plugin's on-site **Guide** (`/guides/{id}`) alongside the GitHub and SpigotMC buttons (#221).

--- a/__tests__/relativeTime.test.ts
+++ b/__tests__/relativeTime.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest'
+import {relativeTimeFrom} from '../utils/relativeTime'
+
+const NOW = 1_700_000_000_000
+const ago = (ms: number) => new Date(NOW - ms).toISOString()
+
+describe('relativeTimeFrom', () => {
+    it('returns "just now" under a minute', () => {
+        expect(relativeTimeFrom(ago(30 * 1000), NOW)).toBe('just now')
+    })
+
+    it('formats minutes, singular and plural', () => {
+        expect(relativeTimeFrom(ago(60 * 1000), NOW)).toBe('1 minute ago')
+        expect(relativeTimeFrom(ago(5 * 60 * 1000), NOW)).toBe('5 minutes ago')
+    })
+
+    it('formats hours', () => {
+        expect(relativeTimeFrom(ago(3 * 60 * 60 * 1000), NOW)).toBe('3 hours ago')
+    })
+
+    it('formats days', () => {
+        expect(relativeTimeFrom(ago(2 * 24 * 60 * 60 * 1000), NOW)).toBe('2 days ago')
+        expect(relativeTimeFrom(ago(24 * 60 * 60 * 1000), NOW)).toBe('1 day ago')
+    })
+
+    it('returns an empty string for an unparseable timestamp', () => {
+        expect(relativeTimeFrom('not-a-date', NOW)).toBe('')
+    })
+})

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -28,6 +28,7 @@ import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles'
+import {relativeTimeFrom} from '../utils/relativeTime'
 
 const version = require('../package.json').version
 
@@ -210,6 +211,9 @@ const LeaderboardPage: NextPage = () => {
                                                             {faction.description}
                                                         </Typography>
                                                     )}
+                                                    <Typography variant="caption" color="text.secondary" display="block">
+                                                        Updated {relativeTimeFrom(faction.updatedAt, Date.now())}
+                                                    </Typography>
                                                 </TableCell>
                                                 <TableCell>
                                                     <Stack spacing={0.5} alignItems="flex-start">

--- a/utils/relativeTime.ts
+++ b/utils/relativeTime.ts
@@ -1,0 +1,28 @@
+// Format an ISO timestamp as a short relative time (e.g. "3 days ago"). `now`
+// is passed in (rather than read from the clock) so the function is pure and
+// testable; callers supply `Date.now()`.
+export const relativeTimeFrom = (iso: string, now: number): string => {
+    const then = new Date(iso).getTime()
+    if (Number.isNaN(then)) {
+        return ''
+    }
+    const seconds = Math.round((now - then) / 1000)
+    if (seconds < 60) {
+        return 'just now'
+    }
+    const units: [number, string][] = [
+        [60, 'minute'],
+        [60, 'hour'],
+        [24, 'day'],
+    ]
+    let value = seconds
+    let unit = 'second'
+    for (const [size, name] of units) {
+        if (value < size) {
+            break
+        }
+        value = Math.round(value / size)
+        unit = name
+    }
+    return `${value} ${unit}${value === 1 ? '' : 's'} ago`
+}


### PR DESCRIPTION
## Summary
Adds a "Updated N days ago" line to each faction row (from `faction.updatedAt`), so visitors can judge whether a member count is current. Backed by a new pure helper `utils/relativeTime.relativeTimeFrom(iso, now)` (now passed in for testability).

## Test plan
- [x] `npm test` 74 pass (5 new in `relativeTime.test.ts`: just-now, minutes sing/plural, hours, days, unparseable).
- [x] `npm run lint` clean, `npm run build` succeeds. Verified the Server cell renders once (no markup duplication).

Closes #212

---

_drafted by Claude on behalf of Daniel Stephenson_