### PR TITLE
Dev portal 1/4: mirror open GitHub issues/PRs into a /dev backlog console

### DIFF
--- a/__tests__/backlogService.test.ts
+++ b/__tests__/backlogService.test.ts
@@ -1,0 +1,62 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getBacklogItems, getBacklogSummary} from '../services/backlogService';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+const rejectFetch = () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getBacklogItems', () => {
+    it('returns the items on a 200 response', async () => {
+        const items = [{repo: 'Fiefs', number: 1, targetId: 'Fiefs#1'}];
+        stubFetch({ok: true, json: async () => items});
+        expect(await getBacklogItems()).toEqual(items);
+    });
+
+    it('scopes the request to a repo when provided', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => []} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getBacklogItems('Medieval-Factions');
+        expect(fetchMock.mock.calls[0][0]).toContain('repo=Medieval-Factions');
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500});
+        expect(await getBacklogItems()).toEqual([]);
+    });
+
+    it('returns an empty array when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getBacklogItems()).toEqual([]);
+    });
+});
+
+describe('getBacklogSummary', () => {
+    it('returns the summary rows on a 200 response', async () => {
+        const summary = [{repo: 'Fiefs', openIssueCount: 1, openPrCount: 0, draftPrCount: 0, oldestOpenItemAt: null}];
+        stubFetch({ok: true, json: async () => summary});
+        expect(await getBacklogSummary()).toEqual(summary);
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500});
+        expect(await getBacklogSummary()).toEqual([]);
+    });
+
+    it('returns an empty array when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getBacklogSummary()).toEqual([]);
+    });
+});

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -94,6 +94,7 @@ const TopBar: React.FC = () => {
                         <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>
                         <NavButton href="/roadmap" active={isActiveNavLink(pathname, '/roadmap')}>Road Map</NavButton>
                         <NavButton href="/commissions" active={isActiveNavLink(pathname, '/commissions')}>Commissions</NavButton>
+                        <NavButton href="/dev" active={isActiveNavLink(pathname, '/dev')}>Dev Portal</NavButton>
                         <NavButton href="/account" active={isActiveNavLink(pathname, '/account')}>{accountLabel}</NavButton>
                         <NavButton href="https://discord.gg/xXtuAQ2">Discord</NavButton>
                         <NavButton href="https://www.patreon.com/danspluginscommunity">Patreon</NavButton>

--- a/dpc-api/src/main/java/com/dansplugins/api/DpcApiApplication.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/DpcApiApplication.java
@@ -1,12 +1,15 @@
 package com.dansplugins.api;
 
+import com.dansplugins.api.config.BacklogProperties;
 import com.dansplugins.api.config.FactionSyncSafetyProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties(FactionSyncSafetyProperties.class)
+@EnableConfigurationProperties({FactionSyncSafetyProperties.class, BacklogProperties.class})
+@EnableScheduling
 public class DpcApiApplication {
 
     public static void main(String[] args) {

--- a/dpc-api/src/main/java/com/dansplugins/api/config/BacklogProperties.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/BacklogProperties.java
@@ -1,0 +1,27 @@
+package com.dansplugins.api.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration for the dev-portal backlog sync (mirrors open GitHub issues/PRs
+ * for one org into {@code backlog_items} so the /dev console has something to
+ * read without calling GitHub on every page load).
+ *
+ * <p>{@code githubToken} is optional: without it the sync still runs against the
+ * unauthenticated GitHub REST API, just at a much lower rate limit (10
+ * requests/min for search, vs. 30 with a token). Set a classic PAT with no
+ * scopes (public read access only needs an authenticated identity, not any
+ * permission) via {@code DPC_BACKLOG_GITHUB_TOKEN} to raise the ceiling.</p>
+ */
+@Validated
+@ConfigurationProperties(prefix = "dpc.backlog")
+public record BacklogProperties(
+        @NotBlank String org,
+        String githubToken,
+        @Positive long syncIntervalMs,
+        boolean syncEnabled
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -74,6 +74,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/factions/**").permitAll()
                         // Public like counts (must precede the authenticated /likes rule below)
                         .requestMatchers(HttpMethod.GET, "/api/v1/likes/counts").permitAll()
+                        // Backlog console data is a public aggregation of already-public GitHub data
+                        .requestMatchers(HttpMethod.GET, "/api/v1/backlog", "/api/v1/backlog/**").permitAll()
                         // Public single-user profile (GET /api/v1/profile/{username}). The /me rule
                         // is listed first so the authenticated self-profile (which exposes API keys)
                         // is never served by the public path; the single-segment glob then permits

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/BacklogController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/BacklogController.java
@@ -1,0 +1,40 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.dto.BacklogItemResponse;
+import com.dansplugins.api.dto.RepoSummaryResponse;
+import com.dansplugins.api.service.BacklogQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Read-only view of the dev-portal backlog console: open GitHub issues/PRs
+ * mirrored from the Dans-Plugins org by BacklogSyncService. All public — the
+ * data is already public on GitHub, this is just an aggregated view of it.
+ */
+@RestController
+@RequestMapping("/api/v1/backlog")
+@RequiredArgsConstructor
+@Tag(name = "Backlog", description = "Cross-repo GitHub issue/PR backlog for the dev portal")
+public class BacklogController {
+
+    private final BacklogQueryService backlogQueryService;
+
+    @GetMapping
+    @Operation(summary = "Open issues/PRs, optionally filtered to one repo")
+    public List<BacklogItemResponse> items(@RequestParam(value = "repo", required = false) String repo) {
+        return backlogQueryService.openItems(repo);
+    }
+
+    @GetMapping("/summary")
+    @Operation(summary = "Per-repo counts and oldest open item, sorted by backlog size")
+    public List<RepoSummaryResponse> summary() {
+        return backlogQueryService.summary();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/BacklogItemResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/BacklogItemResponse.java
@@ -1,0 +1,37 @@
+package com.dansplugins.api.dto;
+
+import com.dansplugins.api.entity.BacklogItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "One open GitHub issue or pull request mirrored from the Dans-Plugins org")
+public record BacklogItemResponse(
+        String repo,
+        int number,
+        String targetId,
+        String itemType,
+        String title,
+        boolean draft,
+        String authorLogin,
+        String htmlUrl,
+        int commentCount,
+        Instant githubCreatedAt,
+        Instant githubUpdatedAt
+) {
+    public static BacklogItemResponse from(BacklogItem item) {
+        return new BacklogItemResponse(
+                item.getRepo(),
+                item.getNumber(),
+                item.targetId(),
+                item.getItemType().name(),
+                item.getTitle(),
+                item.isDraft(),
+                item.getAuthorLogin(),
+                item.getHtmlUrl(),
+                item.getCommentCount(),
+                item.getGithubCreatedAt(),
+                item.getGithubUpdatedAt()
+        );
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/RepoSummaryResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/RepoSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "Per-repo backlog rollup: counts and the oldest still-open item")
+public record RepoSummaryResponse(
+        String repo,
+        long openIssueCount,
+        long openPrCount,
+        long draftPrCount,
+        Instant oldestOpenItemAt
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/entity/BacklogItem.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/entity/BacklogItem.java
@@ -1,0 +1,115 @@
+package com.dansplugins.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A local mirror of one open (or recently-open) GitHub issue or pull request from
+ * the Dans-Plugins org, refreshed by the scheduled sync in BacklogSyncService.
+ * GitHub remains the system of record for state; a row here flips to CLOSED
+ * (rather than being deleted) when a sync no longer sees it in the open set, so
+ * the console can show "recently closed" without a second source of truth.
+ */
+@Entity
+@Table(name = "backlog_items", uniqueConstraints =
+        @UniqueConstraint(name = "uq_backlog_item", columnNames = {"repo", "number"}))
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class BacklogItem {
+
+    public enum ItemType { ISSUE, PULL_REQUEST }
+
+    public enum State { OPEN, CLOSED }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(lombok.AccessLevel.NONE)
+    private UUID id;
+
+    @Column(name = "repo", nullable = false, length = 100)
+    @Setter(lombok.AccessLevel.NONE)
+    private String repo;
+
+    @Column(name = "number", nullable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private int number;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "item_type", nullable = false, length = 16)
+    private ItemType itemType;
+
+    @Column(name = "title", nullable = false, length = 512)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false, length = 16)
+    private State state;
+
+    @Column(name = "draft", nullable = false)
+    private boolean draft;
+
+    @Column(name = "author_login", length = 100)
+    private String authorLogin;
+
+    @Column(name = "html_url", nullable = false, length = 512)
+    private String htmlUrl;
+
+    @Column(name = "comment_count", nullable = false)
+    private int commentCount;
+
+    @Column(name = "github_created_at", nullable = false)
+    private Instant githubCreatedAt;
+
+    @Column(name = "github_updated_at", nullable = false)
+    private Instant githubUpdatedAt;
+
+    @Column(name = "last_synced_at", nullable = false)
+    private Instant lastSyncedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private Instant updatedAt;
+
+    public BacklogItem(String repo, int number, ItemType itemType) {
+        this.repo = repo;
+        this.number = number;
+        this.itemType = itemType;
+    }
+
+    /** A stable key for cross-referencing this item from likes/claims/feature requests: "repo#number". */
+    public String targetId() {
+        return repo + "#" + number;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/BacklogItemRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/BacklogItemRepository.java
@@ -1,0 +1,20 @@
+package com.dansplugins.api.repository;
+
+import com.dansplugins.api.entity.BacklogItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BacklogItemRepository extends JpaRepository<BacklogItem, UUID> {
+
+    Optional<BacklogItem> findByRepoAndNumber(String repo, int number);
+
+    List<BacklogItem> findByStateOrderByGithubCreatedAtAsc(BacklogItem.State state);
+
+    List<BacklogItem> findByRepoAndStateOrderByGithubCreatedAtAsc(String repo, BacklogItem.State state);
+
+    /** Every row not touched by the sync in progress — these are no longer open on GitHub. */
+    List<BacklogItem> findByStateAndLastSyncedAtBefore(BacklogItem.State state, java.time.Instant cutoff);
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/BacklogQueryService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/BacklogQueryService.java
@@ -1,0 +1,55 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.dto.BacklogItemResponse;
+import com.dansplugins.api.dto.RepoSummaryResponse;
+import com.dansplugins.api.entity.BacklogItem;
+import com.dansplugins.api.repository.BacklogItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Read side of the backlog console: the flat open-item list and the per-repo
+ * rollup shown on /dev. Kept separate from {@link BacklogSyncService}, which
+ * owns writing to backlog_items.
+ */
+@Service
+@RequiredArgsConstructor
+public class BacklogQueryService {
+
+    private final BacklogItemRepository backlogItemRepository;
+
+    @Transactional(readOnly = true)
+    public List<BacklogItemResponse> openItems(String repo) {
+        List<BacklogItem> items = (repo == null || repo.isBlank())
+                ? backlogItemRepository.findByStateOrderByGithubCreatedAtAsc(BacklogItem.State.OPEN)
+                : backlogItemRepository.findByRepoAndStateOrderByGithubCreatedAtAsc(repo, BacklogItem.State.OPEN);
+        return items.stream().map(BacklogItemResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<RepoSummaryResponse> summary() {
+        List<BacklogItem> openItems = backlogItemRepository.findByStateOrderByGithubCreatedAtAsc(BacklogItem.State.OPEN);
+        Map<String, List<BacklogItem>> byRepo = openItems.stream().collect(Collectors.groupingBy(BacklogItem::getRepo));
+
+        return byRepo.entrySet().stream()
+                .map(entry -> {
+                    String repo = entry.getKey();
+                    List<BacklogItem> items = entry.getValue();
+                    long issues = items.stream().filter(i -> i.getItemType() == BacklogItem.ItemType.ISSUE).count();
+                    List<BacklogItem> prs = items.stream()
+                            .filter(i -> i.getItemType() == BacklogItem.ItemType.PULL_REQUEST).toList();
+                    long draftPrs = prs.stream().filter(BacklogItem::isDraft).count();
+                    var oldest = items.stream().min(Comparator.comparing(BacklogItem::getGithubCreatedAt));
+                    return new RepoSummaryResponse(repo, issues, prs.size(), draftPrs,
+                            oldest.map(BacklogItem::getGithubCreatedAt).orElse(null));
+                })
+                .sorted(Comparator.comparing((RepoSummaryResponse r) -> r.openIssueCount() + r.openPrCount()).reversed())
+                .toList();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/BacklogSyncService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/BacklogSyncService.java
@@ -1,0 +1,99 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.config.BacklogProperties;
+import com.dansplugins.api.entity.BacklogItem;
+import com.dansplugins.api.repository.BacklogItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mirrors open GitHub issues/PRs for the configured org into {@link BacklogItem}
+ * rows, on a fixed schedule (dpc.backlog.sync-interval-ms). GitHub stays the
+ * system of record: a row whose repo/number wasn't seen in the sync just
+ * completed is flipped to CLOSED rather than deleted, so the /dev console never
+ * drifts into showing something GitHub no longer considers open.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BacklogSyncService {
+
+    private final GitHubClient gitHubClient;
+    private final BacklogItemRepository backlogItemRepository;
+    private final BacklogProperties backlogProperties;
+
+    @Scheduled(fixedDelayString = "${dpc.backlog.sync-interval-ms:900000}",
+            initialDelayString = "${dpc.backlog.sync-initial-delay-ms:5000}")
+    @Transactional
+    public void sync() {
+        if (!backlogProperties.syncEnabled()) {
+            return;
+        }
+        Instant syncStartedAt = Instant.now();
+        int upserted = 0;
+        upserted += upsertAll(gitHubClient.openIssues(), BacklogItem.ItemType.ISSUE, syncStartedAt);
+        upserted += upsertAll(gitHubClient.openPullRequests(), BacklogItem.ItemType.PULL_REQUEST, syncStartedAt);
+
+        List<BacklogItem> staleOpenItems =
+                backlogItemRepository.findByStateAndLastSyncedAtBefore(BacklogItem.State.OPEN, syncStartedAt);
+        for (BacklogItem item : staleOpenItems) {
+            item.setState(BacklogItem.State.CLOSED);
+        }
+        backlogItemRepository.saveAll(staleOpenItems);
+
+        log.info("Backlog sync: upserted {} open items, closed {} stale items", upserted, staleOpenItems.size());
+    }
+
+    @SuppressWarnings("unchecked")
+    private int upsertAll(List<Map<String, Object>> rawItems, BacklogItem.ItemType itemType, Instant syncedAt) {
+        int count = 0;
+        for (Map<String, Object> raw : rawItems) {
+            try {
+                upsertOne(raw, itemType, syncedAt);
+                count++;
+            } catch (RuntimeException e) {
+                log.warn("Skipping malformed backlog item {}: {}", raw.get("html_url"), e.getMessage());
+            }
+        }
+        return count;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void upsertOne(Map<String, Object> raw, BacklogItem.ItemType itemType, Instant syncedAt) {
+        String repo = repoFrom((String) raw.get("repository_url"));
+        int number = (Integer) raw.get("number");
+
+        BacklogItem item = backlogItemRepository.findByRepoAndNumber(repo, number)
+                .orElseGet(() -> new BacklogItem(repo, number, itemType));
+
+        item.setItemType(itemType);
+        item.setTitle((String) raw.get("title"));
+        item.setState(BacklogItem.State.OPEN);
+        item.setDraft(Boolean.TRUE.equals(raw.get("draft")));
+        Map<String, Object> user = (Map<String, Object>) raw.get("user");
+        item.setAuthorLogin(user == null ? null : (String) user.get("login"));
+        item.setHtmlUrl((String) raw.get("html_url"));
+        Object comments = raw.get("comments");
+        item.setCommentCount(comments == null ? 0 : (Integer) comments);
+        item.setGithubCreatedAt(Instant.parse((String) raw.get("created_at")));
+        item.setGithubUpdatedAt(Instant.parse((String) raw.get("updated_at")));
+        item.setLastSyncedAt(syncedAt);
+
+        backlogItemRepository.save(item);
+    }
+
+    private String repoFrom(String repositoryUrl) {
+        if (repositoryUrl == null) {
+            throw new IllegalArgumentException("missing repository_url");
+        }
+        String[] parts = repositoryUrl.split("/");
+        return parts[parts.length - 1];
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/GitHubClient.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/GitHubClient.java
@@ -1,0 +1,94 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.config.BacklogProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Thin client for the parts of the GitHub REST API the backlog sync needs: the
+ * Search API, scoped to open issues/PRs in one org. Read-only — nothing here
+ * writes to GitHub (see GitHubIssueClient for that, used by feature-request
+ * conversion).
+ */
+@Service
+@Slf4j
+public class GitHubClient {
+
+    private static final String SEARCH_URL = "https://api.github.com/search/issues";
+    private static final int PER_PAGE = 100;
+    private static final int MAX_PAGES = 5;
+
+    private final RestTemplate restTemplate;
+    private final BacklogProperties properties;
+
+    public GitHubClient(RestTemplateBuilder restTemplateBuilder, BacklogProperties properties) {
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(15))
+                .build();
+        this.properties = properties;
+    }
+
+    /**
+     * All open issues (not PRs) in the configured org, across as many pages as
+     * {@link #MAX_PAGES} allows.
+     */
+    public List<Map<String, Object>> openIssues() {
+        return search("org:" + properties.org() + "+is:issue+is:open");
+    }
+
+    /** All open pull requests in the configured org. */
+    public List<Map<String, Object>> openPullRequests() {
+        return search("org:" + properties.org() + "+is:pr+is:open");
+    }
+
+    private List<Map<String, Object>> search(String query) {
+        List<Map<String, Object>> results = new ArrayList<>();
+        for (int page = 1; page <= MAX_PAGES; page++) {
+            String url = SEARCH_URL + "?q=" + query + "&per_page=" + PER_PAGE + "&page=" + page;
+            List<Map<String, Object>> items = fetchPage(url);
+            if (items.isEmpty()) {
+                break;
+            }
+            results.addAll(items);
+            if (items.size() < PER_PAGE) {
+                break;
+            }
+        }
+        return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> fetchPage(String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/vnd.github+json");
+        headers.set("User-Agent", "dpc-api-backlog-sync");
+        if (properties.githubToken() != null && !properties.githubToken().isBlank()) {
+            headers.setBearerAuth(properties.githubToken());
+        }
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    url, HttpMethod.GET, new HttpEntity<>(headers), Map.class);
+            Map<String, Object> body = response.getBody();
+            if (body == null || body.get("items") == null) {
+                return List.of();
+            }
+            return (List<Map<String, Object>>) body.get("items");
+        } catch (RestClientException e) {
+            log.warn("GitHub search request failed for {}: {}", url, e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -40,3 +40,14 @@ dpc:
       max-deactivation-ratio: ${DPC_SYNC_MAX_DEACTIVATION_RATIO:0.5}
       # Hard absolute cap on factions that one sync may deactivate. 0 disables.
       max-deactivations-per-sync: ${DPC_SYNC_MAX_DEACTIVATIONS:1000}
+  backlog:
+    # GitHub org the dev-portal backlog console mirrors open issues/PRs from.
+    org: ${DPC_BACKLOG_ORG:Dans-Plugins}
+    # Optional classic PAT (no scopes needed — search only reads public data).
+    # Raises the GitHub Search API rate limit from 10/min to 30/min.
+    github-token: ${DPC_BACKLOG_GITHUB_TOKEN:}
+    # How often the sync re-pulls GitHub, in milliseconds. Kept well above the
+    # search API's per-minute rate limit floor.
+    sync-interval-ms: ${DPC_BACKLOG_SYNC_INTERVAL_MS:900000}
+    # Disable in tests/local runs that shouldn't call out to the real GitHub API.
+    sync-enabled: ${DPC_BACKLOG_SYNC_ENABLED:true}

--- a/dpc-api/src/main/resources/db/migration/V12__create_backlog_items_table.sql
+++ b/dpc-api/src/main/resources/db/migration/V12__create_backlog_items_table.sql
@@ -1,0 +1,26 @@
+-- Local mirror of open GitHub issues/PRs across the Dans-Plugins org, refreshed by
+-- the scheduled sync (dev portal backlog console). GitHub stays authoritative for
+-- state; a row flips to 'CLOSED' rather than being deleted when a sync no longer
+-- sees it in the open set.
+
+CREATE TABLE backlog_items (
+    id                UUID PRIMARY KEY,
+    repo              VARCHAR(100) NOT NULL,
+    number            INTEGER      NOT NULL,
+    item_type         VARCHAR(16)  NOT NULL,
+    title             VARCHAR(512) NOT NULL,
+    state             VARCHAR(16)  NOT NULL,
+    draft             BOOLEAN      NOT NULL DEFAULT false,
+    author_login      VARCHAR(100),
+    html_url          VARCHAR(512) NOT NULL,
+    comment_count     INTEGER      NOT NULL DEFAULT 0,
+    github_created_at TIMESTAMPTZ  NOT NULL,
+    github_updated_at TIMESTAMPTZ  NOT NULL,
+    last_synced_at    TIMESTAMPTZ  NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uq_backlog_item UNIQUE (repo, number)
+);
+
+-- Supports the console's per-repo grouping and the public summary aggregation.
+CREATE INDEX idx_backlog_items_repo_state ON backlog_items (repo, state);

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/BacklogControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/BacklogControllerTest.java
@@ -1,0 +1,81 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.entity.BacklogItem;
+import com.dansplugins.api.repository.BacklogItemRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BacklogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BacklogItemRepository backlogItemRepository;
+
+    @BeforeEach
+    void setUp() {
+        backlogItemRepository.deleteAll();
+
+        BacklogItem issue = new BacklogItem("Medieval-Factions", 42, BacklogItem.ItemType.ISSUE);
+        issue.setTitle("A bug");
+        issue.setState(BacklogItem.State.OPEN);
+        issue.setHtmlUrl("https://github.com/Dans-Plugins/Medieval-Factions/issues/42");
+        issue.setGithubCreatedAt(Instant.parse("2023-07-23T10:12:29Z"));
+        issue.setGithubUpdatedAt(Instant.parse("2023-07-23T10:12:29Z"));
+        issue.setLastSyncedAt(Instant.now());
+        backlogItemRepository.save(issue);
+
+        BacklogItem closed = new BacklogItem("Medieval-Factions", 41, BacklogItem.ItemType.ISSUE);
+        closed.setTitle("Already closed");
+        closed.setState(BacklogItem.State.CLOSED);
+        closed.setHtmlUrl("https://github.com/Dans-Plugins/Medieval-Factions/issues/41");
+        closed.setGithubCreatedAt(Instant.parse("2023-07-20T10:12:29Z"));
+        closed.setGithubUpdatedAt(Instant.parse("2023-07-20T10:12:29Z"));
+        closed.setLastSyncedAt(Instant.now());
+        backlogItemRepository.save(closed);
+    }
+
+    @AfterEach
+    void tearDown() {
+        backlogItemRepository.deleteAll();
+    }
+
+    @Test
+    void items_isPublic_andOnlyReturnsOpenItems() throws Exception {
+        mockMvc.perform(get("/api/v1/backlog"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].targetId").value("Medieval-Factions#42"));
+    }
+
+    @Test
+    void items_filteredByRepo() throws Exception {
+        mockMvc.perform(get("/api/v1/backlog").param("repo", "Fiefs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void summary_isPublic_andAggregatesByRepo() throws Exception {
+        mockMvc.perform(get("/api/v1/backlog/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].repo").value("Medieval-Factions"))
+                .andExpect(jsonPath("$[0].openIssueCount").value(1));
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/service/BacklogQueryServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/BacklogQueryServiceTest.java
@@ -1,0 +1,72 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.dto.RepoSummaryResponse;
+import com.dansplugins.api.entity.BacklogItem;
+import com.dansplugins.api.repository.BacklogItemRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BacklogQueryServiceTest {
+
+    @Mock
+    private BacklogItemRepository backlogItemRepository;
+
+    private BacklogQueryService service;
+
+    private static BacklogItem item(String repo, int number, BacklogItem.ItemType type, boolean draft, String createdAt) {
+        BacklogItem item = new BacklogItem(repo, number, type);
+        item.setDraft(draft);
+        item.setGithubCreatedAt(Instant.parse(createdAt));
+        item.setTitle("t");
+        item.setHtmlUrl("https://github.com/Dans-Plugins/" + repo);
+        return item;
+    }
+
+    @Test
+    void summary_groupsByRepo_andCountsIssuesPrsAndDrafts() {
+        service = new BacklogQueryService(backlogItemRepository);
+        when(backlogItemRepository.findByStateOrderByGithubCreatedAtAsc(BacklogItem.State.OPEN)).thenReturn(List.of(
+                item("Medieval-Factions", 1, BacklogItem.ItemType.ISSUE, false, "2024-01-01T00:00:00Z"),
+                item("Medieval-Factions", 2, BacklogItem.ItemType.ISSUE, false, "2023-01-01T00:00:00Z"),
+                item("Medieval-Factions", 3, BacklogItem.ItemType.PULL_REQUEST, true, "2025-01-01T00:00:00Z"),
+                item("Fiefs", 1, BacklogItem.ItemType.PULL_REQUEST, false, "2024-11-22T00:00:00Z")
+        ));
+
+        List<RepoSummaryResponse> summary = service.summary();
+
+        RepoSummaryResponse mf = summary.stream().filter(r -> r.repo().equals("Medieval-Factions")).findFirst().orElseThrow();
+        assertThat(mf.openIssueCount()).isEqualTo(2);
+        assertThat(mf.openPrCount()).isEqualTo(1);
+        assertThat(mf.draftPrCount()).isEqualTo(1);
+        assertThat(mf.oldestOpenItemAt()).isEqualTo(Instant.parse("2023-01-01T00:00:00Z"));
+
+        RepoSummaryResponse fiefs = summary.stream().filter(r -> r.repo().equals("Fiefs")).findFirst().orElseThrow();
+        assertThat(fiefs.openIssueCount()).isZero();
+        assertThat(fiefs.openPrCount()).isEqualTo(1);
+
+        // Biggest backlog first.
+        assertThat(summary.get(0).repo()).isEqualTo("Medieval-Factions");
+    }
+
+    @Test
+    void openItems_withRepoFilter_delegatesToScopedQuery() {
+        service = new BacklogQueryService(backlogItemRepository);
+        BacklogItem mfIssue = item("Medieval-Factions", 9, BacklogItem.ItemType.ISSUE, false, "2024-01-01T00:00:00Z");
+        when(backlogItemRepository.findByRepoAndStateOrderByGithubCreatedAtAsc("Medieval-Factions", BacklogItem.State.OPEN))
+                .thenReturn(List.of(mfIssue));
+
+        var result = service.openItems("Medieval-Factions");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).targetId()).isEqualTo("Medieval-Factions#9");
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/service/BacklogSyncServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/BacklogSyncServiceTest.java
@@ -1,0 +1,130 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.config.BacklogProperties;
+import com.dansplugins.api.entity.BacklogItem;
+import com.dansplugins.api.repository.BacklogItemRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BacklogSyncServiceTest {
+
+    @Mock
+    private GitHubClient gitHubClient;
+
+    @Mock
+    private BacklogItemRepository backlogItemRepository;
+
+    private BacklogSyncService service;
+
+    private static Map<String, Object> rawItem(String repo, int number, String title, boolean draft) {
+        return Map.of(
+                "repository_url", "https://api.github.com/repos/Dans-Plugins/" + repo,
+                "number", number,
+                "title", title,
+                "draft", draft,
+                "user", Map.of("login", "someone"),
+                "html_url", "https://github.com/Dans-Plugins/" + repo + "/issues/" + number,
+                "comments", 2,
+                "created_at", "2025-01-01T00:00:00Z",
+                "updated_at", "2025-06-01T00:00:00Z"
+        );
+    }
+
+    @Test
+    void sync_doesNothing_whenDisabled() {
+        service = new BacklogSyncService(gitHubClient, backlogItemRepository,
+                new BacklogProperties("Dans-Plugins", null, 900000, false));
+
+        service.sync();
+
+        verify(gitHubClient, org.mockito.Mockito.never()).openIssues();
+        verify(gitHubClient, org.mockito.Mockito.never()).openPullRequests();
+    }
+
+    @Test
+    void sync_upsertsNewIssueAsOpen() {
+        service = new BacklogSyncService(gitHubClient, backlogItemRepository,
+                new BacklogProperties("Dans-Plugins", null, 900000, true));
+        when(gitHubClient.openIssues()).thenReturn(List.of(rawItem("Medieval-Factions", 42, "A bug", false)));
+        when(gitHubClient.openPullRequests()).thenReturn(List.of());
+        when(backlogItemRepository.findByRepoAndNumber("Medieval-Factions", 42)).thenReturn(Optional.empty());
+        when(backlogItemRepository.findByStateAndLastSyncedAtBefore(any(), any())).thenReturn(List.of());
+
+        service.sync();
+
+        verify(backlogItemRepository).save(argThatItem(item ->
+                item.getRepo().equals("Medieval-Factions")
+                        && item.getNumber() == 42
+                        && item.getTitle().equals("A bug")
+                        && item.getState() == BacklogItem.State.OPEN
+                        && item.getItemType() == BacklogItem.ItemType.ISSUE));
+    }
+
+    @Test
+    void sync_updatesExistingItem_ratherThanDuplicating() {
+        service = new BacklogSyncService(gitHubClient, backlogItemRepository,
+                new BacklogProperties("Dans-Plugins", null, 900000, true));
+        BacklogItem existing = new BacklogItem("SimpleSkills", 7, BacklogItem.ItemType.ISSUE);
+        when(gitHubClient.openIssues()).thenReturn(List.of(rawItem("SimpleSkills", 7, "Updated title", false)));
+        when(gitHubClient.openPullRequests()).thenReturn(List.of());
+        when(backlogItemRepository.findByRepoAndNumber("SimpleSkills", 7)).thenReturn(Optional.of(existing));
+        when(backlogItemRepository.findByStateAndLastSyncedAtBefore(any(), any())).thenReturn(List.of());
+
+        service.sync();
+
+        assertThat(existing.getTitle()).isEqualTo("Updated title");
+        verify(backlogItemRepository, times(1)).save(existing);
+    }
+
+    @Test
+    void sync_closesItemsNoLongerSeenAsOpen() {
+        service = new BacklogSyncService(gitHubClient, backlogItemRepository,
+                new BacklogProperties("Dans-Plugins", null, 900000, true));
+        when(gitHubClient.openIssues()).thenReturn(List.of());
+        when(gitHubClient.openPullRequests()).thenReturn(List.of());
+        BacklogItem stale = new BacklogItem("Fiefs", 1, BacklogItem.ItemType.ISSUE);
+        stale.setState(BacklogItem.State.OPEN);
+        when(backlogItemRepository.findByStateAndLastSyncedAtBefore(eq(BacklogItem.State.OPEN), any()))
+                .thenReturn(List.of(stale));
+
+        service.sync();
+
+        assertThat(stale.getState()).isEqualTo(BacklogItem.State.CLOSED);
+        verify(backlogItemRepository).saveAll(List.of(stale));
+    }
+
+    @Test
+    void sync_skipsMalformedItem_withoutFailingTheWholeSync() {
+        service = new BacklogSyncService(gitHubClient, backlogItemRepository,
+                new BacklogProperties("Dans-Plugins", null, 900000, true));
+        Map<String, Object> malformed = Map.of("repository_url", "https://api.github.com/repos/Dans-Plugins/X");
+        Map<String, Object> good = rawItem("Fiefs", 5, "Fine", false);
+        when(gitHubClient.openIssues()).thenReturn(List.of(malformed, good));
+        when(gitHubClient.openPullRequests()).thenReturn(List.of());
+        when(backlogItemRepository.findByRepoAndNumber("Fiefs", 5)).thenReturn(Optional.empty());
+        when(backlogItemRepository.findByStateAndLastSyncedAtBefore(any(), any())).thenReturn(List.of());
+
+        service.sync();
+
+        verify(backlogItemRepository, times(1)).save(any(BacklogItem.class));
+    }
+
+    private static BacklogItem argThatItem(java.util.function.Predicate<BacklogItem> predicate) {
+        return org.mockito.ArgumentMatchers.argThat(predicate::test);
+    }
+}

--- a/dpc-api/src/test/resources/application-test.yml
+++ b/dpc-api/src/test/resources/application-test.yml
@@ -22,3 +22,8 @@ dpc:
       minimum-incoming-factions: 1
       max-deactivation-ratio: 0.5
       max-deactivations-per-sync: 1000
+  backlog:
+    org: Dans-Plugins
+    # Tests exercise BacklogSyncService directly; the scheduled trigger must not
+    # also fire and make real calls out to the GitHub API.
+    sync-enabled: false

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -1,0 +1,291 @@
+import {
+    Alert,
+    Box,
+    Card,
+    CardContent,
+    Chip,
+    Container,
+    MenuItem,
+    Skeleton,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TextField,
+    Typography,
+} from '@mui/material'
+import BugReportIcon from '@mui/icons-material/BugReport'
+import type {NextPage} from 'next'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import TopBar from '../../components/TopBar'
+import Seo from '../../components/Seo'
+import BottomBar from '../../components/BottomBar'
+import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles'
+import {relativeTimeFrom} from '../../utils/relativeTime'
+import {getBacklogItems, getBacklogSummary, BacklogItem, RepoSummary} from '../../services/backlogService'
+
+const version = require('../../package.json').version
+
+const signalFor = (summary: RepoSummary): { label: string; color: 'success' | 'warning' | 'error' | 'default' } => {
+    const total = summary.openIssueCount + summary.openPrCount
+    if (total === 0) {
+        return {label: 'Quiet', color: 'default'}
+    }
+    const ageDays = summary.oldestOpenItemAt
+        ? (Date.now() - new Date(summary.oldestOpenItemAt).getTime()) / 86_400_000
+        : 0
+    if (ageDays > 365 * 2) {
+        return {label: 'Stale', color: 'error'}
+    }
+    if (summary.openPrCount > 0 && summary.draftPrCount === summary.openPrCount) {
+        return {label: 'Automation backlog', color: 'warning'}
+    }
+    if (summary.openIssueCount > 0 && summary.openPrCount === 0) {
+        return {label: 'Needs triage', color: 'warning'}
+    }
+    return {label: 'Active', color: 'success'}
+}
+
+const DevPortalPage: NextPage = () => {
+    const [summary, setSummary] = useState<RepoSummary[]>([])
+    const [items, setItems] = useState<BacklogItem[]>([])
+    const [repoFilter, setRepoFilter] = useState('')
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+
+    const load = useCallback(async () => {
+        setLoading(true)
+        setError(null)
+        try {
+            const [summaryData, itemData] = await Promise.all([getBacklogSummary(), getBacklogItems()])
+            setSummary(summaryData)
+            setItems(itemData)
+            if (summaryData.length === 0 && itemData.length === 0) {
+                setError('No backlog data yet — the sync runs on a schedule and may not have completed its first pass.')
+            }
+        } catch (e) {
+            console.error('Failed to load backlog data:', e)
+            setError('We couldn’t load the backlog right now. Please try again later.')
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        load()
+    }, [load])
+
+    const visibleItems = useMemo(
+        () => (repoFilter ? items.filter((item) => item.repo === repoFilter) : items),
+        [items, repoFilter]
+    )
+
+    return (
+        <Box sx={(theme) => pageStyle(theme)}>
+            <Seo title="Developer Portal" description="Cross-repo GitHub issue/PR backlog for everyone building on Dan's Plugins."/>
+            <TopBar/>
+            <Container component="main" id="main" maxWidth="lg" sx={(theme) => containerPaddingStyle(theme)}>
+                <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                    Developer Portal
+                </Typography>
+                <Typography variant="body1" gutterBottom color="text.secondary" sx={{mb: 3}}>
+                    Every open issue and pull request across the Dans-Plugins GitHub org, mirrored here so the
+                    state of each plugin is a glance instead of a dozen tabs. GitHub stays the source of truth —
+                    this view refreshes on a schedule and never writes back.
+                </Typography>
+
+                {error && (
+                    <Alert severity="info" sx={{mb: 2}}>
+                        {error}
+                    </Alert>
+                )}
+
+                <Typography variant="h6" component="h2" gutterBottom>
+                    By repository
+                </Typography>
+                <Card sx={{mb: 4}}>
+                    <CardContent sx={{p: 0, '&:last-child': {pb: 0}}}>
+                        <TableContainer>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow
+                                        sx={{
+                                            '& th': {
+                                                bgcolor: 'action.hover',
+                                                borderBottom: 2,
+                                                borderColor: 'divider',
+                                                fontWeight: 600,
+                                                fontSize: '0.72rem',
+                                                textTransform: 'uppercase',
+                                                letterSpacing: '0.07em',
+                                                color: 'text.secondary',
+                                            },
+                                        }}
+                                    >
+                                        <TableCell>Repo</TableCell>
+                                        <TableCell align="right">Issues</TableCell>
+                                        <TableCell align="right">PRs (draft)</TableCell>
+                                        <TableCell>Oldest open item</TableCell>
+                                        <TableCell>Signal</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {loading ? (
+                                        Array.from({length: 5}).map((_, i) => (
+                                            <TableRow key={i}>
+                                                <TableCell><Skeleton width={140}/></TableCell>
+                                                <TableCell align="right"><Skeleton width={30}/></TableCell>
+                                                <TableCell align="right"><Skeleton width={50}/></TableCell>
+                                                <TableCell><Skeleton width={100}/></TableCell>
+                                                <TableCell><Skeleton width={90}/></TableCell>
+                                            </TableRow>
+                                        ))
+                                    ) : (
+                                        summary.map((row) => {
+                                            const signal = signalFor(row)
+                                            return (
+                                                <TableRow
+                                                    key={row.repo}
+                                                    hover
+                                                    selected={repoFilter === row.repo}
+                                                    onClick={() => setRepoFilter(repoFilter === row.repo ? '' : row.repo)}
+                                                    sx={{cursor: 'pointer'}}
+                                                >
+                                                    <TableCell>
+                                                        <Typography fontWeight={600}>{row.repo}</Typography>
+                                                    </TableCell>
+                                                    <TableCell align="right">{row.openIssueCount}</TableCell>
+                                                    <TableCell align="right">
+                                                        {row.openPrCount}
+                                                        {row.draftPrCount > 0 && (
+                                                            <Typography component="span" color="text.secondary">
+                                                                {' '}({row.draftPrCount})
+                                                            </Typography>
+                                                        )}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        {row.oldestOpenItemAt
+                                                            ? relativeTimeFrom(row.oldestOpenItemAt, Date.now())
+                                                            : '—'}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Chip label={signal.label} size="small" color={signal.color}/>
+                                                    </TableCell>
+                                                </TableRow>
+                                            )
+                                        })
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    </CardContent>
+                </Card>
+
+                <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{mb: 2}}>
+                    <Typography variant="h6" component="h2">
+                        Open items {repoFilter && `— ${repoFilter}`}
+                    </Typography>
+                    <TextField
+                        select
+                        size="small"
+                        label="Repo"
+                        value={repoFilter}
+                        onChange={(e) => setRepoFilter(e.target.value)}
+                        sx={{minWidth: 220}}
+                    >
+                        <MenuItem value="">All repos</MenuItem>
+                        {summary.map((row) => (
+                            <MenuItem key={row.repo} value={row.repo}>{row.repo}</MenuItem>
+                        ))}
+                    </TextField>
+                </Stack>
+
+                <Card>
+                    <CardContent sx={{p: 0, '&:last-child': {pb: 0}}}>
+                        <TableContainer>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow
+                                        sx={{
+                                            '& th': {
+                                                bgcolor: 'action.hover',
+                                                borderBottom: 2,
+                                                borderColor: 'divider',
+                                                fontWeight: 600,
+                                                fontSize: '0.72rem',
+                                                textTransform: 'uppercase',
+                                                letterSpacing: '0.07em',
+                                                color: 'text.secondary',
+                                            },
+                                        }}
+                                    >
+                                        <TableCell>Item</TableCell>
+                                        <TableCell>Type</TableCell>
+                                        <TableCell>Opened</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {loading ? (
+                                        Array.from({length: 6}).map((_, i) => (
+                                            <TableRow key={i}>
+                                                <TableCell><Skeleton width={320}/></TableCell>
+                                                <TableCell><Skeleton width={80}/></TableCell>
+                                                <TableCell><Skeleton width={90}/></TableCell>
+                                            </TableRow>
+                                        ))
+                                    ) : visibleItems.length === 0 ? (
+                                        <TableRow>
+                                            <TableCell colSpan={3} align="center" sx={{py: 4}}>
+                                                <Typography color="text.secondary">
+                                                    Nothing open here right now.
+                                                </Typography>
+                                            </TableCell>
+                                        </TableRow>
+                                    ) : (
+                                        visibleItems.map((item) => (
+                                            <TableRow key={item.targetId} hover>
+                                                <TableCell>
+                                                    <Typography
+                                                        component="a"
+                                                        href={item.htmlUrl}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        color="inherit"
+                                                    >
+                                                        {item.repo} #{item.number} — {item.title}
+                                                    </Typography>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Chip
+                                                        size="small"
+                                                        variant="outlined"
+                                                        icon={item.itemType === 'ISSUE' ? <BugReportIcon/> : undefined}
+                                                        label={
+                                                            item.itemType === 'ISSUE'
+                                                                ? 'Issue'
+                                                                : item.draft ? 'Draft PR' : 'PR'
+                                                        }
+                                                        color={item.itemType === 'PULL_REQUEST' && item.draft ? 'warning' : 'default'}
+                                                    />
+                                                </TableCell>
+                                                <TableCell>
+                                                    {relativeTimeFrom(item.githubCreatedAt, Date.now())}
+                                                </TableCell>
+                                            </TableRow>
+                                        ))
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    </CardContent>
+                </Card>
+            </Container>
+            <BottomBar version={version}/>
+        </Box>
+    )
+}
+
+export default DevPortalPage

--- a/services/backlogService.ts
+++ b/services/backlogService.ts
@@ -1,0 +1,48 @@
+// Client-side calls to the dpc-api dev-portal backlog endpoints — a read-only
+// mirror of open GitHub issues/PRs across the Dans-Plugins org.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+
+export interface BacklogItem {
+    repo: string;
+    number: number;
+    targetId: string;
+    itemType: 'ISSUE' | 'PULL_REQUEST';
+    title: string;
+    draft: boolean;
+    authorLogin: string | null;
+    htmlUrl: string;
+    commentCount: number;
+    githubCreatedAt: string;
+    githubUpdatedAt: string;
+}
+
+export interface RepoSummary {
+    repo: string;
+    openIssueCount: number;
+    openPrCount: number;
+    draftPrCount: number;
+    oldestOpenItemAt: string | null;
+}
+
+/** Open issues/PRs, optionally scoped to one repo. */
+export const getBacklogItems = async (repo?: string): Promise<BacklogItem[]> => {
+    try {
+        const url = repo
+            ? `${API_BASE}/api/v1/backlog?repo=${encodeURIComponent(repo)}`
+            : `${API_BASE}/api/v1/backlog`;
+        const res = await fetch(url);
+        return res.ok ? await res.json() : [];
+    } catch {
+        return [];
+    }
+};
+
+/** Per-repo backlog rollup, sorted largest-first. */
+export const getBacklogSummary = async (): Promise<RepoSummary[]> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/backlog/summary`);
+        return res.ok ? await res.json() : [];
+    } catch {
+        return [];
+    }
+};


### PR DESCRIPTION
## Summary
First phase of the developer-portal plan (see the backlog-console pitch): a read-only mirror of every open GitHub issue/PR across the Dans-Plugins org, so the state of the ecosystem is a glance instead of a dozen tabs.

- `GitHubClient` — calls the GitHub Search API for open issues/PRs in the org (works unauthenticated at a lower rate limit; set `DPC_BACKLOG_GITHUB_TOKEN` to raise it — no scopes needed, it's public data).
- `BacklogSyncService` — scheduled sync (`dpc.backlog.sync-interval-ms`, default 15 min) upserts into a new `backlog_items` table. GitHub stays the system of record: an item not seen in a sync flips to `CLOSED` rather than being deleted.
- `GET /api/v1/backlog` / `/api/v1/backlog/summary` — public read endpoints (the data's already public on GitHub).
- `/dev` — new page: a per-repo rollup (issues, PRs/drafts, oldest open item, a signal chip) plus a filterable flat list of open items.

## Why
Right now checking the backlog across ~17 active repos means opening that many tabs. This makes it one page, and is the foundation the next three PRs in this stack build on (splash chooser + "interested" voting, self-claim, feature-request intake).

## Test plan
- [x] `./mvnw test` — 129 tests, 0 failures (`FlywayMigrationTest` skips without Docker, as it does today on `main`)
- [x] `npm run lint` — clean
- [x] `npm test` — 81 tests, 0 failures
- [x] `npm run build` — compiles, `/dev` renders at 4.88 kB
- [ ] Not verified: the scheduled sync's behavior against a real GitHub API response in a running instance (sandbox has no outbound network for a live check) — the parsing logic is covered by `BacklogSyncServiceTest` against realistic fixture payloads instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_