### PR TITLE
Dev portal 3/4: self-claim ("I'm working on this") with 30-day auto-release

### DIFF
--- a/__tests__/claimService.test.ts
+++ b/__tests__/claimService.test.ts
@@ -1,0 +1,79 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {claimItem, getActiveClaims, getMyClaims, releaseItem} from '../services/claimService';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+const rejectFetch = () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getActiveClaims', () => {
+    it('returns the claims on a 200 response', async () => {
+        const claims = [{repo: 'Fiefs', number: 136, targetId: 'Fiefs#136', claimantUsername: 'alice', claimedAt: '2026-01-01T00:00:00Z'}];
+        stubFetch({ok: true, json: async () => claims});
+        expect(await getActiveClaims()).toEqual(claims);
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500});
+        expect(await getActiveClaims()).toEqual([]);
+    });
+
+    it('returns an empty array when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getActiveClaims()).toEqual([]);
+    });
+});
+
+describe('getMyClaims', () => {
+    it('sends the bearer token', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => []} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getMyClaims('my-token');
+        expect(fetchMock.mock.calls[0][1]).toMatchObject({headers: {Authorization: 'Bearer my-token'}});
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 401});
+        expect(await getMyClaims('token')).toEqual([]);
+    });
+});
+
+describe('claimItem / releaseItem', () => {
+    it('resolves ok:true with the claim on a successful claim', async () => {
+        const claim = {repo: 'Fiefs', number: 136, targetId: 'Fiefs#136', claimantUsername: 'alice', claimedAt: '2026-01-01T00:00:00Z'};
+        stubFetch({ok: true, json: async () => claim});
+        expect(await claimItem('token', 'Fiefs', 136)).toEqual({ok: true, claim});
+    });
+
+    it('resolves ok:true with no claim on a successful release', async () => {
+        stubFetch({ok: true, status: 204});
+        expect(await releaseItem('token', 'Fiefs', 136)).toEqual({ok: true});
+    });
+
+    it('resolves ok:false with the server detail message on conflict', async () => {
+        stubFetch({ok: false, status: 409, json: async () => ({detail: 'Already claimed by bob'})});
+        expect(await claimItem('token', 'Fiefs', 136)).toEqual({ok: false, message: 'Already claimed by bob'});
+    });
+
+    it('resolves ok:false with a generic message when the error body is not JSON', async () => {
+        stubFetch({ok: false, status: 500, json: async () => { throw new Error('not json'); }});
+        expect(await claimItem('token', 'Fiefs', 136)).toEqual({ok: false, message: 'Request failed (HTTP 500)'});
+    });
+
+    it('resolves ok:false when fetch rejects', async () => {
+        rejectFetch();
+        expect(await claimItem('token', 'Fiefs', 136)).toEqual({ok: false, message: 'Network error — please try again.'});
+    });
+});

