### PR TITLE
Dev portal 2/4: first-visit experience splash + "interested" voting

### DIFF
--- a/__tests__/experience.test.ts
+++ b/__tests__/experience.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { hasChosenExperience } from '../utils/experience';
+
+describe('hasChosenExperience', () => {
+    it('is true once the visitor has dismissed or acted on the splash', () => {
+        expect(hasChosenExperience('true')).toBe(true);
+    });
+
+    it('is false when nothing is stored yet', () => {
+        expect(hasChosenExperience(null)).toBe(false);
+    });
+
+    it('is false for any unrecognised value', () => {
+        expect(hasChosenExperience('false')).toBe(false);
+        expect(hasChosenExperience('')).toBe(false);
+        expect(hasChosenExperience('yes')).toBe(false);
+    });
+});

--- a/components/ExperienceSplash.tsx
+++ b/components/ExperienceSplash.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {Box, Button, Dialog, DialogContent, Stack, Typography} from '@mui/material';
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+import CodeIcon from '@mui/icons-material/Code';
+
+interface ExperienceChoiceProps {
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    onClick: () => void;
+}
+
+const ExperienceChoice: React.FC<ExperienceChoiceProps> = ({icon, title, description, onClick}) => (
+    <Button
+        onClick={onClick}
+        variant="outlined"
+        sx={{
+            flex: 1,
+            p: 3,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 1,
+            textTransform: 'none',
+            height: '100%',
+        }}
+    >
+        <Box sx={{fontSize: 40, display: 'flex'}}>{icon}</Box>
+        <Typography variant="h6" component="span">{title}</Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+            {description}
+        </Typography>
+    </Button>
+);
+
+interface ExperienceSplashProps {
+    open: boolean;
+    onChoosePlayer: () => void;
+    onChooseDeveloper: () => void;
+}
+
+/**
+ * First-visit choice between the plugin catalogue and the developer portal.
+ * Dismissing without choosing (backdrop click / Escape) is treated the same
+ * as "I run a server" — the common case — rather than trapping the visitor.
+ */
+const ExperienceSplash: React.FC<ExperienceSplashProps> = ({open, onChoosePlayer, onChooseDeveloper}) => (
+    <Dialog open={open} onClose={onChoosePlayer} maxWidth="sm" fullWidth>
+        <DialogContent sx={{p: 4}}>
+            <Typography variant="h5" component="h2" gutterBottom textAlign="center" sx={{mb: 1}}>
+                Welcome to Dan&apos;s Plugins Community
+            </Typography>
+            <Typography variant="body2" color="text.secondary" textAlign="center" sx={{mb: 3}}>
+                What brings you here?
+            </Typography>
+            <Stack direction={{xs: 'column', sm: 'row'}} spacing={2}>
+                <ExperienceChoice
+                    icon={<SportsEsportsIcon fontSize="inherit"/>}
+                    title="I run a server"
+                    description="Browse and install plugins for your Minecraft server."
+                    onClick={onChoosePlayer}
+                />
+                <ExperienceChoice
+                    icon={<CodeIcon fontSize="inherit"/>}
+                    title="I build plugins"
+                    description="See what's open across every repo and pitch in."
+                    onClick={onChooseDeveloper}
+                />
+            </Stack>
+            <Typography variant="caption" color="text.secondary" display="block" textAlign="center" sx={{mt: 2}}>
+                You can switch anytime from the Dev Portal link in the top navigation.
+            </Typography>
+        </DialogContent>
+    </Dialog>
+);
+
+export default ExperienceSplash;

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/LikeRequest.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/LikeRequest.java
@@ -4,15 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-@Schema(description = "A like target: a plugin or guide, keyed by the plugin id")
+@Schema(description = "A like target: a plugin, guide, or backlog issue/PR")
 public record LikeRequest(
         @NotBlank(message = "targetType is required")
-        @Schema(description = "'plugin' or 'guide'", example = "plugin")
+        @Schema(description = "'plugin', 'guide', or 'issue'", example = "plugin")
         String targetType,
 
         @NotBlank(message = "targetId is required")
         @Size(max = 64)
-        @Schema(description = "The plugin id from plugins.json", example = "medieval-factions")
+        @Schema(description = "The plugin id from plugins.json, or 'repo#number' for an 'issue' target",
+                example = "medieval-factions")
         String targetId
 ) {
 }

