### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.14.0] – 2026-06-14
+
 ### Added
 
 - Each faction row on the leaderboard now shows how recently its data was synced ("Updated N days ago"), so visitors can tell whether a member count is current or stale (#212). Backed by a tested `utils/relativeTime` helper.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Release prep for **0.14.0** — rolls the CHANGELOG `[Unreleased]` into `[0.14.0] – 2026-06-14` and bumps `package.json`. Ships the UX/UI/accessibility polish batch (#206–#213, #217–#221).

- [x] `npm run lint` clean, `npm run build` succeeds.

---

_drafted by Claude on behalf of Daniel Stephenson_