--- a/components/ClaimButton.tsx
+++ b/components/ClaimButton.tsx
@@ -1,0 +1,96 @@
+import React, {useState} from 'react';
+import {Box, Button, Snackbar, Tooltip, Typography} from '@mui/material';
+import {claimItem, releaseItem} from '../services/claimService';
+import {usernameFromToken} from '../utils/authToken';
+
+interface ClaimButtonProps {
+    repo: string;
+    number: number;
+    // Who currently holds the claim, or null if it's unclaimed.
+    claimantUsername: string | null;
+    token: string | null;
+    // Called after a successful claim/release so the parent can update its map.
+    onChange: (claimantUsername: string | null) => void;
+}
+
+const ClaimButton: React.FC<ClaimButtonProps> = ({repo, number, claimantUsername, token, onChange}) => {
+    const [busy, setBusy] = useState(false);
+    const [notice, setNotice] = useState<{message: string; signIn?: boolean} | null>(null);
+    const currentUsername = usernameFromToken(token);
+    const isMine = claimantUsername !== null && claimantUsername === currentUsername;
+
+    const goSignIn = () => {
+        const returnTo = window.location.pathname + window.location.search;
+        window.location.href = `/account?returnTo=${encodeURIComponent(returnTo)}`;
+    };
+
+    const handleClaim = async () => {
+        if (!token) {
+            setNotice({message: 'Sign in to claim an issue or PR.', signIn: true});
+            return;
+        }
+        if (busy) {
+            return;
+        }
+        setBusy(true);
+        const result = await claimItem(token, repo, number);
+        if (result.ok) {
+            onChange(result.claim?.claimantUsername ?? currentUsername);
+        } else {
+            setNotice({message: result.message});
+        }
+        setBusy(false);
+    };
+
+    const handleRelease = async () => {
+        if (!token || busy) {
+            return;
+        }
+        setBusy(true);
+        const result = await releaseItem(token, repo, number);
+        if (result.ok) {
+            onChange(null);
+        } else {
+            setNotice({message: result.message});
+        }
+        setBusy(false);
+    };
+
+    if (claimantUsername && !isMine) {
+        return (
+            <Tooltip title="Someone's already working on this">
+                <Typography variant="body2" color="text.secondary">
+                    Claimed by {claimantUsername}
+                </Typography>
+            </Tooltip>
+        );
+    }
+
+    return (
+        <>
+            <Box sx={{display: 'inline-flex', alignItems: 'center'}}>
+                {isMine ? (
+                    <Button size="small" variant="outlined" disabled={busy} onClick={handleRelease}>
+                        Release
+                    </Button>
+                ) : (
+                    <Button size="small" variant="text" disabled={busy} onClick={handleClaim}>
+                        I&apos;m working on this
+                    </Button>
+                )}
+            </Box>
+            <Snackbar
+                open={notice !== null}
+                autoHideDuration={4000}
+                onClose={() => setNotice(null)}
+                message={notice?.message}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+                action={notice?.signIn
+                    ? <Button color="secondary" size="small" onClick={goSignIn}>Sign in</Button>
+                    : undefined}
+            />
+        </>
+    );
+};
+
+export default ClaimButton;

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/likes/counts").permitAll()
                         // Backlog console data is a public aggregation of already-public GitHub data
                         .requestMatchers(HttpMethod.GET, "/api/v1/backlog", "/api/v1/backlog/**").permitAll()
+                        // Who's claimed what is shown to every visitor; claiming/releasing requires auth
+                        .requestMatchers(HttpMethod.GET, "/api/v1/claims/active").permitAll()
                         // Public single-user profile (GET /api/v1/profile/{username}). The /me rule
                         // is listed first so the authenticated self-profile (which exposes API keys)
                         // is never served by the public path; the single-segment glob then permits
