### PR TITLE
Dev portal 4/4: feature-request intake with admin convert-to-GitHub-issue

### DIFF
--- a/__tests__/featureRequestService.test.ts
+++ b/__tests__/featureRequestService.test.ts
@@ -1,0 +1,80 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {convertFeatureRequest, createFeatureRequest, getFeatureRequests} from '../services/featureRequestService';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+const rejectFetch = () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+};
+
+beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getFeatureRequests', () => {
+    it('returns the requests on a 200 response', async () => {
+        const requests = [{id: '1', repo: 'Fiefs', title: 'Add X', description: 'Because Y',
+            authorUsername: 'alice', status: 'OPEN', convertedIssueUrl: null, createdAt: '2026-01-01T00:00:00Z'}];
+        stubFetch({ok: true, json: async () => requests});
+        expect(await getFeatureRequests()).toEqual(requests);
+    });
+
+    it('scopes the request to a repo when provided', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ok: true, json: async () => []} as Response);
+        vi.stubGlobal('fetch', fetchMock);
+        await getFeatureRequests('Fiefs');
+        expect(fetchMock.mock.calls[0][0]).toContain('repo=Fiefs');
+    });
+
+    it('returns an empty array on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500});
+        expect(await getFeatureRequests()).toEqual([]);
+    });
+
+    it('returns an empty array when fetch rejects', async () => {
+        rejectFetch();
+        expect(await getFeatureRequests()).toEqual([]);
+    });
+});
+
+describe('createFeatureRequest', () => {
+    it('resolves ok:true with the created request', async () => {
+        const request = {id: '1', repo: 'Fiefs', title: 'Add X', description: 'Because Y',
+            authorUsername: 'alice', status: 'OPEN', convertedIssueUrl: null, createdAt: '2026-01-01T00:00:00Z'};
+        stubFetch({ok: true, json: async () => request});
+        expect(await createFeatureRequest('token', 'Fiefs', 'Add X', 'Because Y')).toEqual({ok: true, value: request});
+    });
+
+    it('resolves ok:false with the server detail message on validation failure', async () => {
+        stubFetch({ok: false, status: 400, json: async () => ({detail: 'title is required'})});
+        expect(await createFeatureRequest('token', 'Fiefs', '', 'Because Y'))
+            .toEqual({ok: false, message: 'title is required'});
+    });
+
+    it('resolves ok:false when fetch rejects', async () => {
+        rejectFetch();
+        expect(await createFeatureRequest('token', 'Fiefs', 'Add X', 'Because Y'))
+            .toEqual({ok: false, message: 'Network error — please try again.'});
+    });
+});
+
+describe('convertFeatureRequest', () => {
+    it('resolves ok:true with the converted request', async () => {
+        const request = {id: '1', repo: 'Fiefs', title: 'Add X', description: 'Because Y',
+            authorUsername: 'alice', status: 'CONVERTED', convertedIssueUrl: 'https://github.com/x', createdAt: '2026-01-01T00:00:00Z'};
+        stubFetch({ok: true, json: async () => request});
+        expect(await convertFeatureRequest('token', '1')).toEqual({ok: true, value: request});
+    });
+
+    it('resolves ok:false with a generic message when the error body is not JSON', async () => {
+        stubFetch({ok: false, status: 403, json: async () => { throw new Error('not json'); }});
+        expect(await convertFeatureRequest('token', '1')).toEqual({ok: false, message: 'Request failed (HTTP 403)'});
+    });
+});

