### PR TITLE
fix(a11y): page <h1>, <main> landmark + skip link (#218, #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Each page now has a single `<h1>` (its title) and wraps its content in a `<main id="main">` landmark, and a "Skip to main content" link (hidden until focused) lets keyboard and screen-reader users bypass the navigation — fixing the missing-heading and no-bypass-blocks gaps (WCAG 2.4.1, 1.3.1) (#218, #219).
 - The `<html>` element now sets `lang="en"`, so assistive technology and translation tools can identify the page language (WCAG 3.1.1) (#217).
 - External links on the News, Road Map, and Commissions pages now use `rel="noopener noreferrer"` (previously only `noopener`), matching the rest of the site and avoiding referrer leakage (#213).
 

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -62,6 +62,7 @@ const Blurb: React.FC = () => (
         <Box sx={{textAlign: 'center', py: {xs: 4, md: 8}}}>
             <Typography
                 variant="h2"
+                component="h1"
                 gutterBottom
                 sx={(theme) => ({...blurbTitleStyle(theme), marginBottom: theme.spacing(2)})}
             >

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -18,7 +18,7 @@ const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({co
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo title={`${code} — ${title}`} description={message}/>
         <TopBar/>
-        <Container maxWidth="sm" sx={{py: 8, textAlign: 'center'}}>
+        <Container component="main" id="main" maxWidth="sm" sx={{py: 8, textAlign: 'center'}}>
             <Typography variant="h1" color="primary" sx={{fontWeight: 700}}>
                 {code}
             </Typography>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type {AppProps} from 'next/app'
 import React, {useEffect, useMemo, useState} from 'react';
-import {createTheme, CssBaseline, ThemeProvider} from '@mui/material';
+import {Box, createTheme, CssBaseline, ThemeProvider} from '@mui/material';
 import {ColorModeContext} from '../utils/ColorModeContext';
 import {COLOR_MODE_STORAGE_KEY, ColorMode, resolveInitialColorMode} from '../utils/colorMode';
 
@@ -95,6 +95,30 @@ function MyApp({Component, pageProps}: AppProps) {
             <ColorModeContext.Provider value={colorMode}>
                 <ThemeProvider theme={theme}>
                     <CssBaseline/>
+                    {/* Skip link: the first focusable element, hidden until focused, lets
+                        keyboard/screen-reader users jump past the nav to the page's
+                        <main id="main"> content (WCAG 2.4.1). */}
+                    <Box
+                        component="a"
+                        href="#main"
+                        sx={{
+                            position: 'fixed',
+                            top: 8,
+                            left: 8,
+                            zIndex: (t) => t.zIndex.tooltip + 1,
+                            px: 2,
+                            py: 1,
+                            borderRadius: 1,
+                            boxShadow: 3,
+                            bgcolor: 'background.paper',
+                            color: 'primary.main',
+                            transform: 'translateY(-150%)',
+                            transition: 'transform 0.2s ease',
+                            '&:focus': {transform: 'translateY(0)'},
+                        }}
+                    >
+                        Skip to main content
+                    </Box>
                     <Component {...pageProps} />
                 </ThemeProvider>
             </ColorModeContext.Provider>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -16,8 +16,8 @@ const About: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo title="About Us" description="Learn about Dan's Plugins Community, an open-source community building plugins for Minecraft servers."/>
         <TopBar/>
-        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
-            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+        <Container component="main" id="main" maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 About Us
             </Typography>
             <Typography variant="body1" gutterBottom>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -320,8 +320,8 @@ const AccountPage: NextPage = () => {
         <Box sx={(theme) => pageStyle(theme)}>
             <Seo title="Account" description="Manage your account and the API keys your Minecraft servers use to sync with the DPC community data API."/>
             <TopBar/>
-            <Container maxWidth="md" sx={{py: 4}}>
-                <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            <Container component="main" id="main" maxWidth="md" sx={{py: 4}}>
+                <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                     Account
                 </Typography>
                 <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>

--- a/pages/commissions.tsx
+++ b/pages/commissions.tsx
@@ -53,9 +53,9 @@ const Commissions: NextPage = () => {
         <Box sx={(theme) => pageStyle(theme)}>
             <Seo title="Commissions" description="Custom Minecraft plugin development by the creator of Dan's Plugins Community — pricing and availability."/>
             <TopBar/>
-            <Container maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
+            <Container component="main" id="main" maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>
-                    <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                    <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                         Commissions
                     </Typography>
                     <Chip

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -28,8 +28,8 @@ const Guides: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo title="Guides" description="User guides for every Dan's Plugins Community plugin."/>
         <TopBar/>
-        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
-            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+        <Container component="main" id="main" maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 Guides
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -231,7 +231,7 @@ const Home: NextPage<HomeProps> = ({ visits, startDate, pluginsWithCounts }) => 
         <Box sx={pageStyle}>
             <Seo/>
             <TopBar/>
-            <Container maxWidth="xl" sx={{py: 4}}>
+            <Container component="main" id="main" maxWidth="xl" sx={{py: 4}}>
                 <Blurb/>
                 <SectionDivider/>
                 <PluginsSection initialPlugins={pluginsWithCounts} />

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -105,8 +105,8 @@ const LeaderboardPage: NextPage = () => {
         <Box sx={(theme) => pageStyle(theme)}>
             <Seo title="Faction Leaderboard" description="Medieval Factions ranked by member count across all servers."/>
             <TopBar/>
-            <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
-                <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            <Container component="main" id="main" maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+                <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                     Faction Leaderboard
                 </Typography>
                 <Typography variant="body1" gutterBottom color="text.secondary" sx={{mb: 3}}>

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -66,8 +66,8 @@ const News: NextPage<NewsProps> = ({posts}) => (
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo title="News" description="Announcements and updates from Dan's Plugins Community."/>
         <TopBar/>
-        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
-            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+        <Container component="main" id="main" maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 News
             </Typography>
             {posts.length > 0 ? (

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -54,8 +54,8 @@ const Roadmap: NextPage = () => (
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo title="Road Map" description="What's planned, in progress, and completed across Dan's Plugins Community."/>
         <TopBar/>
-        <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
-            <Typography variant="h3" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+        <Container component="main" id="main" maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
+            <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 Road Map
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -55,7 +55,7 @@ const PublicProfilePage: NextPage = () => {
         <Box sx={(theme) => pageStyle(theme)}>
             <Seo title={`${heading} — Profile`} description={`The public DPC community profile for ${heading}.`}/>
             <TopBar/>
-            <Container maxWidth="md" sx={{py: 4}}>
+            <Container component="main" id="main" maxWidth="md" sx={{py: 4}}>
                 {loading ? (
                     <Box sx={{display: 'flex', justifyContent: 'center', py: 6}}>
                         <CircularProgress/>
@@ -73,7 +73,7 @@ const PublicProfilePage: NextPage = () => {
                                         {heading.charAt(0).toUpperCase()}
                                     </Avatar>
                                     <Box>
-                                        <Typography variant="h4" sx={(theme) => sectionHeaderStyle(theme)}>
+                                        <Typography variant="h4" component="h1" sx={(theme) => sectionHeaderStyle(theme)}>
                                             {heading}
                                         </Typography>
                                         {profile.displayName && (


### PR DESCRIPTION
## Summary
- **#218** — every page's primary title is now a semantic `<h1>` (`Typography component="h1"`, visual size unchanged); the home hero is the home page's `<h1>`.
- **#219** — each page's content `Container` is now `component="main" id="main"`, and `_app` renders a "Skip to main content" link (visually hidden until focused) as the first focusable element, targeting `#main` (WCAG 2.4.1, Level A). The 404/500 `ErrorPage` got the landmark too so the skip link has a target there.

## Scope note
This touches **13 files** — over the ~10-file soft ceiling — but every change is the same uniform, mechanical attribute add (`component="h1"` on the title, `component="main" id="main"` on the Container) plus one skip link in `_app`. It's trivially reviewable as a block; splitting #218 and #219 would mean editing all 9 pages twice across two PRs. Well under the hard ceiling (~40 net LOC).

## Test plan
- [x] `npm run lint` clean, `npm run build` succeeds.
- [x] Verified: 9 `component="h1"` (8 pages + home hero), 9 `component="main"` content regions (+ ErrorPage), one skip link.

Closes #218
Closes #219

---

_drafted by Claude on behalf of Daniel Stephenson_