### PR TITLE
Route internal navigation through next/link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Plugin cards now show each plugin's real branded icon (from `public/icons/`) instead of a generated letter avatar where one is mapped in `plugins.json`; plugins without a mapped icon still fall back to the letter avatar (#214).
 
+### Changed
+
+- Internal navigation (top nav, the wordmark, plugin/guide links, the account and public-profile pages) now routes through `next/link` instead of plain `<a href>`/`<Button href>`, so moving between pages is an instant client-side transition instead of a full page reload. External links (Discord, GitHub, SpigotMC, etc.) and same-page hash anchors are unchanged (#222).
+
 ## [0.14.0] – 2026-06-14
 
 ### Added

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -4,6 +4,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import TopBar from './TopBar';
 import Seo from './Seo';
 import BottomBar from './BottomBar';
+import {NextLinkComposed} from './NextLinkComposed';
 import {pageStyle, sectionHeaderStyle} from '../styles/styles';
 
 const version = require('../package.json').version;
@@ -28,7 +29,7 @@ const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({co
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 {message}
             </Typography>
-            <Button variant="contained" startIcon={<HomeIcon/>} href="/">
+            <Button variant="contained" startIcon={<HomeIcon/>} component={NextLinkComposed} to="/">
                 Back to home
             </Button>
         </Container>

--- a/components/NextLinkComposed.tsx
+++ b/components/NextLinkComposed.tsx
@@ -6,11 +6,14 @@ import NextLink, {LinkProps as NextLinkProps} from 'next/link';
 // an anchor (Button, Link, ListItemButton, Box component="a", ...) can navigate
 // without a full page reload. `to` (rather than `href`) avoids colliding with
 // the `href` most of those MUI components already accept in their own props.
-interface NextLinkComposedProps
-    extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
-        Omit<NextLinkProps, 'href' | 'as' | 'passHref'> {
+interface NextLinkComposedProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
     to: NextLinkProps['href'];
     linkAs?: NextLinkProps['as'];
+    replace?: NextLinkProps['replace'];
+    scroll?: NextLinkProps['scroll'];
+    shallow?: NextLinkProps['shallow'];
+    prefetch?: NextLinkProps['prefetch'];
+    locale?: NextLinkProps['locale'];
 }
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(

--- a/components/NextLinkComposed.tsx
+++ b/components/NextLinkComposed.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import NextLink, {LinkProps as NextLinkProps} from 'next/link';
+
+// Bridges next/link's client-side routing into MUI's `component` prop pattern
+// (component={NextLinkComposed} to="/path"), so any MUI component that renders
+// an anchor (Button, Link, ListItemButton, Box component="a", ...) can navigate
+// without a full page reload. `to` (rather than `href`) avoids colliding with
+// the `href` most of those MUI components already accept in their own props.
+interface NextLinkComposedProps
+    extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
+        Omit<NextLinkProps, 'href' | 'as' | 'passHref'> {
+    to: NextLinkProps['href'];
+    linkAs?: NextLinkProps['as'];
+}
+
+export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
+    function NextLinkComposed(props, ref) {
+        const {to, linkAs, replace, scroll, shallow, prefetch, locale, ...other} = props;
+
+        return (
+            <NextLink
+                href={to}
+                as={linkAs}
+                replace={replace}
+                scroll={scroll}
+                shallow={shallow}
+                prefetch={prefetch}
+                locale={locale}
+                passHref
+            >
+                <a ref={ref} {...other} />
+            </NextLink>
+        );
+    },
+);

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -4,6 +4,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import DnsIcon from '@mui/icons-material/Dns';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import LikeButton from './LikeButton';
+import {NextLinkComposed} from './NextLinkComposed';
 import {
     pluginCardStyle,
     pluginCardContentStyle,
@@ -103,8 +104,8 @@ const PluginCard: React.FC<PluginCardProps> = ({
                 <Button
                     size="small"
                     startIcon={<MenuBookIcon/>}
-                    component={Link}
-                    href={`/guides/${id}`}
+                    component={NextLinkComposed}
+                    to={`/guides/${id}`}
                 >
                     Guide
                 </Button>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -3,6 +3,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {useRouter} from 'next/router';
 import React, {useContext, useEffect, useState} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
+import {NextLinkComposed} from './NextLinkComposed';
 import {ColorModeContext} from '../utils/ColorModeContext';
 import {isActiveNavLink} from '../utils/nav';
 import {usernameFromToken} from '../utils/authToken';
@@ -24,9 +25,9 @@ const NavButton: React.FC<{ href: string; active?: boolean; children: React.Reac
     return (
         <Button
             color="inherit"
-            href={href}
-            target={isExternal ? '_blank' : undefined}
-            rel={isExternal ? 'noopener noreferrer' : undefined}
+            {...(isExternal
+                ? {href, target: '_blank', rel: 'noopener noreferrer'}
+                : {component: NextLinkComposed, to: href})}
             endIcon={isExternal ? <OpenInNewIcon fontSize="small"/> : undefined}
             aria-current={active ? 'page' : undefined}
             sx={(theme) => ({
@@ -49,7 +50,8 @@ const BrandName: React.FC = () => (
     // The wordmark links home — the near-universal "click the logo to return to
     // the home page" convention.
     <Link
-        href="/"
+        component={NextLinkComposed}
+        to="/"
         underline="none"
         color="inherit"
         sx={(theme) => ({...brandNameStyle(theme), display: 'inline-block'})}

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -25,6 +25,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react'
 import TopBar from '../components/TopBar'
 import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
+import {NextLinkComposed} from '../components/NextLinkComposed'
 import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 import {getMyLikes, type LikedTarget} from '../services/likeService'
 import {resolveLikedItems} from '../utils/likedItems'
@@ -412,7 +413,7 @@ const AccountPage: NextPage = () => {
                                     <Typography variant="body2" color="text.secondary" gutterBottom>
                                         Member since {new Date(profile.createdAt).toLocaleDateString()}
                                         {' · '}
-                                        <Box component="a" href={`/u/${profile.username}`} sx={{color: 'primary.main'}}>
+                                        <Box component={NextLinkComposed} to={`/u/${profile.username}`} sx={{color: 'primary.main'}}>
                                             View your public profile
                                         </Box>
                                     </Typography>
@@ -470,7 +471,7 @@ const AccountPage: NextPage = () => {
                                     <List disablePadding>
                                         {likedItems.map((item) => (
                                             <ListItem key={item.key} disablePadding>
-                                                <ListItemButton component="a" href={item.href}>
+                                                <ListItemButton component={NextLinkComposed} to={item.href}>
                                                     <ListItemText primary={item.title}/>
                                                     <Chip
                                                         label={item.targetType}
@@ -485,9 +486,9 @@ const AccountPage: NextPage = () => {
                                 ) : (
                                     <Typography variant="body2" color="text.secondary">
                                         You haven&apos;t liked any plugins or guides yet. Browse the{' '}
-                                        <Box component="a" href="/#plugins" sx={{color: 'primary.main'}}>plugins</Box>
+                                        <Box component={NextLinkComposed} to="/#plugins" sx={{color: 'primary.main'}}>plugins</Box>
                                         {' '}or{' '}
-                                        <Box component="a" href="/guides" sx={{color: 'primary.main'}}>guides</Box>
+                                        <Box component={NextLinkComposed} to="/guides" sx={{color: 'primary.main'}}>guides</Box>
                                         {' '}and tap the like button.
                                     </Typography>
                                 )}

--- a/pages/guides.tsx
+++ b/pages/guides.tsx
@@ -5,6 +5,7 @@ import TopBar from '../components/TopBar';
 import Seo from '../components/Seo';
 import React from 'react';
 import BottomBar from '../components/BottomBar';
+import {NextLinkComposed} from '../components/NextLinkComposed';
 
 // Import styles
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles';
@@ -41,8 +42,8 @@ const Guides: NextPage = () => (
                     {guides.map((plugin, index) => (
                         <ListItem key={plugin.id} disablePadding divider={index < guides.length - 1}>
                             <ListItemButton
-                                component="a"
-                                href={`/guides/${plugin.id}`}
+                                component={NextLinkComposed}
+                                to={`/guides/${plugin.id}`}
                             >
                                 <ListItemText primary={`${plugin.title} Guide`}/>
                                 <ChevronRightIcon fontSize="small" color="action"/>

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -8,6 +8,7 @@ import TopBar from '../../components/TopBar';
 import Seo from '../../components/Seo';
 import GuideLikeButton from '../../components/GuideLikeButton';
 import BottomBar from '../../components/BottomBar';
+import {NextLinkComposed} from '../../components/NextLinkComposed';
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles';
 import {userGuideUrl, userGuideRawUrl} from '../../utils/guides';
 
@@ -87,7 +88,7 @@ const GuidePage: NextPage<GuidePageProps> = ({id, title, githubLink, markdown}) 
         <Seo title={`${title} Guide`} description={`User guide for the ${title} plugin from Dan's Plugins Community.`}/>
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
-            <Button href="/guides" startIcon={<ArrowBackIcon/>} sx={{mb: 2}}>
+            <Button component={NextLinkComposed} to="/guides" startIcon={<ArrowBackIcon/>} sx={{mb: 2}}>
                 All guides
             </Button>
             <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -19,6 +19,7 @@ import React, {useEffect, useState} from 'react'
 import TopBar from '../../components/TopBar'
 import Seo from '../../components/Seo'
 import BottomBar from '../../components/BottomBar'
+import {NextLinkComposed} from '../../components/NextLinkComposed'
 import {pageStyle, sectionHeaderStyle} from '../../styles/styles'
 import {getPublicProfile, type PublicProfile} from '../../services/profileService'
 import {resolveLikedItems} from '../../utils/likedItems'
@@ -113,7 +114,7 @@ const PublicProfilePage: NextPage = () => {
                                     <List disablePadding>
                                         {likedItems.map((item) => (
                                             <ListItem key={item.key} disablePadding>
-                                                <ListItemButton component="a" href={item.href}>
+                                                <ListItemButton component={NextLinkComposed} to={item.href}>
                                                     <ListItemText primary={item.title}/>
                                                     <Chip
                                                         label={item.targetType}


### PR DESCRIPTION
## Summary

- Adds `components/NextLinkComposed.tsx`, the standard MUI + `next/link` bridge component (`component={NextLinkComposed} to="/path"`), so any MUI component that renders an anchor gets client-side routing.
- Wires it into every same-origin internal link: `TopBar` (nav buttons + wordmark), `ErrorPage`'s "Back to home", `PluginCard`'s "Guide" button, the guides list and guide detail's "All guides" back-link, and the liked-items lists / inline links on the account and public-profile pages.
- Leaves external links (Discord, GitHub, SpigotMC, Patreon, LinkedIn, RPKit, issue/source links) and same-page hash anchors (`components/Blurb.tsx`'s `#plugins`, the `_app.tsx` skip-link) untouched — these were correctly excluded per the issue.
- Adds a CHANGELOG entry under `[Unreleased]`.

Closes #222

## Test plan

- [ ] `npm run lint` and `npm run build` — **could not be run in this sandbox**: this gardener-dispatched environment has no Node.js/npm installed and no outbound network access to install it, so lint/build/tests could not be executed here. All changes were verified by hand against the existing MUI v5 + Next.js 12.2.2 versions in `package.json`, following the pattern MUI's own docs recommend for `next/link` integration. **A human should run `npm run lint && npm run build && npm test` locally before merging.**
- [ ] Manually click through top nav, the wordmark, a plugin's Guide button, guides list → guide detail → back, and the account/public-profile liked-items links to confirm no full-page flash and that each destination is correct.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