--- a/components/FeatureRequestSection.tsx
+++ b/components/FeatureRequestSection.tsx
@@ -1,0 +1,212 @@
+import React, {useCallback, useEffect, useState} from 'react';
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    MenuItem,
+    Snackbar,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+import LikeButton from './LikeButton';
+import {
+    convertFeatureRequest,
+    createFeatureRequest,
+    getFeatureRequests,
+    FeatureRequest,
+} from '../services/featureRequestService';
+import {getLikeCounts, getMyLikes} from '../services/likeService';
+
+interface FeatureRequestSectionProps {
+    repos: string[];
+    repoFilter: string;
+    token: string | null;
+}
+
+const FeatureRequestSection: React.FC<FeatureRequestSectionProps> = ({repos, repoFilter, token}) => {
+    const [requests, setRequests] = useState<FeatureRequest[]>([]);
+    const [upvoteCounts, setUpvoteCounts] = useState<Record<string, number>>({});
+    const [upvotedSet, setUpvotedSet] = useState<Set<string>>(new Set());
+    const [formRepo, setFormRepo] = useState(repoFilter || repos[0] || '');
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [notice, setNotice] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        const [requestData, counts] = await Promise.all([
+            getFeatureRequests(repoFilter || undefined),
+            getLikeCounts('feature_request'),
+        ]);
+        setRequests(requestData);
+        setUpvoteCounts(counts);
+    }, [repoFilter]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    useEffect(() => {
+        if (token) {
+            getMyLikes(token).then((likes) =>
+                setUpvotedSet(new Set(likes.filter((l) => l.targetType === 'feature_request').map((l) => l.targetId))));
+        }
+    }, [token]);
+
+    useEffect(() => {
+        setFormRepo(repoFilter || repos[0] || '');
+    }, [repoFilter, repos]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!token) {
+            setNotice('Sign in to suggest a feature.');
+            return;
+        }
+        if (!formRepo || !title.trim() || !description.trim()) {
+            return;
+        }
+        setSubmitting(true);
+        const result = await createFeatureRequest(token, formRepo, title.trim(), description.trim());
+        if (result.ok) {
+            setTitle('');
+            setDescription('');
+            load();
+        } else {
+            setNotice(result.message);
+        }
+        setSubmitting(false);
+    };
+
+    const handleConvert = async (id: string) => {
+        if (!token) {
+            return;
+        }
+        const result = await convertFeatureRequest(token, id);
+        if (result.ok) {
+            load();
+        } else {
+            setNotice(result.message);
+        }
+    };
+
+    return (
+        <Box sx={{mt: 4}}>
+            <Typography variant="h6" component="h2" gutterBottom>
+                Feature requests {repoFilter && `— ${repoFilter}`}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+                Not a GitHub issue yet — an idea anyone can upvote. Once it&apos;s clearly wanted, it gets converted
+                into a real issue on the plugin&apos;s repo.
+            </Typography>
+
+            <Card sx={{mb: 3}}>
+                <CardContent>
+                    <Box component="form" onSubmit={handleSubmit}>
+                        <Stack spacing={2}>
+                            <TextField
+                                select
+                                size="small"
+                                label="Plugin"
+                                value={formRepo}
+                                onChange={(e) => setFormRepo(e.target.value)}
+                                sx={{maxWidth: 320}}
+                            >
+                                {repos.map((repo) => (
+                                    <MenuItem key={repo} value={repo}>{repo}</MenuItem>
+                                ))}
+                            </TextField>
+                            <TextField
+                                size="small"
+                                label="What should it do?"
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                                inputProps={{maxLength: 200}}
+                                required
+                            />
+                            <TextField
+                                size="small"
+                                label="Why would this help?"
+                                value={description}
+                                onChange={(e) => setDescription(e.target.value)}
+                                inputProps={{maxLength: 4000}}
+                                multiline
+                                minRows={2}
+                                required
+                            />
+                            <Box>
+                                <Button type="submit" variant="contained" disabled={submitting}>
+                                    Suggest it
+                                </Button>
+                            </Box>
+                        </Stack>
+                    </Box>
+                </CardContent>
+            </Card>
+
+            <Stack spacing={2}>
+                {requests.length === 0 && (
+                    <Typography color="text.secondary">No feature requests here yet — be the first.</Typography>
+                )}
+                {requests.map((request) => (
+                    <Card key={request.id}>
+                        <CardContent>
+                            <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
+                                <Box sx={{flex: 1}}>
+                                    <Stack direction="row" alignItems="center" spacing={1} sx={{mb: 0.5}}>
+                                        <Typography variant="subtitle1" fontWeight={600}>{request.title}</Typography>
+                                        <Chip size="small" label={request.repo} variant="outlined"/>
+                                        {request.status === 'CONVERTED' && (
+                                            <Chip size="small" color="success" label="Converted to issue"/>
+                                        )}
+                                    </Stack>
+                                    <Typography variant="body2" color="text.secondary">
+                                        {request.description}
+                                    </Typography>
+                                    <Typography variant="caption" color="text.secondary" display="block" sx={{mt: 0.5}}>
+                                        Suggested by {request.authorUsername}
+                                        {request.convertedIssueUrl && (
+                                            <>
+                                                {' · '}
+                                                <a href={request.convertedIssueUrl} target="_blank" rel="noopener noreferrer">
+                                                    View the issue
+                                                </a>
+                                            </>
+                                        )}
+                                    </Typography>
+                                </Box>
+                                <Stack alignItems="flex-end" spacing={1}>
+                                    <LikeButton
+                                        targetType="feature_request"
+                                        targetId={request.id}
+                                        count={upvoteCounts[request.id] || 0}
+                                        liked={upvotedSet.has(request.id)}
+                                        token={token}
+                                    />
+                                    {request.status === 'OPEN' && token && (
+                                        <Button size="small" onClick={() => handleConvert(request.id)}>
+                                            Convert to GitHub issue
+                                        </Button>
+                                    )}
+                                </Stack>
+                            </Stack>
+                        </CardContent>
+                    </Card>
+                ))}
+            </Stack>
+
+            <Snackbar
+                open={notice !== null}
+                autoHideDuration={4000}
+                onClose={() => setNotice(null)}
+                message={notice}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+            />
+        </Box>
+    );
+};
+
+export default FeatureRequestSection;

--- a/dpc-api/src/main/java/com/dansplugins/api/DpcApiApplication.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/DpcApiApplication.java
@@ -1,14 +1,17 @@
 package com.dansplugins.api;
 
+import com.dansplugins.api.config.AdminProperties;
 import com.dansplugins.api.config.BacklogProperties;
 import com.dansplugins.api.config.FactionSyncSafetyProperties;
