### PR TITLE
test: cover badges.ts and visitService.ts

### DIFF
--- a/__tests__/badges.test.ts
+++ b/__tests__/badges.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest';
+import {badgeLabel, BADGE_LABELS} from '../utils/badges';
+
+describe('badgeLabel', () => {
+    it('returns the human-readable label for a known badge code', () => {
+        expect(badgeLabel('SERVER_OWNER')).toBe('Server Owner');
+    });
+
+    it('falls back to the raw code for an unknown badge', () => {
+        expect(badgeLabel('SOME_NEW_BADGE')).toBe('SOME_NEW_BADGE');
+    });
+
+    it('is consistent with the BADGE_LABELS map for every known code', () => {
+        Object.entries(BADGE_LABELS).forEach(([code, label]) => {
+            expect(badgeLabel(code)).toBe(label);
+        });
+    });
+});

--- a/__tests__/visitService.test.ts
+++ b/__tests__/visitService.test.ts
@@ -1,0 +1,51 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getVisits, incrementVisits} from '../services/visitService';
+
+const stubFetch = (response: Partial<Response>) => {
+    const fetchMock = vi.fn().mockResolvedValue(response as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+};
+
+beforeEach(() => {
+    vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+});
+
+describe('incrementVisits', () => {
+    it('POSTs to /api/visits on the default base URL', async () => {
+        const fetchMock = stubFetch({ok: true});
+        await incrementVisits();
+        expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/visits', {method: 'POST'});
+    });
+
+    it('uses NEXT_PUBLIC_BASE_URL when set', async () => {
+        vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://dansplugins.com');
+        const fetchMock = stubFetch({ok: true});
+        await incrementVisits();
+        expect(fetchMock).toHaveBeenCalledWith('https://dansplugins.com/api/visits', {method: 'POST'});
+    });
+});
+
+describe('getVisits', () => {
+    it('returns the parsed visit data on a 200 response', async () => {
+        const visitData = {visits: 42, startDate: '2020-01-01'};
+        stubFetch({ok: true, json: async () => visitData});
+        expect(await getVisits()).toEqual(visitData);
+    });
+
+    it('throws with the status and status text on a non-ok response', async () => {
+        stubFetch({ok: false, status: 500, statusText: 'Internal Server Error'});
+        await expect(getVisits()).rejects.toThrow('Failed to fetch visits: 500 Internal Server Error');
+    });
+
+    it('propagates a rejected fetch', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+        await expect(getVisits()).rejects.toThrow('network down');
+    });
+});


### PR DESCRIPTION
## Summary
- `utils/badges.ts` (`badgeLabel`, used by the Account and public profile pages to render badge chips) and `services/visitService.ts` (drives the homepage visit counter, including its `NEXT_PUBLIC_BASE_URL` fallback) were both behavior-bearing modules with no test coverage.
- Adds `__tests__/badges.test.ts` and `__tests__/visitService.test.ts`, following the existing fetch-mocking conventions used by `likeService.test.ts` / `bstats.test.ts` (stub global `fetch`, assert resolved/rejected/non-ok paths).
- No test-suite-wide sweep was done beyond these two files; the rest of `utils/`/`services/` already has matching test files (verified by diffing the two directory listings against `__tests__/`).

<!-- gardener-tend-dispatch -->

## Test plan
- [ ] CI (`npm ci && npm run lint && npm test && npm run build`) — this sandbox has no network/npm access, so this PR relies on CI as the verification anchor; see self-review comment for details.
- [x] Manually traced `badgeLabel`/`BADGE_LABELS` and `getVisits`/`incrementVisits`/`getBaseUrl` against the new assertions to confirm each expected value.

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
