### PR TITLE
Show real plugin icons on catalogue cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Plugin cards now show each plugin's real branded icon (from `public/icons/`) instead of a generated letter avatar where one is mapped in `plugins.json`; plugins without a mapped icon still fall back to the letter avatar (#214).
+
 ## [0.14.0] – 2026-06-14
 
 ### Added

--- a/__tests__/pluginIcons.test.ts
+++ b/__tests__/pluginIcons.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from 'vitest'
+import {existsSync} from 'fs'
+import {join} from 'path'
+import plugins from '../pages/data/plugins.json'
+
+describe('plugin icon paths', () => {
+    it('every mapped icon file exists under public/', () => {
+        const missing = plugins.plugins
+            .filter((plugin) => plugin.icon)
+            .filter((plugin) => !existsSync(join(__dirname, '..', 'public', plugin.icon as string)))
+            .map((plugin) => `${plugin.id}: ${plugin.icon}`)
+
+        expect(missing).toEqual([])
+    })
+})

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -17,6 +17,7 @@ interface PluginCardProps {
     githubLink: string;
     spigotmcLink?: string;
     bStatsId?: string;
+    icon?: string;
     serverCount?: number | null;
     likeCount: number;
     liked: boolean;
@@ -42,6 +43,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
     description,
     githubLink,
     spigotmcLink,
+    icon,
     serverCount,
     likeCount,
     liked,
@@ -53,7 +55,9 @@ const PluginCard: React.FC<PluginCardProps> = ({
                 <Stack direction="row" spacing={1.5} alignItems="center" sx={{mb: 1.5}}>
                     <Avatar
                         variant="rounded"
-                        aria-hidden
+                        src={icon}
+                        alt={icon ? `${title} icon` : undefined}
+                        aria-hidden={!icon}
                         sx={{
                             bgcolor: colorForTitle(title),
                             width: 40,

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -55,9 +55,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
                 <Stack direction="row" spacing={1.5} alignItems="center" sx={{mb: 1.5}}>
                     <Avatar
                         variant="rounded"
-                        src={icon}
-                        alt={icon ? `${title} icon` : undefined}
-                        aria-hidden={!icon}
+                        {...(icon ? {src: icon, alt: `${title} icon`} : {'aria-hidden': true})}
                         sx={{
                             bgcolor: colorForTitle(title),
                             width: 40,

--- a/pages/data/plugins.json
+++ b/pages/data/plugins.json
@@ -6,7 +6,8 @@
       "description": "Tracks the activity of players.",
       "githubLink": "https://github.com/Dans-Plugins/Activity-Tracker",
       "spigotmcLink": "https://www.spigotmc.org/resources/activity-tracker.96724/",
-      "bStatsId": "12983"
+      "bStatsId": "12983",
+      "icon": "/icons/at.png"
     },
     {
       "id": "alternate-account-finder",
@@ -14,7 +15,8 @@
       "description": "Identifies accounts that have used the same IP address.",
       "githubLink": "https://github.com/Dans-Plugins/AlternateAccountFinder",
       "spigotmcLink": "https://www.spigotmc.org/resources/alternate-account-finder.83290/",
-      "bStatsId": "9834"
+      "bStatsId": "9834",
+      "icon": "/icons/aaf.png"
     },
     {
       "id": "currencies",
@@ -22,7 +24,8 @@
       "description": "An expansion for Medieval Factions that allows faction owners to create and mint local currencies.",
       "githubLink": "https://github.com/Dans-Plugins/Currencies",
       "spigotmcLink": "https://www.spigotmc.org/resources/currencies.96381/",
-      "bStatsId": "12810"
+      "bStatsId": "12810",
+      "icon": "/icons/c.png"
     },
     {
       "id": "dans-essentials",
@@ -30,7 +33,8 @@
       "description": "Provides miscellaneous commands.",
       "githubLink": "https://github.com/Dans-Plugins/Dans-Essentials",
       "spigotmcLink": "https://www.spigotmc.org/resources/dans-essentials.80513/",
-      "bStatsId": "9527"
+      "bStatsId": "9527",
+      "icon": "/icons/de.png"
     },
     {
       "id": "dans-spawn-system",
@@ -38,7 +42,8 @@
       "description": "Allows players to use signs to select a custom spawn in their world.",
       "githubLink": "https://github.com/Dans-Plugins/Dans-Spawn-System",
       "spigotmcLink": "https://www.spigotmc.org/resources/dans-spawn-system.82697/",
-      "bStatsId": "12161"
+      "bStatsId": "12161",
+      "icon": "/icons/dss.png"
     },
     {
       "id": "fiefs",
@@ -46,7 +51,8 @@
       "description": "Allows players to create fiefs and manage them.",
       "githubLink": "https://github.com/Dans-Plugins/Fiefs",
       "spigotmcLink": "https://www.spigotmc.org/resources/fiefs-early-access.98559/",
-      "bStatsId": "12743"
+      "bStatsId": "12743",
+      "icon": "/icons/f.png"
     },
     {
       "id": "food-spoilage",
@@ -54,7 +60,8 @@
       "description": "Makes food items turn into rotten flesh after a certain period of time.",
       "githubLink": "https://github.com/Dans-Plugins/FoodSpoilage",
       "spigotmcLink": "https://www.spigotmc.org/resources/food-spoilage.81507/",
-      "bStatsId": "8992"
+      "bStatsId": "8992",
+      "icon": "/icons/fs.png"
     },
     {
       "id": "mailboxes",
@@ -62,7 +69,8 @@
       "description": "Allows players and plugins to send persistent messages to players.",
       "githubLink": "https://github.com/Dans-Plugins/Mailboxes",
       "spigotmcLink": "https://www.spigotmc.org/resources/mailboxes.96611/",
-      "bStatsId": "12902"
+      "bStatsId": "12902",
+      "icon": "/icons/m.png"
     },
     {
       "id": "medieval-cookery",
@@ -78,7 +86,8 @@
       "description": "Allows players to organize themselves into feudal, diplomatic, lawful groups akin to nations.",
       "githubLink": "https://github.com/Dans-Plugins/Medieval-Factions",
       "spigotmcLink": "https://www.spigotmc.org/resources/medieval-factions.79941/",
-      "bStatsId": "8929"
+      "bStatsId": "8929",
+      "icon": "/icons/mf.png"
     },
     {
       "id": "medieval-roleplay-engine",
@@ -86,7 +95,8 @@
       "description": "Facilitates roleplay between players.",
       "githubLink": "https://github.com/Dans-Plugins/Medieval-Roleplay-Engine",
       "spigotmcLink": "https://www.spigotmc.org/resources/medieval-roleplay-engine.79993/",
-      "bStatsId": "8996"
+      "bStatsId": "8996",
+      "icon": "/icons/mre.png"
     },
     {
       "id": "more-recipes",
@@ -94,7 +104,8 @@
       "description": "Adds static recipes for items that are not craftable in vanilla.",
       "githubLink": "https://github.com/Dans-Plugins/More-Recipes",
       "spigotmcLink": "https://www.spigotmc.org/resources/more-recipes.81832/",
-      "bStatsId": "12140"
+      "bStatsId": "12140",
+      "icon": "/icons/mr.png"
     },
     {
       "id": "nether-access-controller",
@@ -102,7 +113,8 @@
       "description": "Allows operators to control who has access to the nether.",
       "githubLink": "https://github.com/Dans-Plugins/Nether-Access-Controller",
       "spigotmcLink": "https://www.spigotmc.org/resources/nether-access-controller.95905/",
-      "bStatsId": "12673"
+      "bStatsId": "12673",
+      "icon": "/icons/nac.png"
     },
     {
       "id": "no-more-creepers",
@@ -110,7 +122,8 @@
       "description": "Prevents creepers from spawning.",
       "githubLink": "https://github.com/Dans-Plugins/NoMoreCreepers",
       "spigotmcLink": "https://www.spigotmc.org/resources/nomorecreepers.97946/",
-      "bStatsId": "13432"
+      "bStatsId": "13432",
+      "icon": "/icons/nmc.png"
     },
     {
       "id": "simple-skills",
@@ -118,7 +131,8 @@
       "description": "Introduces skills into the game in a systematic, easy to use, expandable way.",
       "githubLink": "https://github.com/Dans-Plugins/SimpleSkills",
       "spigotmcLink": "https://www.spigotmc.org/resources/simpleskills.98039/",
-      "bStatsId": "13470"
+      "bStatsId": "13470",
+      "icon": "/icons/ss.png"
     },
     {
       "id": "wild-pets",
@@ -126,7 +140,8 @@
       "description": "Allows players to tame any entity and keep them as a pet.",
       "githubLink": "https://github.com/Dans-Plugins/Wild-Pets",
       "spigotmcLink": "https://www.spigotmc.org/resources/wild-pets.95800/",
-      "bStatsId": "12332"
+      "bStatsId": "12332",
+      "icon": "/icons/wp.png"
     }
   ],
   "mostPopular": [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,6 +48,7 @@ interface Plugin {
     githubLink: string;
     spigotmcLink?: string;
     bStatsId?: string;
+    icon?: string;
 }
 
 interface PluginWithServerCount extends Plugin {
@@ -72,6 +73,7 @@ const PluginSection: React.FC<PluginSectionProps> = ({ plugins, likeCounts, like
                     githubLink={plugin.githubLink}
                     spigotmcLink={plugin.spigotmcLink}
                     bStatsId={plugin.bStatsId}
+                    icon={plugin.icon}
                     serverCount={plugin.serverCount}
                     likeCount={likeCounts[plugin.id] || 0}
                     liked={likedSet.has(plugin.id)}


### PR DESCRIPTION
## Summary
- Plugin cards previously rendered a generated letter-avatar for every plugin, even though branded icons for most plugins already exist unused under `public/icons/`.
- Adds an optional `icon` field to each `pages/data/plugins.json` entry and renders it as the card `Avatar`'s `src` in `components/PluginCard.tsx`, with descriptive alt text (`"<Title> icon"`).
- Mapped 15 of 16 plugins to their existing icon file, verified by viewing each icon image against the plugin it represents. `medieval-cookery` has no confidently-matching icon asset in `public/icons/`, so it (and any future plugin without an `icon` entry) still falls back to the original letter avatar — no guessed/incorrect mapping was forced.
- CHANGELOG updated under `[Unreleased]`.

Closes #214

## Test plan
- [x] `npm run lint` — no warnings/errors
- [x] `npm run build` — compiles and generates all pages successfully
- [x] `npm test` — all 103 existing tests pass unchanged
- [x] Ran `next dev` locally and fetched the homepage HTML: confirmed all 15 mapped icons return `200` and render with correct `alt="<Title> icon"` text, and confirmed `medieval-cookery` still renders the `aria-hidden` letter-avatar fallback (`M`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_