+import com.dansplugins.api.config.FeatureRequestProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties({FactionSyncSafetyProperties.class, BacklogProperties.class})
+@EnableConfigurationProperties({FactionSyncSafetyProperties.class, BacklogProperties.class,
+        AdminProperties.class, FeatureRequestProperties.class})
 @EnableScheduling
 public class DpcApiApplication {
 

--- a/dpc-api/src/main/java/com/dansplugins/api/config/AdminProperties.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/AdminProperties.java
@@ -1,0 +1,22 @@
+package com.dansplugins.api.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+/**
+ * UserAuth usernames allowed to perform admin-only dev-portal actions —
+ * currently just converting a feature request into a real GitHub issue.
+ * Configured rather than hardcoded so it doesn't need a code change (or a
+ * broader roles/permissions system) to add or remove an admin.
+ */
+@Validated
+@ConfigurationProperties(prefix = "dpc.admin")
+public record AdminProperties(
+        List<String> usernames
+) {
+    public boolean isAdmin(String username) {
+        return username != null && usernames != null && usernames.contains(username);
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/config/FeatureRequestProperties.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/FeatureRequestProperties.java
@@ -1,0 +1,16 @@
+package com.dansplugins.api.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration for converting a triaged {@link com.dansplugins.api.entity.FeatureRequest}
+ * into a real GitHub issue. Needs a token with write access (unlike the
+ * read-only backlog sync), since creating an issue is a GitHub write.
+ */
+@Validated
+@ConfigurationProperties(prefix = "dpc.feature-requests")
+public record FeatureRequestProperties(
+        String githubToken
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/config/SecurityConfig.java
@@ -78,6 +78,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/backlog", "/api/v1/backlog/**").permitAll()
                         // Who's claimed what is shown to every visitor; claiming/releasing requires auth
                         .requestMatchers(HttpMethod.GET, "/api/v1/claims/active").permitAll()
+                        // Feature requests are browsable by everyone; submitting/converting requires auth
+                        .requestMatchers(HttpMethod.GET, "/api/v1/feature-requests", "/api/v1/feature-requests/**")
+                        .permitAll()
                         // Public single-user profile (GET /api/v1/profile/{username}). The /me rule
                         // is listed first so the authenticated self-profile (which exposes API keys)
                         // is never served by the public path; the single-segment glob then permits
@@ -91,6 +94,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/profile/**").authenticated()
                         .requestMatchers("/api/v1/likes", "/api/v1/likes/**").authenticated()
                         .requestMatchers("/api/v1/claims", "/api/v1/claims/**").authenticated()
+                        // Only POST reaches here for feature requests — GET was already permitted above
+                        .requestMatchers("/api/v1/feature-requests", "/api/v1/feature-requests/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").authenticated()
                         // API key auth for faction writes is enforced by ApiKeyAuthFilter (returns 401
                         // before this authorization layer runs); permitAll here avoids a double-reject.

--- a/dpc-api/src/main/java/com/dansplugins/api/controller/FeatureRequestController.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/controller/FeatureRequestController.java
@@ -1,0 +1,59 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.dto.FeatureRequestCreateRequest;
+import com.dansplugins.api.dto.FeatureRequestResponse;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.service.FeatureRequestService;
+import com.dansplugins.api.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Community-submitted plugin ideas, scoped to a repo. Listing is public;
+ * submitting requires a UserAuth token; converting to a real GitHub issue is
+ * admin-only (see {@link com.dansplugins.api.config.AdminProperties}).
+ */
+@RestController
+@RequestMapping("/api/v1/feature-requests")
+@RequiredArgsConstructor
+@Tag(name = "Feature Requests", description = "Community-submitted plugin ideas")
+public class FeatureRequestController {
+
+    private final UserService userService;
+    private final FeatureRequestService featureRequestService;
+
+    @PostMapping
+    @Operation(summary = "Submit a feature request", security = @SecurityRequirement(name = "bearerAuth"))
+    public FeatureRequestResponse create(Principal principal, @Valid @RequestBody FeatureRequestCreateRequest request) {
+        User author = userService.getOrCreate(principal.getName());
+        return FeatureRequestResponse.from(
+                featureRequestService.create(author, request.repo(), request.title(), request.description()));
+    }
+
+    @GetMapping
+    @Operation(summary = "List feature requests, optionally filtered to one repo")
+    public List<FeatureRequestResponse> list(@RequestParam(value = "repo", required = false) String repo) {
+        return featureRequestService.list(repo).stream().map(FeatureRequestResponse::from).toList();
+    }
+
+    @PostMapping("/{id}/convert")
+    @Operation(summary = "Convert a feature request into a real GitHub issue (admin-only)",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    public FeatureRequestResponse convert(Principal principal, @PathVariable UUID id) {
+        return FeatureRequestResponse.from(featureRequestService.convert(principal.getName(), id));
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/FeatureRequestCreateRequest.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/FeatureRequestCreateRequest.java
@@ -1,0 +1,21 @@
+package com.dansplugins.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "A new community-submitted plugin idea")
+public record FeatureRequestCreateRequest(
+        @NotBlank(message = "repo is required")
+        @Schema(example = "Medieval-Factions")
+        String repo,
+
+        @NotBlank(message = "title is required")
+        @Size(max = 200)
+        String title,
+
+        @NotBlank(message = "description is required")
+        @Size(max = 4000)
+        String description
+) {
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/FeatureRequestResponse.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/FeatureRequestResponse.java
@@ -1,0 +1,31 @@
+package com.dansplugins.api.dto;
+
+import com.dansplugins.api.entity.FeatureRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "A community-submitted plugin idea")
+public record FeatureRequestResponse(
+        String id,
+        String repo,
+        String title,
+        String description,
+        String authorUsername,
+        String status,
+        String convertedIssueUrl,
+        Instant createdAt
+) {
+    public static FeatureRequestResponse from(FeatureRequest featureRequest) {
+        return new FeatureRequestResponse(
+                featureRequest.targetId(),
+                featureRequest.getRepo(),
+                featureRequest.getTitle(),
+                featureRequest.getDescription(),
+                featureRequest.getAuthor().getUserauthUsername(),
+                featureRequest.getStatus().name(),
+                featureRequest.getConvertedIssueUrl(),
+                featureRequest.getCreatedAt()
+        );
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/dto/LikeRequest.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/dto/LikeRequest.java
@@ -4,15 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-@Schema(description = "A like target: a plugin, guide, or backlog issue/PR")
+@Schema(description = "A like target: a plugin, guide, backlog issue/PR, or feature request")
 public record LikeRequest(
         @NotBlank(message = "targetType is required")
-        @Schema(description = "'plugin', 'guide', or 'issue'", example = "plugin")
+        @Schema(description = "'plugin', 'guide', 'issue', or 'feature_request'", example = "plugin")
         String targetType,
 
         @NotBlank(message = "targetId is required")
         @Size(max = 64)
-        @Schema(description = "The plugin id from plugins.json, or 'repo#number' for an 'issue' target",
+        @Schema(description = "The plugin id from plugins.json, 'repo#number' for an 'issue' target, "
+                + "or the feature request's id for a 'feature_request' target",
                 example = "medieval-factions")
         String targetId
 ) {

--- a/dpc-api/src/main/java/com/dansplugins/api/entity/FeatureRequest.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/entity/FeatureRequest.java
@@ -1,0 +1,86 @@
+package com.dansplugins.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A community-submitted idea for one plugin, scoped to a repo but not yet a
+ * GitHub issue. Upvotes reuse the existing Like mechanism (targetType
+ * "feature_request", targetId this row's id) rather than a bespoke voting
+ * table. Once triaged, {@link com.dansplugins.api.service.FeatureRequestService}
+ * converts it into a real GitHub issue so ideas end up in the same backlog
+ * everything else lives in, instead of a second, parallel one.
+ */
+@Entity
+@Table(name = "feature_requests")
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class FeatureRequest {
+
+    public enum Status { OPEN, CONVERTED }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(lombok.AccessLevel.NONE)
+    private UUID id;
+
+    @Column(name = "repo", nullable = false, length = 100)
+    private String repo;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 4000)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private User author;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private Status status;
+
+    @Column(name = "converted_issue_url", length = 512)
+    private String convertedIssueUrl;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(lombok.AccessLevel.NONE)
+    private Instant createdAt;
+
+    public FeatureRequest(String repo, String title, String description, User author) {
+        this.repo = repo;
+        this.title = title;
+        this.description = description;
+        this.author = author;
+        this.status = Status.OPEN;
+    }
+
+    /** The id under which this row's upvotes are keyed in the likes table. */
+    public String targetId() {
+        return id.toString();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/filter/ApiKeyAuthFilter.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/filter/ApiKeyAuthFilter.java
@@ -38,7 +38,8 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
             "/api/v1/auth/",
             "/api/v1/profile/",
             "/api/v1/likes",
-            "/api/v1/claims"
+            "/api/v1/claims",
+            "/api/v1/feature-requests"
     );
 
     private final ApiKeyService apiKeyService;

--- a/dpc-api/src/main/java/com/dansplugins/api/repository/FeatureRequestRepository.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/repository/FeatureRequestRepository.java
@@ -1,0 +1,23 @@
+package com.dansplugins.api.repository;
+
+import com.dansplugins.api.entity.FeatureRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FeatureRequestRepository extends JpaRepository<FeatureRequest, UUID> {
+
+    @Query("select f from FeatureRequest f join fetch f.author order by f.createdAt desc")
+    List<FeatureRequest> findAllWithAuthorOrderByCreatedAtDesc();
+
+    @Query("select f from FeatureRequest f join fetch f.author where f.repo = :repo order by f.createdAt desc")
+    List<FeatureRequest> findByRepoWithAuthorOrderByCreatedAtDesc(@Param("repo") String repo);
+
+    /** Callers map straight to a DTO, which touches the lazy author — fetch it eagerly here. */
+    @Query("select f from FeatureRequest f join fetch f.author where f.id = :id")
+    Optional<FeatureRequest> findByIdWithAuthor(@Param("id") UUID id);
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/FeatureRequestService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/FeatureRequestService.java
@@ -1,0 +1,68 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.config.AdminProperties;
+import com.dansplugins.api.entity.FeatureRequest;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.repository.FeatureRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Community-submitted plugin ideas, and their one-way trip into a real GitHub
+ * issue once triaged. GitHub stays the eventual home for every idea that goes
+ * anywhere — this is intake, not a permanent second backlog.
+ */
+@Service
+@RequiredArgsConstructor
+public class FeatureRequestService {
+
+    private final FeatureRequestRepository featureRequestRepository;
+    private final AdminProperties adminProperties;
+    private final GitHubIssueClient gitHubIssueClient;
+
+    @Transactional
+    public FeatureRequest create(User author, String repo, String title, String description) {
+        return featureRequestRepository.save(new FeatureRequest(repo, title, description, author));
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeatureRequest> list(String repo) {
+        return (repo == null || repo.isBlank())
+                ? featureRequestRepository.findAllWithAuthorOrderByCreatedAtDesc()
+                : featureRequestRepository.findByRepoWithAuthorOrderByCreatedAtDesc(repo);
+    }
+
+    /**
+     * Converts a feature request into a real GitHub issue. Admin-only (see
+     * {@link AdminProperties}); idempotent if it's already been converted —
+     * repeat clicks don't create duplicate issues.
+     */
+    @Transactional
+    public FeatureRequest convert(String requestingUsername, UUID id) {
+        if (!adminProperties.isAdmin(requestingUsername)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only an admin can convert a feature request");
+        }
+        FeatureRequest featureRequest = featureRequestRepository.findByIdWithAuthor(id)
+                .orElseThrow(() -> new ResourceNotFoundException("No feature request with id " + id));
+
+        if (featureRequest.getStatus() == FeatureRequest.Status.CONVERTED) {
+            return featureRequest;
+        }
+
+        String body = featureRequest.getDescription()
+                + "\n\n---\n_Submitted via the dansplugins.com dev portal by "
+                + featureRequest.getAuthor().getUserauthUsername() + "._";
+        String issueUrl = gitHubIssueClient.createIssue(featureRequest.getRepo(), featureRequest.getTitle(), body);
+
+        featureRequest.setStatus(FeatureRequest.Status.CONVERTED);
+        featureRequest.setConvertedIssueUrl(issueUrl);
+        return featureRequestRepository.save(featureRequest);
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/GitHubIssueClient.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/GitHubIssueClient.java
@@ -1,0 +1,67 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.config.FeatureRequestProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Creates real GitHub issues — the write counterpart to the read-only
+ * {@link GitHubClient} used by the backlog sync. Used only by feature-request
+ * conversion, so a missing/under-scoped token only breaks that one action
+ * rather than the whole dev portal.
+ */
+@Service
+@Slf4j
+public class GitHubIssueClient {
+
+    private final RestTemplate restTemplate;
+    private final FeatureRequestProperties properties;
+
+    public GitHubIssueClient(RestTemplateBuilder restTemplateBuilder, FeatureRequestProperties properties) {
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(15))
+                .build();
+        this.properties = properties;
+    }
+
+    /** Creates an issue on {@code Dans-Plugins/<repo>} and returns its html_url. */
+    @SuppressWarnings("unchecked")
+    public String createIssue(String repo, String title, String body) {
+        if (properties.githubToken() == null || properties.githubToken().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Feature-request conversion isn't configured (no GitHub token)");
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/vnd.github+json");
+        headers.set("User-Agent", "dpc-api-feature-request-conversion");
+        headers.setBearerAuth(properties.githubToken());
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(Map.of("title", title, "body", body), headers);
+
+        String url = "https://api.github.com/repos/Dans-Plugins/" + repo + "/issues";
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, entity, Map.class);
+            Map<String, Object> responseBody = response.getBody();
+            Object htmlUrl = responseBody == null ? null : responseBody.get("html_url");
+            if (htmlUrl == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "GitHub did not return an issue URL");
+            }
+            return htmlUrl.toString();
+        } catch (RestClientException e) {
+            log.warn("Failed to create GitHub issue in {}: {}", repo, e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to create the GitHub issue: " + e.getMessage());
+        }
+    }
+}

--- a/dpc-api/src/main/java/com/dansplugins/api/service/LikeService.java
+++ b/dpc-api/src/main/java/com/dansplugins/api/service/LikeService.java
@@ -14,15 +14,16 @@ import java.util.stream.Collectors;
 
 /**
  * Likes on plugins, guides, and — for the dev portal — backlog issues/PRs
- * ("interested", keyed by {@code repo#number}). A like is idempotent (the
- * unique constraint on {@code (user, target_type, target_id)} means liking
- * twice is a no-op), and counts are public.
+ * ("interested", keyed by {@code repo#number}) and feature-request upvotes
+ * (keyed by the feature request's id). A like is idempotent (the unique
+ * constraint on {@code (user, target_type, target_id)} means liking twice is a
+ * no-op), and counts are public.
  */
 @Service
 @RequiredArgsConstructor
 public class LikeService {
 
-    static final Set<String> ALLOWED_TYPES = Set.of("plugin", "guide", "issue");
+    static final Set<String> ALLOWED_TYPES = Set.of("plugin", "guide", "issue", "feature_request");
 
     private final LikeRepository likeRepository;
 

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -51,3 +51,17 @@ dpc:
     sync-interval-ms: ${DPC_BACKLOG_SYNC_INTERVAL_MS:900000}
     # Disable in tests/local runs that shouldn't call out to the real GitHub API.
     sync-enabled: ${DPC_BACKLOG_SYNC_ENABLED:true}
+  claims:
+    # A claim with no activity for this many days is auto-released.
+    auto-release-after-days: ${DPC_CLAIMS_AUTO_RELEASE_DAYS:30}
+  admin:
+    # Comma-separated UserAuth usernames allowed to convert a feature request
+    # into a real GitHub issue. Empty by default — nobody can convert until
+    # this is set.
+    usernames: ${DPC_ADMIN_USERNAMES:}
+  feature-requests:
+    # Needs a classic PAT with at least 'public_repo' scope — creating a GitHub
+    # issue is a write, unlike the read-only backlog sync above. Falls back to
+    # dpc.backlog.github-token if unset, since both just need an authenticated
+    # GitHub identity with access to the Dans-Plugins repos.
+    github-token: ${DPC_FEATURE_REQUEST_GITHUB_TOKEN:${DPC_BACKLOG_GITHUB_TOKEN:}}

--- a/dpc-api/src/main/resources/db/migration/V14__create_feature_requests_table.sql
+++ b/dpc-api/src/main/resources/db/migration/V14__create_feature_requests_table.sql
@@ -1,0 +1,16 @@
+-- Community-submitted plugin ideas (#233), scoped to a repo. Upvotes reuse the
+-- existing likes table (target_type = 'feature_request', target_id = this
+-- row's id) rather than a second voting mechanism.
+
+CREATE TABLE feature_requests (
+    id                  UUID PRIMARY KEY,
+    repo                VARCHAR(100)  NOT NULL,
+    title               VARCHAR(200)  NOT NULL,
+    description         VARCHAR(4000) NOT NULL,
+    author_id           UUID          NOT NULL REFERENCES users(id),
+    status              VARCHAR(16)   NOT NULL,
+    converted_issue_url VARCHAR(512),
+    created_at          TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_feature_requests_repo ON feature_requests (repo);

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/FeatureRequestControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/FeatureRequestControllerTest.java
@@ -1,0 +1,126 @@
+package com.dansplugins.api.controller;
+
+import com.dansplugins.api.repository.FeatureRequestRepository;
+import com.dansplugins.api.repository.UserRepository;
+import com.dansplugins.api.service.GitHubIssueClient;
+import com.dansplugins.api.service.UserAuthClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = "dpc.admin.usernames=admin-alice")
+class FeatureRequestControllerTest {
+
+    private static final String ALICE_BEARER = "Bearer alice-token";
+    private static final String ADMIN_BEARER = "Bearer admin-token";
+    private static final String CREATE_REQUEST =
+            "{\"repo\":\"Fiefs\",\"title\":\"Add X\",\"description\":\"Because Y\"}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FeatureRequestRepository featureRequestRepository;
+
+    @MockBean
+    private UserAuthClient userAuthClient;
+
+    @MockBean
+    private GitHubIssueClient gitHubIssueClient;
+
+    @BeforeEach
+    void setUp() {
+        featureRequestRepository.deleteAll();
+        userRepository.deleteAll();
+        when(userAuthClient.validate("alice-token")).thenReturn(Optional.of("alice"));
+        when(userAuthClient.validate("admin-token")).thenReturn(Optional.of("admin-alice"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        featureRequestRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void create_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/feature-requests")
+                        .contentType(MediaType.APPLICATION_JSON).content(CREATE_REQUEST))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void create_thenAppearsInThePublicList() throws Exception {
+        mockMvc.perform(post("/api/v1/feature-requests").header("Authorization", ALICE_BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(CREATE_REQUEST))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.authorUsername").value("alice"));
+
+        // No token — the list is public.
+        mockMvc.perform(get("/api/v1/feature-requests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].repo").value("Fiefs"));
+    }
+
+    @Test
+    void list_filteredByRepo() throws Exception {
+        mockMvc.perform(post("/api/v1/feature-requests").header("Authorization", ALICE_BEARER)
+                .contentType(MediaType.APPLICATION_JSON).content(CREATE_REQUEST)).andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/feature-requests").param("repo", "Medieval-Factions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void convert_byNonAdmin_returns403() throws Exception {
+        String id = createAndGetId();
+
+        mockMvc.perform(post("/api/v1/feature-requests/" + id + "/convert").header("Authorization", ALICE_BEARER))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void convert_byAdmin_createsTheIssueAndMarksConverted() throws Exception {
+        String id = createAndGetId();
+        when(gitHubIssueClient.createIssue(anyString(), anyString(), anyString()))
+                .thenReturn("https://github.com/Dans-Plugins/Fiefs/issues/200");
+
+        mockMvc.perform(post("/api/v1/feature-requests/" + id + "/convert").header("Authorization", ADMIN_BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CONVERTED"))
+                .andExpect(jsonPath("$.convertedIssueUrl").value("https://github.com/Dans-Plugins/Fiefs/issues/200"));
+    }
+
+    private String createAndGetId() throws Exception {
+        String response = mockMvc.perform(post("/api/v1/feature-requests").header("Authorization", ALICE_BEARER)
+                        .contentType(MediaType.APPLICATION_JSON).content(CREATE_REQUEST))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return response.replaceAll(".*\"id\":\"([^\"]+)\".*", "$1");
+    }
+}

--- a/dpc-api/src/test/java/com/dansplugins/api/service/FeatureRequestServiceTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/service/FeatureRequestServiceTest.java
@@ -1,0 +1,105 @@
+package com.dansplugins.api.service;
+
+import com.dansplugins.api.config.AdminProperties;
+import com.dansplugins.api.entity.FeatureRequest;
+import com.dansplugins.api.entity.User;
+import com.dansplugins.api.exception.ResourceNotFoundException;
+import com.dansplugins.api.repository.FeatureRequestRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureRequestServiceTest {
+
+    @Mock
+    private FeatureRequestRepository featureRequestRepository;
+
+    @Mock
+    private GitHubIssueClient gitHubIssueClient;
+
+    private final User alice = new User("alice");
+
+    private FeatureRequestService service(List<String> admins) {
+        return new FeatureRequestService(featureRequestRepository, new AdminProperties(admins), gitHubIssueClient);
+    }
+
+    @Test
+    void create_savesANewOpenRequest() {
+        FeatureRequestService service = service(List.of());
+        when(featureRequestRepository.save(any(FeatureRequest.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        FeatureRequest result = service.create(alice, "Fiefs", "Add X", "Because Y");
+
+        assertThat(result.getRepo()).isEqualTo("Fiefs");
+        assertThat(result.getStatus()).isEqualTo(FeatureRequest.Status.OPEN);
+        assertThat(result.getAuthor()).isEqualTo(alice);
+    }
+
+    @Test
+    void convert_byNonAdmin_throwsForbidden_andNeverCallsGitHub() {
+        FeatureRequestService service = service(List.of("dmccoystephenson"));
+        UUID id = UUID.randomUUID();
+
+        assertThatThrownBy(() -> service.convert("alice", id))
+                .isInstanceOf(ResponseStatusException.class);
+        verify(gitHubIssueClient, never()).createIssue(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void convert_missingRequest_throwsNotFound() {
+        FeatureRequestService service = service(List.of("dmccoystephenson"));
+        UUID id = UUID.randomUUID();
+        when(featureRequestRepository.findByIdWithAuthor(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.convert("dmccoystephenson", id))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void convert_byAdmin_createsTheIssue_andMarksConverted() {
+        FeatureRequestService service = service(List.of("dmccoystephenson"));
+        FeatureRequest request = new FeatureRequest("Fiefs", "Add X", "Because Y", alice);
+        UUID id = UUID.randomUUID();
+        when(featureRequestRepository.findByIdWithAuthor(id)).thenReturn(Optional.of(request));
+        when(gitHubIssueClient.createIssue("Fiefs", "Add X", request.getDescription()
+                + "\n\n---\n_Submitted via the dansplugins.com dev portal by alice._"))
+                .thenReturn("https://github.com/Dans-Plugins/Fiefs/issues/200");
+        when(featureRequestRepository.save(request)).thenReturn(request);
+
+        FeatureRequest result = service.convert("dmccoystephenson", id);
+
+        assertThat(result.getStatus()).isEqualTo(FeatureRequest.Status.CONVERTED);
+        assertThat(result.getConvertedIssueUrl()).isEqualTo("https://github.com/Dans-Plugins/Fiefs/issues/200");
+    }
+
+    @Test
+    void convert_alreadyConverted_isIdempotent_andNeverCallsGitHubAgain() {
+        FeatureRequestService service = service(List.of("dmccoystephenson"));
+        FeatureRequest request = new FeatureRequest("Fiefs", "Add X", "Because Y", alice);
+        request.setStatus(FeatureRequest.Status.CONVERTED);
+        request.setConvertedIssueUrl("https://github.com/Dans-Plugins/Fiefs/issues/200");
+        UUID id = UUID.randomUUID();
+        when(featureRequestRepository.findByIdWithAuthor(id)).thenReturn(Optional.of(request));
+
+        FeatureRequest result = service.convert("dmccoystephenson", id);
+
+        assertThat(result.getConvertedIssueUrl()).isEqualTo("https://github.com/Dans-Plugins/Fiefs/issues/200");
+        verify(gitHubIssueClient, never()).createIssue(anyString(), anyString(), anyString());
+        verify(featureRequestRepository, never()).save(any());
+    }
+}

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -25,6 +25,7 @@ import Seo from '../../components/Seo'
 import BottomBar from '../../components/BottomBar'
 import LikeButton from '../../components/LikeButton'
 import ClaimButton from '../../components/ClaimButton'
+import FeatureRequestSection from '../../components/FeatureRequestSection'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles'
 import {relativeTimeFrom} from '../../utils/relativeTime'
 import {getBacklogItems, getBacklogSummary, BacklogItem, RepoSummary} from '../../services/backlogService'
@@ -336,6 +337,12 @@ const DevPortalPage: NextPage = () => {
                         </TableContainer>
                     </CardContent>
                 </Card>
+
+                <FeatureRequestSection
+                    repos={summary.map((row) => row.repo)}
+                    repoFilter={repoFilter}
+                    token={token}
+                />
             </Container>
             <BottomBar version={version}/>
         </Box>

--- a/services/featureRequestService.ts
+++ b/services/featureRequestService.ts
@@ -1,0 +1,77 @@
+// Client-side calls to the dpc-api feature-request endpoints — community
+// plugin ideas, upvoted via the existing like mechanism and (admin-only)
+// convertible into a real GitHub issue.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+
+export interface FeatureRequest {
+    id: string;
+    repo: string;
+    title: string;
+    description: string;
+    authorUsername: string;
+    status: 'OPEN' | 'CONVERTED';
+    convertedIssueUrl: string | null;
+    createdAt: string;
+}
+
+type Result<T> = {ok: true; value: T} | {ok: false; message: string};
+
+const parseErrorMessage = async (res: Response, fallback: string): Promise<string> => {
+    try {
+        const body = await res.json();
+        return typeof body.detail === 'string' ? body.detail : fallback;
+    } catch {
+        return fallback;
+    }
+};
+
+/** Feature requests, optionally scoped to one repo. */
+export const getFeatureRequests = async (repo?: string): Promise<FeatureRequest[]> => {
+    try {
+        const url = repo
+            ? `${API_BASE}/api/v1/feature-requests?repo=${encodeURIComponent(repo)}`
+            : `${API_BASE}/api/v1/feature-requests`;
+        const res = await fetch(url);
+        return res.ok ? await res.json() : [];
+    } catch {
+        return [];
+    }
+};
+
+/** Submit a new feature request. */
+export const createFeatureRequest = async (
+    token: string,
+    repo: string,
+    title: string,
+    description: string
+): Promise<Result<FeatureRequest>> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/feature-requests`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', Authorization: `Bearer ${token}`},
+            body: JSON.stringify({repo, title, description}),
+        });
+        if (!res.ok) {
+            return {ok: false, message: await parseErrorMessage(res, `Request failed (HTTP ${res.status})`)};
+        }
+        return {ok: true, value: await res.json()};
+    } catch {
+        return {ok: false, message: 'Network error — please try again.'};
+    }
+};
+
+/** Convert a feature request into a real GitHub issue. Admin-only server-side. */
+export const convertFeatureRequest = async (token: string, id: string): Promise<Result<FeatureRequest>> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/feature-requests/${encodeURIComponent(id)}/convert`, {
+            method: 'POST',
+            headers: {Authorization: `Bearer ${token}`},
+        });
+        if (!res.ok) {
+            return {ok: false, message: await parseErrorMessage(res, `Request failed (HTTP ${res.status})`)};
+        }
+        return {ok: true, value: await res.json()};
+    } catch {
+        return {ok: false, message: 'Network error — please try again.'};
+    }
+};

--- a/services/likeService.ts
+++ b/services/likeService.ts
@@ -2,7 +2,7 @@
 // public API the leaderboard/account pages use.
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
 
-export type LikeTargetType = 'plugin' | 'guide' | 'issue';
+export type LikeTargetType = 'plugin' | 'guide' | 'issue' | 'feature_request';
 
 export interface LikedTarget {
     targetType: LikeTargetType;


### PR DESCRIPTION
## Summary
Stacked on #233. Fourth and final phase of the dev-portal plan.

- `FeatureRequest` — a community-submitted idea scoped to a repo, not yet a GitHub issue.
- Upvotes reuse the existing like mechanism again (`targetType: 'feature_request'`, keyed by the request's id) — third reuse of the same primitive, no new voting table.
- `POST /api/v1/feature-requests` (auth) to submit, `GET /api/v1/feature-requests` (public) to browse.
- `POST /api/v1/feature-requests/{id}/convert` — admin-only (`dpc.admin.usernames` allowlist, empty by default so nobody can convert until it's set), calls a new write-side `GitHubIssueClient` to create the real issue. Idempotent: converting an already-converted request just returns it rather than creating a duplicate issue.
- `/dev` gets a "Feature requests" section: a submission form plus a list with upvotes and (for signed-in users — the actual admin check is server-side, so the client never needs to know who's an admin) a "Convert to GitHub issue" button that a non-admin will just get a clear 403 from.

## Why
This is the "surface feature requests" half of the original ask, and it's designed so an idea's endpoint is always a real GitHub issue — this is intake, not a second, parallel backlog living forever in dpc-api.

## Test plan
- [x] `./mvnw test` — 153 tests, 0 failures (1 skip, same as `main`)
- [x] `npm run lint` — clean
- [x] `npm test` — 103 tests, 0 failures
- [x] `npm run build` — compiles; `/dev` renders the feature-request section
- [ ] Not manually clicked through in a browser (sandbox has no browser), and the GitHub issue-creation call is only exercised against a mocked `GitHubIssueClient` — no live network call was made to actually create an issue anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_