@@ -88,6 +90,7 @@ public class SecurityConfig {
                         // Profile, likes, and logout require a valid UserAuth token
                         .requestMatchers("/api/v1/profile/**").authenticated()
                         .requestMatchers("/api/v1/likes", "/api/v1/likes/**").authenticated()
+                        .requestMatchers("/api/v1/claims", "/api/v1/claims/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").authenticated()
                         // API key auth for faction writes is enforced by ApiKeyAuthFilter (returns 401
                         // before this authorization layer runs); permitAll here avoids a double-reject.

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/ClaimController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/ClaimController.java
@@ -1,0 +1,67 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.dto.ClaimRequest;
+import com.dansplugins.api.dto.ClaimResponse;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.service.ClaimService;
+import com.dansplugins.api.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * "I'm working on this" claims on backlog issues/PRs — see {@link ClaimService}
+ * for why this is a dpc-api record rather than a native GitHub assignee.
+ */
+@RestController
+@RequestMapping("/api/v1/claims")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Claims", description = "Self-claim backlog issues/PRs")
+public class ClaimController {
+
+    private final UserService userService;
+    private final ClaimService claimService;
+
+    @PostMapping
+    @Operation(summary = "Claim a backlog item", security = @SecurityRequirement(name = "bearerAuth"))
+    public ClaimResponse claim(Principal principal, @Valid @RequestBody ClaimRequest request) {
+        User user = userService.getOrCreate(principal.getName());
+        return ClaimResponse.from(claimService.claim(user, request.repo(), request.number()));
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Release your own claim", security = @SecurityRequirement(name = "bearerAuth"))
+    public void release(Principal principal, @Valid @RequestBody ClaimRequest request) {
+        User user = userService.getOrCreate(principal.getName());
+        claimService.release(user, request.repo(), request.number());
+    }
+
+    @GetMapping("/active")
+    @Operation(summary = "Every currently active claim, across all repos (public)")
+    public List<ClaimResponse> active() {
+        return claimService.activeClaims().stream().map(ClaimResponse::from).toList();
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "The current user's active claims", security = @SecurityRequirement(name = "bearerAuth"))
+    public List<ClaimResponse> mine(Principal principal) {
+        User user = userService.getOrCreate(principal.getName());
+        return claimService.myActiveClaims(user).stream().map(ClaimResponse::from).toList();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/ClaimRequest.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/ClaimRequest.java
@@ -1,0 +1,17 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "A backlog item to claim or release: 'I'm working on this'")
+public record ClaimRequest(
+        @NotBlank(message = "repo is required")
+        @Schema(example = "Medieval-Factions")
+        String repo,
+
+        @Positive(message = "number must be positive")
+        @Schema(example = "1947")
+        int number
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/ClaimResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/ClaimResponse.java
@@ -1,0 +1,25 @@
+package com.dansplugins.api.dto;
+
+import com.dansplugins.api.entity.Claim;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "An active claim on a backlog issue/PR")
+public record ClaimResponse(
+        String repo,
+        int number,
+        String targetId,
+        String claimantUsername,
+        Instant claimedAt
+) {
+    public static ClaimResponse from(Claim claim) {
+        return new ClaimResponse(
+                claim.getRepo(),
+                claim.getNumber(),
+                claim.targetId(),
+                claim.getUser().getUserauthUsername(),
+                claim.getClaimedAt()
+        );
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/entity/Claim.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/entity/Claim.java
@@ -1,0 +1,78 @@
+package com.dansplugins.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A user's claim on a backlog issue/PR — "I'm working on this" — recorded here
+ * rather than as a native GitHub assignee so that claiming never requires
+ * granting a visitor collaborator access to the repo. At most one claim on a
+ * given (repo, number) is active at a time (released_at is null); the
+ * corresponding partial unique index lives in the V13 migration since Hibernate
+ * cannot express a filtered unique constraint declaratively.
+ */
+@Entity
+@Table(name = "claims")
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Claim {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(lombok.AccessLevel.NONE)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private User user;
+
+    @Column(name = "repo", nullable = false, length = 100)
+    @Setter(lombok.AccessLevel.NONE)
+    private String repo;
+
+    @Column(name = "number", nullable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private int number;
+
+    @Column(name = "claimed_at", nullable = false, updatable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private Instant claimedAt;
+
+    @Column(name = "released_at")
+    private Instant releasedAt;
+
+    public Claim(User user, String repo, int number) {
+        this.user = user;
+        this.repo = repo;
+        this.number = number;
+    }
+
+    public String targetId() {
+        return repo + "#" + number;
+    }
+
+    public boolean isActive() {
+        return releasedAt == null;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.claimedAt = Instant.now();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/filter/ApiKeyAuthFilter.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/filter/ApiKeyAuthFilter.java
@@ -37,7 +37,8 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
             // UserAuth bearer token, not an X-API-Key, so they are exempt from this filter.
             "/api/v1/auth/",
             "/api/v1/profile/",
-            "/api/v1/likes"
+            "/api/v1/likes",
+            "/api/v1/claims"
     );
 
     private final ApiKeyService apiKeyService;

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/ClaimRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/ClaimRepository.java
@@ -1,0 +1,27 @@
+package com.dansplugins.api.repository;
+
+import com.dansplugins.api.entity.Claim;
+import com.dansplugins.api.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ClaimRepository extends JpaRepository<Claim, UUID> {
+
+    Optional<Claim> findByRepoAndNumberAndReleasedAtIsNull(String repo, int number);
+
+    /** Fetches the owning user eagerly — callers map straight to a DTO, outside any open session. */
+    @Query("select c from Claim c join fetch c.user where c.releasedAt is null")
+    List<Claim> findActiveWithUser();
+
+    @Query("select c from Claim c join fetch c.user where c.user = :user and c.releasedAt is null")
+    List<Claim> findActiveWithUserByUser(@Param("user") User user);
+
+    /** Active claims older than the cutoff — candidates for auto-release. */
+    List<Claim> findByReleasedAtIsNullAndClaimedAtBefore(Instant cutoff);
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/ClaimService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/ClaimService.java
@@ -1,0 +1,103 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.entity.Claim;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.ClaimRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * "I'm working on this" claims on backlog issues/PRs. A claim never grants
+ * GitHub write access — it's purely a dpc-api record shown on the /dev console
+ * so two people don't unknowingly duplicate the same work, plus a courtesy
+ * auto-release after a period of inactivity so an abandoned claim doesn't
+ * block others indefinitely.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ClaimService {
+
+    private final ClaimRepository claimRepository;
+
+    @Value("${dpc.claims.auto-release-after-days:30}")
+    private int autoReleaseAfterDays;
+
+    /** Claim a target. Idempotent for the same user; conflicts (409) if someone else holds it. */
+    @Transactional
+    public Claim claim(User user, String repo, int number) {
+        Optional<Claim> existing = claimRepository.findByRepoAndNumberAndReleasedAtIsNull(repo, number);
+        if (existing.isPresent()) {
+            Claim current = existing.get();
+            if (sameUser(current.getUser(), user)) {
+                return current;
+            }
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Already claimed by " + current.getUser().getUserauthUsername());
+        }
+        return claimRepository.save(new Claim(user, repo, number));
+    }
+
+    /** Release the caller's own claim. No-op if they don't hold one; 403 if someone else does. */
+    @Transactional
+    public void release(User user, String repo, int number) {
+        Optional<Claim> existing = claimRepository.findByRepoAndNumberAndReleasedAtIsNull(repo, number);
+        if (existing.isEmpty()) {
+            return;
+        }
+        Claim claim = existing.get();
+        if (!sameUser(claim.getUser(), user)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "That claim belongs to someone else");
+        }
+        claim.setReleasedAt(Instant.now());
+        claimRepository.save(claim);
+    }
+
+    // Compares by the UserAuth username rather than the entity id: id is only
+    // populated once persisted, and the two User instances being compared here
+    // (one freshly resolved from the auth token, one lazily loaded off a Claim)
+    // are never the same JPA-managed instance even when they represent the same
+    // person.
+    private boolean sameUser(User a, User b) {
+        return a.getUserauthUsername().equals(b.getUserauthUsername());
+    }
+
+    // Both read paths join-fetch the owning user: the caller (the controller)
+    // maps these straight to a DTO after the transaction has closed, and
+    // open-in-view is disabled, so a lazy `claim.getUser()` there would throw.
+    @Transactional(readOnly = true)
+    public List<Claim> activeClaims() {
+        return claimRepository.findActiveWithUser();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Claim> myActiveClaims(User user) {
+        return claimRepository.findActiveWithUserByUser(user);
+    }
+
+    /** Releases claims idle longer than dpc.claims.auto-release-after-days, once a day. */
+    @Scheduled(cron = "${dpc.claims.auto-release-cron:0 0 3 * * *}")
+    @Transactional
+    public void autoReleaseStaleClaims() {
+        Instant cutoff = Instant.now().minus(Duration.ofDays(autoReleaseAfterDays));
+        List<Claim> stale = claimRepository.findByReleasedAtIsNullAndClaimedAtBefore(cutoff);
+        for (Claim claim : stale) {
+            claim.setReleasedAt(Instant.now());
+        }
+        claimRepository.saveAll(stale);
+        if (!stale.isEmpty()) {
+            log.info("Auto-released {} claims idle more than {} days", stale.size(), autoReleaseAfterDays);
+        }
+    }
+}

--- a/dpc-api/src/main/resources/db/migration/V13__create_claims_table.sql
+++ b/dpc-api/src/main/resources/db/migration/V13__create_claims_table.sql
@@ -1,0 +1,21 @@
+-- "I'm working on this" claims for the dev-portal backlog console (#232). A
+-- claim is a dpc-api record, not a native GitHub assignee — visitors never need
+-- collaborator access to claim something. At most one active (released_at is
+-- null) claim per (repo, number); history (released claims) is kept, not
+-- deleted, so past releases stay auditable.
+
+CREATE TABLE claims (
+    id          UUID PRIMARY KEY,
+    user_id     UUID        NOT NULL REFERENCES users(id),
+    repo        VARCHAR(100) NOT NULL,
+    number      INTEGER      NOT NULL,
+    claimed_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    released_at TIMESTAMPTZ
+);
+
+-- Hibernate's ddl-auto=validate only checks tables/columns, not indexes, so
+-- this filtered uniqueness guard is enforced here and backed up by an
+-- application-level check in ClaimService before insert.
+CREATE UNIQUE INDEX uq_claims_active_target ON claims (repo, number) WHERE released_at IS NULL;
+
+CREATE INDEX idx_claims_user_active ON claims (user_id) WHERE released_at IS NULL;

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ClaimControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ClaimControllerTest.java
@@ -1,0 +1,128 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.repository.ClaimRepository;
+import com.dansplugins.api.repository.UserRepository;
+import com.dansplugins.api.service.UserAuthClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClaimControllerTest {
+
+    private static final String ALICE_BEARER = "Bearer alice-token";
+    private static final String BOB_BEARER = "Bearer bob-token";
+    private static final String CLAIM_FIEFS_136 = "{\"repo\":\"Fiefs\",\"number\":136}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ClaimRepository claimRepository;
+
+    @MockBean
+    private UserAuthClient userAuthClient;
+
+    @BeforeEach
+    void setUp() {
+        claimRepository.deleteAll();
+        userRepository.deleteAll();
+        when(userAuthClient.validate("alice-token")).thenReturn(Optional.of("alice"));
+        when(userAuthClient.validate("bob-token")).thenReturn(Optional.of("bob"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        claimRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void claim_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/claims").contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void claim_thenAppearsInActiveList_publicly() throws Exception {
+        mockMvc.perform(post("/api/v1/claims").header("Authorization", ALICE_BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.claimantUsername").value("alice"));
+
+        // No token — the active list is public.
+        mockMvc.perform(get("/api/v1/claims/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].targetId").value("Fiefs#136"))
+                .andExpect(jsonPath("$[0].claimantUsername").value("alice"));
+    }
+
+    @Test
+    void claim_alreadyHeldBySomeoneElse_returns409() throws Exception {
+        mockMvc.perform(post("/api/v1/claims").header("Authorization", ALICE_BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136)).andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/claims").header("Authorization", BOB_BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void release_bySomeoneElse_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/claims").header("Authorization", ALICE_BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136)).andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/claims").header("Authorization", BOB_BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void release_ownClaim_removesItFromTheActiveList() throws Exception {
+        mockMvc.perform(post("/api/v1/claims").header("Authorization", ALICE_BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136)).andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/claims").header("Authorization", ALICE_BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/claims/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void mine_returnsOnlyTheCallersActiveClaims() throws Exception {
+        mockMvc.perform(post("/api/v1/claims").header("Authorization", ALICE_BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(CLAIM_FIEFS_136)).andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/claims/me").header("Authorization", BOB_BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+
+        mockMvc.perform(get("/api/v1/claims/me").header("Authorization", ALICE_BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].targetId").value("Fiefs#136"));
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/service/ClaimServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/ClaimServiceTest.java
@@ -1,0 +1,123 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.entity.Claim;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.repository.ClaimRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimServiceTest {
+
+    @Mock
+    private ClaimRepository claimRepository;
+
+    private ClaimService claimService;
+
+    private final User alice = new User("alice");
+    private final User bob = new User("bob");
+
+    private ClaimService service() {
+        ClaimService service = new ClaimService(claimRepository);
+        ReflectionTestUtils.setField(service, "autoReleaseAfterDays", 30);
+        return service;
+    }
+
+    @Test
+    void claim_whenUnclaimed_savesANewClaim() {
+        claimService = service();
+        when(claimRepository.findByRepoAndNumberAndReleasedAtIsNull("Fiefs", 136)).thenReturn(Optional.empty());
+        when(claimRepository.save(any(Claim.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Claim result = claimService.claim(alice, "Fiefs", 136);
+
+        assertThat(result.getUser()).isEqualTo(alice);
+        assertThat(result.getRepo()).isEqualTo("Fiefs");
+        assertThat(result.getNumber()).isEqualTo(136);
+    }
+
+    @Test
+    void claim_bySameUserAgain_isIdempotent() {
+        claimService = service();
+        Claim existing = new Claim(alice, "Fiefs", 136);
+        when(claimRepository.findByRepoAndNumberAndReleasedAtIsNull("Fiefs", 136)).thenReturn(Optional.of(existing));
+
+        Claim result = claimService.claim(alice, "Fiefs", 136);
+
+        assertThat(result).isSameAs(existing);
+        verify(claimRepository, never()).save(any(Claim.class));
+    }
+
+    @Test
+    void claim_alreadyHeldBySomeoneElse_throwsConflict() {
+        claimService = service();
+        Claim existing = new Claim(bob, "Fiefs", 136);
+        when(claimRepository.findByRepoAndNumberAndReleasedAtIsNull("Fiefs", 136)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> claimService.claim(alice, "Fiefs", 136))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("bob");
+    }
+
+    @Test
+    void release_ownClaim_setsReleasedAt() {
+        claimService = service();
+        Claim existing = new Claim(alice, "Fiefs", 136);
+        when(claimRepository.findByRepoAndNumberAndReleasedAtIsNull("Fiefs", 136)).thenReturn(Optional.of(existing));
+
+        claimService.release(alice, "Fiefs", 136);
+
+        assertThat(existing.getReleasedAt()).isNotNull();
+        verify(claimRepository).save(existing);
+    }
+
+    @Test
+    void release_someoneElsesClaim_throwsForbidden() {
+        claimService = service();
+        Claim existing = new Claim(bob, "Fiefs", 136);
+        when(claimRepository.findByRepoAndNumberAndReleasedAtIsNull("Fiefs", 136)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> claimService.release(alice, "Fiefs", 136))
+                .isInstanceOf(ResponseStatusException.class);
+        verify(claimRepository, never()).save(any(Claim.class));
+    }
+
+    @Test
+    void release_whenNothingClaimed_isANoOp() {
+        claimService = service();
+        when(claimRepository.findByRepoAndNumberAndReleasedAtIsNull("Fiefs", 136)).thenReturn(Optional.empty());
+
+        claimService.release(alice, "Fiefs", 136);
+
+        verify(claimRepository, never()).save(any(Claim.class));
+    }
+
+    @Test
+    void autoReleaseStaleClaims_releasesEverythingPastTheCutoff() {
+        claimService = service();
+        Claim stale = new Claim(alice, "Fiefs", 136);
+        when(claimRepository.findByReleasedAtIsNullAndClaimedAtBefore(any(Instant.class)))
+                .thenReturn(List.of(stale));
+
+        claimService.autoReleaseStaleClaims();
+
+        assertThat(stale.getReleasedAt()).isNotNull();
+        verify(claimRepository, times(1)).saveAll(List.of(stale));
+    }
+}

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -24,10 +24,12 @@ import TopBar from '../../components/TopBar'
 import Seo from '../../components/Seo'
 import BottomBar from '../../components/BottomBar'
 import LikeButton from '../../components/LikeButton'
+import ClaimButton from '../../components/ClaimButton'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles'
 import {relativeTimeFrom} from '../../utils/relativeTime'
 import {getBacklogItems, getBacklogSummary, BacklogItem, RepoSummary} from '../../services/backlogService'
 import {getLikeCounts, getMyLikes} from '../../services/likeService'
+import {getActiveClaims} from '../../services/claimService'
 
 const version = require('../../package.json').version
 
@@ -59,6 +61,7 @@ const DevPortalPage: NextPage = () => {
     const [error, setError] = useState<string | null>(null)
     const [interestCounts, setInterestCounts] = useState<Record<string, number>>({})
     const [interestedSet, setInterestedSet] = useState<Set<string>>(new Set())
+    const [claimants, setClaimants] = useState<Record<string, string>>({})
     const [token, setToken] = useState<string | null>(null)
 
     const load = useCallback(async () => {
@@ -91,7 +94,21 @@ const DevPortalPage: NextPage = () => {
             getMyLikes(saved).then((likes) =>
                 setInterestedSet(new Set(likes.filter((l) => l.targetType === 'issue').map((l) => l.targetId))))
         }
+        getActiveClaims().then((claims) =>
+            setClaimants(Object.fromEntries(claims.map((c) => [c.targetId, c.claimantUsername]))))
     }, [])
+
+    const setClaimant = (targetId: string, claimantUsername: string | null) => {
+        setClaimants((prev) => {
+            const next = {...prev}
+            if (claimantUsername) {
+                next[targetId] = claimantUsername
+            } else {
+                delete next[targetId]
+            }
+            return next
+        })
+    }
 
     const visibleItems = useMemo(
         () => (repoFilter ? items.filter((item) => item.repo === repoFilter) : items),
@@ -241,6 +258,7 @@ const DevPortalPage: NextPage = () => {
                                         <TableCell>Type</TableCell>
                                         <TableCell>Opened</TableCell>
                                         <TableCell align="center">Interested</TableCell>
+                                        <TableCell>Claimed</TableCell>
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
@@ -251,11 +269,12 @@ const DevPortalPage: NextPage = () => {
                                                 <TableCell><Skeleton width={80}/></TableCell>
                                                 <TableCell><Skeleton width={90}/></TableCell>
                                                 <TableCell><Skeleton width={50}/></TableCell>
+                                                <TableCell><Skeleton width={100}/></TableCell>
                                             </TableRow>
                                         ))
                                     ) : visibleItems.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={4} align="center" sx={{py: 4}}>
+                                            <TableCell colSpan={5} align="center" sx={{py: 4}}>
                                                 <Typography color="text.secondary">
                                                     Nothing open here right now.
                                                 </Typography>
@@ -298,6 +317,15 @@ const DevPortalPage: NextPage = () => {
                                                         count={interestCounts[item.targetId] || 0}
                                                         liked={interestedSet.has(item.targetId)}
                                                         token={token}
+                                                    />
+                                                </TableCell>
+                                                <TableCell>
+                                                    <ClaimButton
+                                                        repo={item.repo}
+                                                        number={item.number}
+                                                        claimantUsername={claimants[item.targetId] ?? null}
+                                                        token={token}
+                                                        onChange={(claimantUsername) => setClaimant(item.targetId, claimantUsername)}
                                                     />
                                                 </TableCell>
                                             </TableRow>

--- a/services/claimService.ts
+++ b/services/claimService.ts
@@ -1,0 +1,74 @@
+// Client-side calls to the dpc-api claim endpoints — "I'm working on this" on a
+// backlog issue/PR. A claim is a dpc-api record, not a GitHub assignee.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+
+export interface Claim {
+    repo: string;
+    number: number;
+    targetId: string;
+    claimantUsername: string;
+    claimedAt: string;
+}
+
+/** Every currently active claim, across all repos (public). */
+export const getActiveClaims = async (): Promise<Claim[]> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/claims/active`);
+        return res.ok ? await res.json() : [];
+    } catch {
+        return [];
+    }
+};
+
+/** The signed-in user's own active claims (requires a token). */
+export const getMyClaims = async (token: string): Promise<Claim[]> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/claims/me`, {
+            headers: {Authorization: `Bearer ${token}`},
+        });
+        return res.ok ? await res.json() : [];
+    } catch {
+        return [];
+    }
+};
+
+const mutate = async (
+    method: 'POST' | 'DELETE',
+    token: string,
+    repo: string,
+    number: number
+): Promise<{ok: true; claim?: Claim} | {ok: false; message: string}> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/claims`, {
+            method,
+            headers: {'Content-Type': 'application/json', Authorization: `Bearer ${token}`},
+            body: JSON.stringify({repo, number}),
+        });
+        if (!res.ok) {
+            let message = `Request failed (HTTP ${res.status})`;
+            try {
+                const body = await res.json();
+                if (typeof body.detail === 'string') {
+                    message = body.detail;
+                }
+            } catch {
+                // Body wasn't JSON (or was empty) — keep the generic message.
+            }
+            return {ok: false, message};
+        }
+        if (method === 'DELETE') {
+            return {ok: true};
+        }
+        return {ok: true, claim: await res.json()};
+    } catch {
+        return {ok: false, message: 'Network error — please try again.'};
+    }
+};
+
+/** Claim a backlog item. */
+export const claimItem = (token: string, repo: string, number: number) =>
+    mutate('POST', token, repo, number);
+
+/** Release your own claim on a backlog item. */
+export const releaseItem = (token: string, repo: string, number: number) =>
+    mutate('DELETE', token, repo, number);


### PR DESCRIPTION
## Summary
Stacked on #232. Third phase of the dev-portal plan.

- `Claim` — a dpc-api record, deliberately *not* a native GitHub assignee, so claiming something never requires granting a random visitor collaborator access to the repo. A partial unique index (`released_at IS NULL`) enforces one active claimant per `(repo, number)`; releases are kept as history rather than deleted.
- `POST` / `DELETE /api/v1/claims` — claim/release (bearer-token authenticated). Claiming twice as the same user is a no-op; claiming something someone else holds is a 409; releasing someone else's claim is a 403.
- `GET /api/v1/claims/active` — public, so everyone sees who's already working on what.
- A daily scheduled job (`dpc.claims.auto-release-after-days`, default 30) releases claims nobody's touched in a while, so an abandoned claim doesn't block others indefinitely.
- `/dev` gets a "Claimed" column: "I'm working on this" / "Release" / "Claimed by X" depending on state.

## Bug fix bundled in
`ApiKeyAuthFilter` rejects any write method (POST/PUT/PATCH/DELETE) on a path outside a small exempt list with a hard 401 — it's the API-key gate for Minecraft-plugin writes like `POST /api/v1/factions`. The new `/api/v1/claims` writes are bearer-token-authenticated (same as `/api/v1/likes`), so they needed adding to that exempt list; without it every claim/release would 401 before reaching `SecurityConfig`. Caught by `ClaimControllerTest` against the real filter chain.

## Why
This is the concrete "assign it to themselves" piece from the original ask, scoped so it can't become a way to grief someone else's repo access.

## Test plan
- [x] `./mvnw test` — 143 tests, 0 failures (1 skip, same as `main`)
- [x] `npm run lint` — clean
- [x] `npm test` — 94 tests, 0 failures
- [x] `npm run build` — compiles; `/dev` renders the Claimed column
- [ ] Not manually clicked through in a browser (sandbox has no browser) — covered instead by `ClaimServiceTest`/`ClaimControllerTest` (conflict/forbidden/idempotent paths) and `claimService.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_