--- a/dpc-api/src/main/java/com/dansplugins/api/service/LikeService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/LikeService.java
@@ -13,15 +13,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Likes on plugins and guides. A like is idempotent (the unique constraint on
- * {@code (user, target_type, target_id)} means liking twice is a no-op), and
- * counts are public. Targets are keyed by the plugin id from plugins.json.
+ * Likes on plugins, guides, and — for the dev portal — backlog issues/PRs
+ * ("interested", keyed by {@code repo#number}). A like is idempotent (the
+ * unique constraint on {@code (user, target_type, target_id)} means liking
+ * twice is a no-op), and counts are public.
  */
 @Service
 @RequiredArgsConstructor
 public class LikeService {
 
-    static final Set<String> ALLOWED_TYPES = Set.of("plugin", "guide");
+    static final Set<String> ALLOWED_TYPES = Set.of("plugin", "guide", "issue");
 
     private final LikeRepository likeRepository;
 

--- a/dpc-api/src/test/java/com/dansplugins/api/service/LikeServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/LikeServiceTest.java
@@ -49,6 +49,15 @@ class LikeServiceTest {
     }
 
     @Test
+    void like_issueTargetType_isAllowed_forDevPortalInterest() {
+        when(likeRepository.existsByUserAndTargetTypeAndTargetId(user, "issue", "Fiefs#136")).thenReturn(false);
+        when(likeRepository.countByTargetTypeAndTargetId("issue", "Fiefs#136")).thenReturn(1L);
+
+        assertThat(likeService.like(user, "issue", "Fiefs#136")).isEqualTo(1L);
+        verify(likeRepository).save(any(Like.class));
+    }
+
+    @Test
     void like_invalidType_throws() {
         assertThatThrownBy(() -> likeService.like(user, "bogus", "mf"))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -23,9 +23,11 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import TopBar from '../../components/TopBar'
 import Seo from '../../components/Seo'
 import BottomBar from '../../components/BottomBar'
+import LikeButton from '../../components/LikeButton'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles'
 import {relativeTimeFrom} from '../../utils/relativeTime'
 import {getBacklogItems, getBacklogSummary, BacklogItem, RepoSummary} from '../../services/backlogService'
+import {getLikeCounts, getMyLikes} from '../../services/likeService'
 
 const version = require('../../package.json').version
 
@@ -55,6 +57,9 @@ const DevPortalPage: NextPage = () => {
     const [repoFilter, setRepoFilter] = useState('')
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [interestCounts, setInterestCounts] = useState<Record<string, number>>({})
+    const [interestedSet, setInterestedSet] = useState<Set<string>>(new Set())
+    const [token, setToken] = useState<string | null>(null)
 
     const load = useCallback(async () => {
         setLoading(true)
@@ -77,6 +82,16 @@ const DevPortalPage: NextPage = () => {
     useEffect(() => {
         load()
     }, [load])
+
+    useEffect(() => {
+        getLikeCounts('issue').then(setInterestCounts)
+        const saved = window.localStorage.getItem('dpc-token')
+        setToken(saved)
+        if (saved) {
+            getMyLikes(saved).then((likes) =>
+                setInterestedSet(new Set(likes.filter((l) => l.targetType === 'issue').map((l) => l.targetId))))
+        }
+    }, [])
 
     const visibleItems = useMemo(
         () => (repoFilter ? items.filter((item) => item.repo === repoFilter) : items),
@@ -225,6 +240,7 @@ const DevPortalPage: NextPage = () => {
                                         <TableCell>Item</TableCell>
                                         <TableCell>Type</TableCell>
                                         <TableCell>Opened</TableCell>
+                                        <TableCell align="center">Interested</TableCell>
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
@@ -234,11 +250,12 @@ const DevPortalPage: NextPage = () => {
                                                 <TableCell><Skeleton width={320}/></TableCell>
                                                 <TableCell><Skeleton width={80}/></TableCell>
                                                 <TableCell><Skeleton width={90}/></TableCell>
+                                                <TableCell><Skeleton width={50}/></TableCell>
                                             </TableRow>
                                         ))
                                     ) : visibleItems.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={3} align="center" sx={{py: 4}}>
+                                            <TableCell colSpan={4} align="center" sx={{py: 4}}>
                                                 <Typography color="text.secondary">
                                                     Nothing open here right now.
                                                 </Typography>
@@ -273,6 +290,15 @@ const DevPortalPage: NextPage = () => {
                                                 </TableCell>
                                                 <TableCell>
                                                     {relativeTimeFrom(item.githubCreatedAt, Date.now())}
+                                                </TableCell>
+                                                <TableCell align="center">
+                                                    <LikeButton
+                                                        targetType="issue"
+                                                        targetId={item.targetId}
+                                                        count={interestCounts[item.targetId] || 0}
+                                                        liked={interestedSet.has(item.targetId)}
+                                                        token={token}
+                                                    />
                                                 </TableCell>
                                             </TableRow>
                                         ))

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,16 +2,19 @@ import {Box, Container, Grid, IconButton, InputAdornment, TextField, Typography,
 import SearchIcon from '@mui/icons-material/Search'
 import ClearIcon from '@mui/icons-material/Clear'
 import type {NextPage} from 'next'
+import {useRouter} from 'next/router'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
 import Blurb from '../components/Blurb'
 import PluginCard from '../components/PluginCard'
+import ExperienceSplash from '../components/ExperienceSplash'
 import React from 'react';
 import BottomBar from '../components/BottomBar'
 import { getVisits, incrementVisits } from '../services/visitService';
 import { getServerCountsWithRateLimit } from '../utils/bstats';
 import { getLikeCounts, getMyLikes } from '../services/likeService';
 import { sortPlugins, type SortOption } from '../utils/sortPlugins';
+import { EXPERIENCE_CHOSEN_KEY, hasChosenExperience } from '../utils/experience';
 
 interface PluginData {
     mostPopular: string[];
@@ -227,10 +230,33 @@ export const getServerSideProps = async () => {
 };
 
 const Home: NextPage<HomeProps> = ({ visits, startDate, pluginsWithCounts }) => {
+    const router = useRouter();
+    // Starts closed on both server and first client render (no hydration
+    // mismatch — same pattern TopBar uses for its signed-in state), then opens
+    // after mount if this visitor hasn't made a choice yet.
+    const [showSplash, setShowSplash] = React.useState(false);
+
+    React.useEffect(() => {
+        const stored = window.localStorage.getItem(EXPERIENCE_CHOSEN_KEY);
+        setShowSplash(!hasChosenExperience(stored));
+    }, []);
+
+    const dismissSplash = () => {
+        window.localStorage.setItem(EXPERIENCE_CHOSEN_KEY, 'true');
+        setShowSplash(false);
+    };
+
+    const chooseDeveloper = () => {
+        window.localStorage.setItem(EXPERIENCE_CHOSEN_KEY, 'true');
+        setShowSplash(false);
+        router.push('/dev');
+    };
+
     return (
         <Box sx={pageStyle}>
             <Seo/>
             <TopBar/>
+            <ExperienceSplash open={showSplash} onChoosePlayer={dismissSplash} onChooseDeveloper={chooseDeveloper}/>
             <Container component="main" id="main" maxWidth="xl" sx={{py: 4}}>
                 <Blurb/>
                 <SectionDivider/>

--- a/services/likeService.ts
+++ b/services/likeService.ts
@@ -2,7 +2,7 @@
 // public API the leaderboard/account pages use.
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
 
-export type LikeTargetType = 'plugin' | 'guide';
+export type LikeTargetType = 'plugin' | 'guide' | 'issue';
 
 export interface LikedTarget {
     targetType: LikeTargetType;

--- a/utils/experience.ts
+++ b/utils/experience.ts
@@ -1,0 +1,7 @@
+// localStorage key marking that the visitor has already dismissed (or acted on)
+// the first-visit "I run a server" / "I build plugins" splash, so it doesn't
+// reappear on later visits. Kept pure (no window access) so the check is
+// unit-testable.
+export const EXPERIENCE_CHOSEN_KEY = 'dpc-experience-chosen';
+
+export const hasChosenExperience = (stored: string | null): boolean => stored === 'true';


### PR DESCRIPTION
## Summary
Stacked on #231. Second phase of the dev-portal plan.

- `ExperienceSplash` — shown once per visitor on `/`: "I run a server" (dismiss, stay on the plugin catalogue) vs "I build plugins" (go to `/dev`). Remembered via a `dpc-experience-chosen` localStorage flag so it never reappears; backdrop/Escape dismiss counts as "I run a server" rather than trapping the visitor. The "Dev Portal" nav link from #231 remains the way to switch anytime after that — deliberately *not* a permanent redirect on `/`, since that would fight with the "Home" nav link.
- Extends the existing like mechanism to a third target type, `issue` (keyed `repo#number`) — one line in `LikeService.ALLOWED_TYPES`, no new backend concept. The `/dev` item list gets an "Interested" column reusing the same `LikeButton` already used for plugins/guides.

## Why
This is the "users are a thing now" half of the ask: reuse what already shipped (login + likes) instead of building a parallel voting system, and let the splash be a light touch rather than gating the whole site behind a choice.

## Test plan
- [x] `./mvnw test` — 130 tests, 0 failures (1 skip, same as `main`)
- [x] `npm run lint` — clean
- [x] `npm test` — 84 tests, 0 failures
- [x] `npm run build` — compiles; `/` and `/dev` both render
- [ ] Not manually clicked through in a browser (sandbox has no browser) — logic covered by `experience.test.ts` and the existing `LikeButton`/`likeService` test coverage instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_