### PR TITLE
Fix ProfileAuthIntegrationTest missing @AfterEach cleanup

### DIFF
--- a/dpc-api/src/test/java/com/dansplugins/api/controller/FactionControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/FactionControllerTest.java
@@ -51,18 +51,23 @@ class FactionControllerTest {
 
     @BeforeEach
     void setUp() {
-        factionRepository.deleteAll();
-        apiKeyRepository.deleteAll();
-        userRepository.deleteAll();
+        clearDatabase();
         User user = userService.getOrCreate("test-user");
         apiKey = userService.createApiKey(user, "test-server").getRawKey();
     }
 
     @AfterEach
     void tearDown() {
-        // The test H2 DB is shared across @SpringBootTest classes; clean up the rows
-        // (children before users, FK order) so a leftover row can't block another
-        // class's userRepository.deleteAll().
+        clearDatabase();
+    }
+
+    /**
+     * Delete children (factions, api keys) before users — FK order. The test
+     * H2 DB is shared across @SpringBootTest classes, so this runs both before
+     * and after each test to keep a leftover row from this class from blocking
+     * another class's userRepository.deleteAll().
+     */
+    private void clearDatabase() {
         factionRepository.deleteAll();
         apiKeyRepository.deleteAll();
         userRepository.deleteAll();

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/FactionControllerTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/FactionControllerTest.java
@@ -6,6 +6,7 @@ import com.dansplugins.api.repository.ApiKeyRepository;
 import com.dansplugins.api.repository.FactionRepository;
 import com.dansplugins.api.repository.UserRepository;
 import com.dansplugins.api.service.UserService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +56,16 @@ class FactionControllerTest {
         userRepository.deleteAll();
         User user = userService.getOrCreate("test-user");
         apiKey = userService.createApiKey(user, "test-server").getRawKey();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // The test H2 DB is shared across @SpringBootTest classes; clean up the rows
+        // (children before users, FK order) so a leftover row can't block another
+        // class's userRepository.deleteAll().
+        factionRepository.deleteAll();
+        apiKeyRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -57,18 +57,22 @@ class ProfileAuthIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        // Delete children (api keys, likes) before users — both FK to users.
-        apiKeyRepository.deleteAll();
-        likeRepository.deleteAll();
-        userRepository.deleteAll();
+        clearDatabase();
         when(userAuthClient.validate("good-token")).thenReturn(Optional.of("alice"));
     }
 
     @AfterEach
     void tearDown() {
-        // The test H2 DB is shared across @SpringBootTest classes; clean up the rows
-        // (children before users, FK order) so a leftover row can't block another
-        // class's userRepository.deleteAll().
+        clearDatabase();
+    }
+
+    /**
+     * Delete children (api keys, likes) before users — both FK to users. The
+     * test H2 DB is shared across @SpringBootTest classes, so this runs both
+     * before and after each test to keep a leftover row from this class from
+     * blocking another class's userRepository.deleteAll().
+     */
+    private void clearDatabase() {
         apiKeyRepository.deleteAll();
         likeRepository.deleteAll();
         userRepository.deleteAll();

--- a/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
+++ b/dpc-api/src/test/java/com/dansplugins/api/controller/ProfileAuthIntegrationTest.java
@@ -4,6 +4,7 @@ import com.dansplugins.api.repository.ApiKeyRepository;
 import com.dansplugins.api.repository.LikeRepository;
 import com.dansplugins.api.repository.UserRepository;
 import com.dansplugins.api.service.UserAuthClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +62,16 @@ class ProfileAuthIntegrationTest {
         likeRepository.deleteAll();
         userRepository.deleteAll();
         when(userAuthClient.validate("good-token")).thenReturn(Optional.of("alice"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        // The test H2 DB is shared across @SpringBootTest classes; clean up the rows
+        // (children before users, FK order) so a leftover row can't block another
+        // class's userRepository.deleteAll().
+        apiKeyRepository.deleteAll();
+        likeRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `ProfileAuthIntegrationTest` had a `@BeforeEach` that cleans `apiKeyRepository`, `likeRepository`, and `userRepository` (FK-safe order) but no `@AfterEach`, so whichever test method ran last left a row behind in the shared H2 test DB.
- `LikeControllerTest`'s own teardown only cleans `likeRepository`/`userRepository`, not `apiKeyRepository`, so when it ran after `ProfileAuthIntegrationTest` in the same Surefire session, `userRepository.deleteAll()` failed on the leftover API key's FK reference — this is the deterministic CI failure blocking PR #238.
- Adds an `@AfterEach` to `ProfileAuthIntegrationTest` mirroring its own `@BeforeEach`, matching the pattern already used in `LikeControllerTest`.
- `FactionControllerTest` had the same gap (a `@BeforeEach` cleaning `factionRepository`/`apiKeyRepository`/`userRepository` with no matching `@AfterEach`), which would cause the identical FK-violation failure depending on test-class ordering. Fixed with the same `@AfterEach` pattern for consistency and to prevent a recurrence of this issue from a different class.
- Audited every other `@SpringBootTest` controller test class in this package (`FeatureRequestControllerTest`, `BacklogControllerTest`, `ClaimControllerTest`, `LikeControllerTest`) — each already has an `@AfterEach` that cleans up everything its `@BeforeEach` touches, so no further changes are needed there.

Closes #239

## Test plan
- [x] CI: `Build & Test API (Java)` passes — https://github.com/Dans-Plugins/dansplugins-dot-com/actions/runs/29703509188/job/88236504410

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
