### PR TITLE
Dev portal 5/5: make the console navigable and actionable

### DIFF
--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -5,6 +5,7 @@ import {
     CardContent,
     Chip,
     Container,
+    Link as MuiLink,
     MenuItem,
     Skeleton,
     Stack,
@@ -15,11 +16,14 @@ import {
     TableHead,
     TableRow,
     TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+    Tooltip,
     Typography,
 } from '@mui/material'
 import BugReportIcon from '@mui/icons-material/BugReport'
 import type {NextPage} from 'next'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import TopBar from '../../components/TopBar'
 import Seo from '../../components/Seo'
 import BottomBar from '../../components/BottomBar'
@@ -31,47 +35,103 @@ import {relativeTimeFrom} from '../../utils/relativeTime'
 import {getBacklogItems, getBacklogSummary, BacklogItem, RepoSummary} from '../../services/backlogService'
 import {getLikeCounts, getMyLikes} from '../../services/likeService'
 import {getActiveClaims} from '../../services/claimService'
+import {getFeatureRequests} from '../../services/featureRequestService'
 
 const version = require('../../package.json').version
 
-const signalFor = (summary: RepoSummary): { label: string; color: 'success' | 'warning' | 'error' | 'default' } => {
+type SignalKey = 'active' | 'needs-triage' | 'automation-backlog' | 'stale' | 'quiet'
+
+interface Signal {
+    key: SignalKey
+    label: string
+    color: 'success' | 'warning' | 'error' | 'default'
+    description: string
+}
+
+const SIGNALS: Record<SignalKey, Omit<Signal, 'key'>> = {
+    active: {label: 'Active', color: 'success', description: 'Recent PRs, not stuck in draft — moving.'},
+    'needs-triage': {label: 'Needs triage', color: 'warning', description: 'Issues piling up with no PR started yet.'},
+    'automation-backlog': {label: 'Automation backlog', color: 'warning', description: 'Every open PR is stuck in draft.'},
+    stale: {label: 'Stale', color: 'error', description: 'Nothing here has been touched in 2+ years.'},
+    quiet: {label: 'Quiet', color: 'default', description: 'Nothing open right now.'},
+}
+
+const signalFor = (summary: RepoSummary): Signal => {
     const total = summary.openIssueCount + summary.openPrCount
-    if (total === 0) {
-        return {label: 'Quiet', color: 'default'}
-    }
     const ageDays = summary.oldestOpenItemAt
         ? (Date.now() - new Date(summary.oldestOpenItemAt).getTime()) / 86_400_000
         : 0
-    if (ageDays > 365 * 2) {
-        return {label: 'Stale', color: 'error'}
+    let key: SignalKey
+    if (total === 0) {
+        key = 'quiet'
+    } else if (ageDays > 365 * 2) {
+        key = 'stale'
+    } else if (summary.openPrCount > 0 && summary.draftPrCount === summary.openPrCount) {
+        key = 'automation-backlog'
+    } else if (summary.openIssueCount > 0 && summary.openPrCount === 0) {
+        key = 'needs-triage'
+    } else {
+        key = 'active'
     }
-    if (summary.openPrCount > 0 && summary.draftPrCount === summary.openPrCount) {
-        return {label: 'Automation backlog', color: 'warning'}
-    }
-    if (summary.openIssueCount > 0 && summary.openPrCount === 0) {
-        return {label: 'Needs triage', color: 'warning'}
-    }
-    return {label: 'Active', color: 'success'}
+    return {key, ...SIGNALS[key]}
 }
+
+type ItemTypeFilter = 'all' | 'issue' | 'pr' | 'draft'
+type SortOrder = 'oldest' | 'newest' | 'most-interested'
+
+const StatTile: React.FC<{value: React.ReactNode; label: string; tone?: 'warn' | 'crit'}> = ({value, label, tone}) => (
+    <Card variant="outlined" sx={{flex: '1 1 160px', textAlign: 'center', py: 1.5}}>
+        <Typography
+            variant="h4"
+            component="div"
+            fontWeight={700}
+            color={tone === 'crit' ? 'error.main' : tone === 'warn' ? 'warning.main' : 'text.primary'}
+        >
+            {value}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{textTransform: 'uppercase', letterSpacing: '0.06em'}}>
+            {label}
+        </Typography>
+    </Card>
+)
 
 const DevPortalPage: NextPage = () => {
     const [summary, setSummary] = useState<RepoSummary[]>([])
     const [items, setItems] = useState<BacklogItem[]>([])
     const [repoFilter, setRepoFilter] = useState('')
+    const [signalFilter, setSignalFilter] = useState<SignalKey | 'all'>('all')
+    const [typeFilter, setTypeFilter] = useState<ItemTypeFilter>('all')
+    const [sortOrder, setSortOrder] = useState<SortOrder>('oldest')
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
     const [interestCounts, setInterestCounts] = useState<Record<string, number>>({})
     const [interestedSet, setInterestedSet] = useState<Set<string>>(new Set())
     const [claimants, setClaimants] = useState<Record<string, string>>({})
+    const [ideaCounts, setIdeaCounts] = useState<Record<string, number>>({})
     const [token, setToken] = useState<string | null>(null)
+
+    const repoSectionRef = useRef<HTMLDivElement>(null)
+    const itemsSectionRef = useRef<HTMLDivElement>(null)
+    const ideasSectionRef = useRef<HTMLDivElement>(null)
+    const scrollTo = (ref: React.RefObject<HTMLDivElement>) =>
+        ref.current?.scrollIntoView({behavior: 'smooth', block: 'start'})
 
     const load = useCallback(async () => {
         setLoading(true)
         setError(null)
         try {
-            const [summaryData, itemData] = await Promise.all([getBacklogSummary(), getBacklogItems()])
+            const [summaryData, itemData, featureRequests] = await Promise.all([
+                getBacklogSummary(),
+                getBacklogItems(),
+                getFeatureRequests(),
+            ])
             setSummary(summaryData)
             setItems(itemData)
+            const counts: Record<string, number> = {}
+            featureRequests.forEach((fr) => {
+                counts[fr.repo] = (counts[fr.repo] || 0) + 1
+            })
+            setIdeaCounts(counts)
             if (summaryData.length === 0 && itemData.length === 0) {
                 setError('No backlog data yet — the sync runs on a schedule and may not have completed its first pass.')
             }
@@ -111,10 +171,62 @@ const DevPortalPage: NextPage = () => {
         })
     }
 
-    const visibleItems = useMemo(
-        () => (repoFilter ? items.filter((item) => item.repo === repoFilter) : items),
-        [items, repoFilter]
+    const signalByRepo = useMemo(
+        () => Object.fromEntries(summary.map((row) => [row.repo, signalFor(row)])),
+        [summary]
     )
+
+    const visibleSummary = useMemo(
+        () => (signalFilter === 'all' ? summary : summary.filter((row) => signalByRepo[row.repo]?.key === signalFilter)),
+        [summary, signalFilter, signalByRepo]
+    )
+
+    const totals = useMemo(() => {
+        const openIssues = summary.reduce((sum, r) => sum + r.openIssueCount, 0)
+        const openPrs = summary.reduce((sum, r) => sum + r.openPrCount, 0)
+        const draftPrs = summary.reduce((sum, r) => sum + r.draftPrCount, 0)
+        const oldest = summary
+            .map((r) => r.oldestOpenItemAt)
+            .filter((d): d is string => !!d)
+            .sort()[0]
+        return {openIssues, openPrs, draftPrs, oldest}
+    }, [summary])
+
+    const visibleItems = useMemo(() => {
+        let list = items
+        if (repoFilter) {
+            list = list.filter((item) => item.repo === repoFilter)
+        }
+        if (signalFilter !== 'all') {
+            list = list.filter((item) => signalByRepo[item.repo]?.key === signalFilter)
+        }
+        if (typeFilter === 'issue') {
+            list = list.filter((item) => item.itemType === 'ISSUE')
+        } else if (typeFilter === 'pr') {
+            list = list.filter((item) => item.itemType === 'PULL_REQUEST')
+        } else if (typeFilter === 'draft') {
+            list = list.filter((item) => item.itemType === 'PULL_REQUEST' && item.draft)
+        }
+        const sorted = [...list]
+        if (sortOrder === 'newest') {
+            sorted.sort((a, b) => b.githubCreatedAt.localeCompare(a.githubCreatedAt))
+        } else if (sortOrder === 'most-interested') {
+            sorted.sort((a, b) => (interestCounts[b.targetId] || 0) - (interestCounts[a.targetId] || 0))
+        } else {
+            sorted.sort((a, b) => a.githubCreatedAt.localeCompare(b.githubCreatedAt))
+        }
+        return sorted
+    }, [items, repoFilter, signalFilter, typeFilter, sortOrder, signalByRepo, interestCounts])
+
+    const jumpToRepo = (repo: string) => {
+        setRepoFilter(repoFilter === repo ? '' : repo)
+        scrollTo(itemsSectionRef)
+    }
+
+    const jumpToIdeas = (repo: string) => {
+        setRepoFilter(repo)
+        scrollTo(ideasSectionRef)
+    }
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
@@ -124,11 +236,25 @@ const DevPortalPage: NextPage = () => {
                 <Typography variant="h3" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                     Developer Portal
                 </Typography>
-                <Typography variant="body1" gutterBottom color="text.secondary" sx={{mb: 3}}>
+                <Typography variant="body1" gutterBottom color="text.secondary" sx={{mb: 2}}>
                     Every open issue and pull request across the Dans-Plugins GitHub org, mirrored here so the
                     state of each plugin is a glance instead of a dozen tabs. GitHub stays the source of truth —
                     this view refreshes on a schedule and never writes back.
                 </Typography>
+
+                <Stack direction="row" spacing={1} sx={{mb: 3}}>
+                    <MuiLink component="button" variant="body2" onClick={() => scrollTo(repoSectionRef)}>
+                        Jump to: repositories
+                    </MuiLink>
+                    <Typography color="text.secondary">·</Typography>
+                    <MuiLink component="button" variant="body2" onClick={() => scrollTo(itemsSectionRef)}>
+                        open items
+                    </MuiLink>
+                    <Typography color="text.secondary">·</Typography>
+                    <MuiLink component="button" variant="body2" onClick={() => scrollTo(ideasSectionRef)}>
+                        feature requests
+                    </MuiLink>
+                </Stack>
 
                 {error && (
                     <Alert severity="info" sx={{mb: 2}}>
@@ -136,9 +262,43 @@ const DevPortalPage: NextPage = () => {
                     </Alert>
                 )}
 
-                <Typography variant="h6" component="h2" gutterBottom>
-                    By repository
-                </Typography>
+                <Stack direction="row" spacing={1.5} sx={{mb: 4, flexWrap: 'wrap'}}>
+                    <StatTile value={loading ? <Skeleton width={40} sx={{mx: 'auto'}}/> : totals.openIssues} label="Open issues"/>
+                    <StatTile value={loading ? <Skeleton width={40} sx={{mx: 'auto'}}/> : totals.openPrs} label="Open PRs"/>
+                    <StatTile
+                        value={loading ? <Skeleton width={40} sx={{mx: 'auto'}}/> : totals.draftPrs}
+                        label="Stuck in draft"
+                        tone={totals.draftPrs > 0 ? 'warn' : undefined}
+                    />
+                    <StatTile
+                        value={loading ? <Skeleton width={60} sx={{mx: 'auto'}}/> : (totals.oldest ? relativeTimeFrom(totals.oldest, Date.now()) : '—')}
+                        label="Oldest open item"
+                        tone="crit"
+                    />
+                </Stack>
+
+                <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{mb: 1.5, flexWrap: 'wrap', gap: 1}} ref={repoSectionRef}>
+                    <Typography variant="h6" component="h2">
+                        By repository
+                    </Typography>
+                    <ToggleButtonGroup
+                        size="small"
+                        exclusive
+                        value={signalFilter}
+                        onChange={(_e, value) => value !== null && setSignalFilter(value)}
+                        aria-label="filter by signal"
+                    >
+                        <ToggleButton value="all">All</ToggleButton>
+                        {(Object.keys(SIGNALS) as SignalKey[]).map((key) => (
+                            <ToggleButton key={key} value={key}>
+                                <Tooltip title={SIGNALS[key].description}>
+                                    <span>{SIGNALS[key].label}</span>
+                                </Tooltip>
+                            </ToggleButton>
+                        ))}
+                    </ToggleButtonGroup>
+                </Stack>
+
                 <Card sx={{mb: 4}}>
                     <CardContent sx={{p: 0, '&:last-child': {pb: 0}}}>
                         <TableContainer>
@@ -163,6 +323,7 @@ const DevPortalPage: NextPage = () => {
                                         <TableCell align="right">PRs (draft)</TableCell>
                                         <TableCell>Oldest open item</TableCell>
                                         <TableCell>Signal</TableCell>
+                                        <TableCell align="right">Ideas</TableCell>
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
@@ -174,21 +335,30 @@ const DevPortalPage: NextPage = () => {
                                                 <TableCell align="right"><Skeleton width={50}/></TableCell>
                                                 <TableCell><Skeleton width={100}/></TableCell>
                                                 <TableCell><Skeleton width={90}/></TableCell>
+                                                <TableCell align="right"><Skeleton width={30}/></TableCell>
                                             </TableRow>
                                         ))
+                                    ) : visibleSummary.length === 0 ? (
+                                        <TableRow>
+                                            <TableCell colSpan={6} align="center" sx={{py: 4}}>
+                                                <Typography color="text.secondary">
+                                                    No repos match this filter.
+                                                </Typography>
+                                            </TableCell>
+                                        </TableRow>
                                     ) : (
-                                        summary.map((row) => {
-                                            const signal = signalFor(row)
+                                        visibleSummary.map((row) => {
+                                            const signal = signalByRepo[row.repo]
                                             return (
                                                 <TableRow
                                                     key={row.repo}
                                                     hover
                                                     selected={repoFilter === row.repo}
-                                                    onClick={() => setRepoFilter(repoFilter === row.repo ? '' : row.repo)}
+                                                    onClick={() => jumpToRepo(row.repo)}
                                                     sx={{cursor: 'pointer'}}
                                                 >
                                                     <TableCell>
-                                                        <Typography fontWeight={600}>{row.repo}</Typography>
+                                                        <Typography fontWeight={600}>{row.repo} →</Typography>
                                                     </TableCell>
                                                     <TableCell align="right">{row.openIssueCount}</TableCell>
                                                     <TableCell align="right">
@@ -205,7 +375,23 @@ const DevPortalPage: NextPage = () => {
                                                             : '—'}
                                                     </TableCell>
                                                     <TableCell>
-                                                        <Chip label={signal.label} size="small" color={signal.color}/>
+                                                        <Tooltip title={signal.description}>
+                                                            <Chip label={signal.label} size="small" color={signal.color}/>
+                                                        </Tooltip>
+                                                    </TableCell>
+                                                    <TableCell align="right">
+                                                        {ideaCounts[row.repo] ? (
+                                                            <Chip
+                                                                label={ideaCounts[row.repo]}
+                                                                size="small"
+                                                                variant="outlined"
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation()
+                                                                    jumpToIdeas(row.repo)
+                                                                }}
+                                                                clickable
+                                                            />
+                                                        ) : '—'}
                                                     </TableCell>
                                                 </TableRow>
                                             )
@@ -217,26 +403,67 @@ const DevPortalPage: NextPage = () => {
                     </CardContent>
                 </Card>
 
-                <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{mb: 2}}>
+                <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{mb: 2, flexWrap: 'wrap', gap: 1}} ref={itemsSectionRef}>
                     <Typography variant="h6" component="h2">
                         Open items {repoFilter && `— ${repoFilter}`}
                     </Typography>
-                    <TextField
-                        select
-                        size="small"
-                        label="Repo"
-                        value={repoFilter}
-                        onChange={(e) => setRepoFilter(e.target.value)}
-                        sx={{minWidth: 220}}
-                    >
-                        <MenuItem value="">All repos</MenuItem>
-                        {summary.map((row) => (
-                            <MenuItem key={row.repo} value={row.repo}>{row.repo}</MenuItem>
-                        ))}
-                    </TextField>
+                    <Stack direction="row" spacing={1.5} flexWrap="wrap">
+                        <TextField
+                            select
+                            size="small"
+                            label="Repo"
+                            value={repoFilter}
+                            onChange={(e) => setRepoFilter(e.target.value)}
+                            sx={{minWidth: 200}}
+                        >
+                            <MenuItem value="">All repos</MenuItem>
+                            {summary.map((row) => (
+                                <MenuItem key={row.repo} value={row.repo}>{row.repo}</MenuItem>
+                            ))}
+                        </TextField>
+                        <TextField
+                            select
+                            size="small"
+                            label="Type"
+                            value={typeFilter}
+                            onChange={(e) => setTypeFilter(e.target.value as ItemTypeFilter)}
+                            sx={{minWidth: 150}}
+                        >
+                            <MenuItem value="all">All types</MenuItem>
+                            <MenuItem value="issue">Issues only</MenuItem>
+                            <MenuItem value="pr">PRs only</MenuItem>
+                            <MenuItem value="draft">Draft PRs only</MenuItem>
+                        </TextField>
+                        <TextField
+                            select
+                            size="small"
+                            label="Sort by"
+                            value={sortOrder}
+                            onChange={(e) => setSortOrder(e.target.value as SortOrder)}
+                            sx={{minWidth: 170}}
+                        >
+                            <MenuItem value="oldest">Oldest first</MenuItem>
+                            <MenuItem value="newest">Newest first</MenuItem>
+                            <MenuItem value="most-interested">Most interested</MenuItem>
+                        </TextField>
+                    </Stack>
                 </Stack>
 
-                <Card>
+                {(repoFilter || signalFilter !== 'all' || typeFilter !== 'all') && (
+                    <Stack direction="row" spacing={1} sx={{mb: 1.5}} flexWrap="wrap">
+                        {repoFilter && (
+                            <Chip label={`Repo: ${repoFilter}`} size="small" onDelete={() => setRepoFilter('')}/>
+                        )}
+                        {signalFilter !== 'all' && (
+                            <Chip label={`Signal: ${SIGNALS[signalFilter].label}`} size="small" onDelete={() => setSignalFilter('all')}/>
+                        )}
+                        {typeFilter !== 'all' && (
+                            <Chip label={`Type: ${typeFilter}`} size="small" onDelete={() => setTypeFilter('all')}/>
+                        )}
+                    </Stack>
+                )}
+
+                <Card sx={{mb: 4}}>
                     <CardContent sx={{p: 0, '&:last-child': {pb: 0}}}>
                         <TableContainer>
                             <Table size="small">
@@ -277,7 +504,7 @@ const DevPortalPage: NextPage = () => {
                                         <TableRow>
                                             <TableCell colSpan={5} align="center" sx={{py: 4}}>
                                                 <Typography color="text.secondary">
-                                                    Nothing open here right now.
+                                                    Nothing matches these filters.
                                                 </Typography>
                                             </TableCell>
                                         </TableRow>
@@ -338,11 +565,13 @@ const DevPortalPage: NextPage = () => {
                     </CardContent>
                 </Card>
 
-                <FeatureRequestSection
-                    repos={summary.map((row) => row.repo)}
-                    repoFilter={repoFilter}
-                    token={token}
-                />
+                <Box ref={ideasSectionRef}>
+                    <FeatureRequestSection
+                        repos={summary.map((row) => row.repo)}
+                        repoFilter={repoFilter}
+                        token={token}
+                    />
+                </Box>
             </Container>
             <BottomBar version={version}/>
         </Box>

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -15,6 +15,7 @@ import {
     TableContainer,
     TableHead,
     TableRow,
+    TableSortLabel,
     TextField,
     ToggleButton,
     ToggleButtonGroup,
@@ -56,6 +57,15 @@ const SIGNALS: Record<SignalKey, Omit<Signal, 'key'>> = {
     quiet: {label: 'Quiet', color: 'default', description: 'Nothing open right now.'},
 }
 
+// Higher = more urgent; drives the default "Signal" column sort (most urgent first).
+const SIGNAL_SEVERITY: Record<SignalKey, number> = {
+    stale: 4,
+    'automation-backlog': 3,
+    'needs-triage': 3,
+    active: 1,
+    quiet: 0,
+}
+
 const signalFor = (summary: RepoSummary): Signal => {
     const total = summary.openIssueCount + summary.openPrCount
     const ageDays = summary.oldestOpenItemAt
@@ -77,7 +87,68 @@ const signalFor = (summary: RepoSummary): Signal => {
 }
 
 type ItemTypeFilter = 'all' | 'issue' | 'pr' | 'draft'
-type SortOrder = 'oldest' | 'newest' | 'most-interested'
+type SortDirection = 'asc' | 'desc'
+type RepoSortColumn = 'repo' | 'issues' | 'prs' | 'oldest' | 'signal'
+type ItemSortColumn = 'item' | 'type' | 'opened' | 'interested'
+
+interface SortState<C extends string> {
+    column: C | null
+    direction: SortDirection
+}
+
+// First click on a column sorts in the direction that's usually most useful for
+// it (e.g. "Oldest" ascending puts the oldest item on top; "Interested"
+// descending puts the most-wanted item on top). A second click on the same
+// column flips it.
+const REPO_DEFAULT_DIRECTION: Record<RepoSortColumn, SortDirection> = {
+    repo: 'asc', issues: 'desc', prs: 'desc', oldest: 'asc', signal: 'desc',
+}
+const ITEM_DEFAULT_DIRECTION: Record<ItemSortColumn, SortDirection> = {
+    item: 'asc', type: 'asc', opened: 'asc', interested: 'desc',
+}
+
+function toggleSort<C extends string>(
+    current: SortState<C>,
+    column: C,
+    defaultDirections: Record<C, SortDirection>
+): SortState<C> {
+    if (current.column !== column) {
+        return {column, direction: defaultDirections[column]}
+    }
+    return {column, direction: current.direction === 'asc' ? 'desc' : 'asc'}
+}
+
+const compareRepoRows = (a: RepoSummary, b: RepoSummary, column: RepoSortColumn, signalByRepo: Record<string, Signal>): number => {
+    switch (column) {
+        case 'repo':
+            return a.repo.localeCompare(b.repo)
+        case 'issues':
+            return a.openIssueCount - b.openIssueCount
+        case 'prs':
+            return a.openPrCount - b.openPrCount
+        case 'oldest':
+            return (a.oldestOpenItemAt ?? '9999').localeCompare(b.oldestOpenItemAt ?? '9999')
+        case 'signal':
+            return SIGNAL_SEVERITY[signalByRepo[a.repo]?.key ?? 'quiet'] - SIGNAL_SEVERITY[signalByRepo[b.repo]?.key ?? 'quiet']
+        default:
+            return 0
+    }
+}
+
+const compareItemRows = (a: BacklogItem, b: BacklogItem, column: ItemSortColumn, interestCounts: Record<string, number>): number => {
+    switch (column) {
+        case 'item':
+            return a.targetId.localeCompare(b.targetId)
+        case 'type':
+            return a.itemType.localeCompare(b.itemType) || Number(a.draft) - Number(b.draft)
+        case 'opened':
+            return a.githubCreatedAt.localeCompare(b.githubCreatedAt)
+        case 'interested':
+            return (interestCounts[a.targetId] || 0) - (interestCounts[b.targetId] || 0)
+        default:
+            return 0
+    }
+}
 
 const StatTile: React.FC<{value: React.ReactNode; label: string; tone?: 'warn' | 'crit'}> = ({value, label, tone}) => (
     <Card variant="outlined" sx={{flex: '1 1 160px', textAlign: 'center', py: 1.5}}>
@@ -95,13 +166,36 @@ const StatTile: React.FC<{value: React.ReactNode; label: string; tone?: 'warn' |
     </Card>
 )
 
+interface SortableHeaderProps<C extends string> {
+    label: string
+    column: C
+    align?: 'left' | 'right' | 'center'
+    sort: SortState<C>
+    onSort: (column: C) => void
+}
+
+function SortableHeader<C extends string>({label, column, align, sort, onSort}: SortableHeaderProps<C>) {
+    return (
+        <TableCell align={align}>
+            <TableSortLabel
+                active={sort.column === column}
+                direction={sort.column === column ? sort.direction : 'asc'}
+                onClick={() => onSort(column)}
+            >
+                {label}
+            </TableSortLabel>
+        </TableCell>
+    )
+}
+
 const DevPortalPage: NextPage = () => {
     const [summary, setSummary] = useState<RepoSummary[]>([])
     const [items, setItems] = useState<BacklogItem[]>([])
     const [repoFilter, setRepoFilter] = useState('')
     const [signalFilter, setSignalFilter] = useState<SignalKey | 'all'>('all')
     const [typeFilter, setTypeFilter] = useState<ItemTypeFilter>('all')
-    const [sortOrder, setSortOrder] = useState<SortOrder>('oldest')
+    const [repoSort, setRepoSort] = useState<SortState<RepoSortColumn>>({column: null, direction: 'desc'})
+    const [itemSort, setItemSort] = useState<SortState<ItemSortColumn>>({column: null, direction: 'asc'})
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
     const [interestCounts, setInterestCounts] = useState<Record<string, number>>({})
@@ -176,10 +270,17 @@ const DevPortalPage: NextPage = () => {
         [summary]
     )
 
-    const visibleSummary = useMemo(
-        () => (signalFilter === 'all' ? summary : summary.filter((row) => signalByRepo[row.repo]?.key === signalFilter)),
-        [summary, signalFilter, signalByRepo]
-    )
+    const visibleSummary = useMemo(() => {
+        const filtered = signalFilter === 'all' ? summary : summary.filter((row) => signalByRepo[row.repo]?.key === signalFilter)
+        if (!repoSort.column) {
+            return filtered
+        }
+        const column = repoSort.column
+        return [...filtered].sort((a, b) => {
+            const result = compareRepoRows(a, b, column, signalByRepo)
+            return repoSort.direction === 'asc' ? result : -result
+        })
+    }, [summary, signalFilter, signalByRepo, repoSort])
 
     const totals = useMemo(() => {
         const openIssues = summary.reduce((sum, r) => sum + r.openIssueCount, 0)
@@ -207,16 +308,15 @@ const DevPortalPage: NextPage = () => {
         } else if (typeFilter === 'draft') {
             list = list.filter((item) => item.itemType === 'PULL_REQUEST' && item.draft)
         }
-        const sorted = [...list]
-        if (sortOrder === 'newest') {
-            sorted.sort((a, b) => b.githubCreatedAt.localeCompare(a.githubCreatedAt))
-        } else if (sortOrder === 'most-interested') {
-            sorted.sort((a, b) => (interestCounts[b.targetId] || 0) - (interestCounts[a.targetId] || 0))
-        } else {
-            sorted.sort((a, b) => a.githubCreatedAt.localeCompare(b.githubCreatedAt))
+        if (!itemSort.column) {
+            return list
         }
-        return sorted
-    }, [items, repoFilter, signalFilter, typeFilter, sortOrder, signalByRepo, interestCounts])
+        const column = itemSort.column
+        return [...list].sort((a, b) => {
+            const result = compareItemRows(a, b, column, interestCounts)
+            return itemSort.direction === 'asc' ? result : -result
+        })
+    }, [items, repoFilter, signalFilter, typeFilter, signalByRepo, itemSort, interestCounts])
 
     const jumpToRepo = (repo: string) => {
         setRepoFilter(repoFilter === repo ? '' : repo)
@@ -318,11 +418,16 @@ const DevPortalPage: NextPage = () => {
                                             },
                                         }}
                                     >
-                                        <TableCell>Repo</TableCell>
-                                        <TableCell align="right">Issues</TableCell>
-                                        <TableCell align="right">PRs (draft)</TableCell>
-                                        <TableCell>Oldest open item</TableCell>
-                                        <TableCell>Signal</TableCell>
+                                        <SortableHeader label="Repo" column="repo" sort={repoSort}
+                                            onSort={(c) => setRepoSort((s) => toggleSort(s, c, REPO_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="Issues" column="issues" align="right" sort={repoSort}
+                                            onSort={(c) => setRepoSort((s) => toggleSort(s, c, REPO_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="PRs (draft)" column="prs" align="right" sort={repoSort}
+                                            onSort={(c) => setRepoSort((s) => toggleSort(s, c, REPO_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="Oldest open item" column="oldest" sort={repoSort}
+                                            onSort={(c) => setRepoSort((s) => toggleSort(s, c, REPO_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="Signal" column="signal" sort={repoSort}
+                                            onSort={(c) => setRepoSort((s) => toggleSort(s, c, REPO_DEFAULT_DIRECTION))}/>
                                         <TableCell align="right">Ideas</TableCell>
                                     </TableRow>
                                 </TableHead>
@@ -434,18 +539,6 @@ const DevPortalPage: NextPage = () => {
                             <MenuItem value="pr">PRs only</MenuItem>
                             <MenuItem value="draft">Draft PRs only</MenuItem>
                         </TextField>
-                        <TextField
-                            select
-                            size="small"
-                            label="Sort by"
-                            value={sortOrder}
-                            onChange={(e) => setSortOrder(e.target.value as SortOrder)}
-                            sx={{minWidth: 170}}
-                        >
-                            <MenuItem value="oldest">Oldest first</MenuItem>
-                            <MenuItem value="newest">Newest first</MenuItem>
-                            <MenuItem value="most-interested">Most interested</MenuItem>
-                        </TextField>
                     </Stack>
                 </Stack>
 
@@ -482,10 +575,14 @@ const DevPortalPage: NextPage = () => {
                                             },
                                         }}
                                     >
-                                        <TableCell>Item</TableCell>
-                                        <TableCell>Type</TableCell>
-                                        <TableCell>Opened</TableCell>
-                                        <TableCell align="center">Interested</TableCell>
+                                        <SortableHeader label="Item" column="item" sort={itemSort}
+                                            onSort={(c) => setItemSort((s) => toggleSort(s, c, ITEM_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="Type" column="type" sort={itemSort}
+                                            onSort={(c) => setItemSort((s) => toggleSort(s, c, ITEM_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="Opened" column="opened" sort={itemSort}
+                                            onSort={(c) => setItemSort((s) => toggleSort(s, c, ITEM_DEFAULT_DIRECTION))}/>
+                                        <SortableHeader label="Interested" column="interested" align="center" sort={itemSort}
+                                            onSort={(c) => setItemSort((s) => toggleSort(s, c, ITEM_DEFAULT_DIRECTION))}/>
                                         <TableCell>Claimed</TableCell>
                                     </TableRow>
                                 </TableHead>


### PR DESCRIPTION
## Summary
Stacked on #234. Follow-up UX pass after looking at the live preview — the original /dev was two flat tables and a form with no sense of overall state and no fast path to "what should I actually do."

- Stat strip at the top: open issues / open PRs / stuck-in-draft / oldest open item — the headline numbers, visible without reading either table.
- Signal filter (Active / Needs triage / Automation backlog / Stale), applied to both the repo table and the item list, with a tooltip on each explaining what it means.
- Item-list controls: type filter (issues / PRs / draft PRs) and sort (oldest first / newest first / most interested) — "what's most wanted" is now one click, not a manual scan of ~300 rows.
- Clicking a repo row scrolls you down to its items (previously it silently filtered while the page stayed scrolled at the top — easy to miss that anything happened). An "Ideas" column jumps straight to that repo's feature requests.
- Active filters render as removable chips; three jump-to links at the top get you to repositories / items / feature requests without scrolling.

No backend changes — this is frontend-only.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 103 tests, 0 failures (unchanged; no new testable logic beyond what's already covered — the changes are presentational/interaction wiring)
- [x] `npm run build` — compiles, `/dev` renders
- [x] Verified live against the running preview deploy (real GitHub-sourced backlog data) — stat strip totals match the repo table, signal filter/sort/type filter all narrow correctly, repo-row click scrolls to items, Ideas chip jumps to feature requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_