### PR TITLE
Collapse top nav into a hamburger drawer on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Internal navigation (top nav, the wordmark, plugin/guide links, the account and public-profile pages) now routes through `next/link` instead of plain `<a href>`/`<Button href>`, so moving between pages is an instant client-side transition instead of a full page reload. External links (Discord, GitHub, SpigotMC, etc.) and same-page hash anchors are unchanged (#222).
+- The top navigation now collapses into a hamburger menu (a right-hand `Drawer`) below the `md` breakpoint instead of wrapping twelve links into a ragged multi-line block, and the four off-site community links (Discord, Patreon, LinkedIn, RPKit) are grouped behind a "Community" menu/section on both desktop and mobile so the primary in-site nav stays to eight destinations plus Account (#216).
 
 ## [0.14.0] – 2026-06-14
 

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -34,7 +34,8 @@ import {
     toggleSwitchBoxStyle,
     flexContainerStyle,
     navDrawerPaperStyle,
-    navDrawerSectionLabelStyle
+    navDrawerSectionLabelStyle,
+    navDrawerDividerStyle
 } from '../styles/styles';
 
 interface NavLink {
@@ -166,7 +167,7 @@ const NavDrawer: React.FC<{
             <ListItemButton component={NextLinkComposed} to="/account" selected={isActiveNavLink(pathname, '/account')}>
                 <ListItemText primary={accountLabel}/>
             </ListItemButton>
-            <Divider sx={{borderColor: 'rgba(255,255,255,0.12)'}}/>
+            <Divider sx={navDrawerDividerStyle}/>
             <Typography variant="overline" sx={(theme) => navDrawerSectionLabelStyle(theme)} component="div">
                 Community
             </Typography>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,4 +1,22 @@
-import {AppBar, Box, Button, Link, Toolbar, Typography, useTheme} from '@mui/material';
+import {
+    AppBar,
+    Box,
+    Button,
+    Divider,
+    Drawer,
+    IconButton,
+    Link,
+    List,
+    ListItemButton,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Toolbar,
+    Typography,
+    useTheme
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {useRouter} from 'next/router';
 import React, {useContext, useEffect, useState} from 'react';
@@ -14,8 +32,38 @@ import {
     brandNameStyle,
     toolbarStyle,
     toggleSwitchBoxStyle,
-    flexContainerStyle
+    flexContainerStyle,
+    navDrawerPaperStyle,
+    navDrawerSectionLabelStyle
 } from '../styles/styles';
+
+interface NavLink {
+    href: string;
+    label: string;
+}
+
+// In-site destinations shown as top-level links at all sizes. "Account" is
+// handled separately since its label depends on sign-in state.
+const PRIMARY_LINKS: NavLink[] = [
+    {href: '/', label: 'Home'},
+    {href: '/news', label: 'News'},
+    {href: '/guides', label: 'Guides'},
+    {href: '/leaderboard', label: 'Leaderboard'},
+    {href: '/about', label: 'About'},
+    {href: '/roadmap', label: 'Road Map'},
+    {href: '/commissions', label: 'Commissions'},
+    {href: '/dev', label: 'Dev Portal'},
+];
+
+// Off-site community links, grouped behind a "Community" menu/section rather
+// than sitting inline with the primary nav so the top-level item count stays
+// scannable at every screen size.
+const COMMUNITY_LINKS: NavLink[] = [
+    {href: 'https://discord.gg/xXtuAQ2', label: 'Discord'},
+    {href: 'https://www.patreon.com/danspluginscommunity', label: 'Patreon'},
+    {href: 'https://www.linkedin.com/company/dansplugins', label: 'LinkedIn'},
+    {href: 'https://github.com/RP-Kit/RPKit', label: 'RPKit'},
+];
 
 // Internal routes navigate in the same tab; off-site links open in a new tab
 // (with rel="noopener noreferrer") and carry an external-link icon so they are
@@ -62,10 +110,81 @@ const BrandName: React.FC = () => (
     </Link>
 );
 
+// Desktop-only dropdown for the community links, so the always-visible nav
+// stays to eight in-site destinations plus Account.
+const CommunityMenu: React.FC = () => {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    return (
+        <>
+            <Button
+                color="inherit"
+                endIcon={<ExpandMoreIcon fontSize="small"/>}
+                onClick={(event) => setAnchorEl(event.currentTarget)}
+                sx={(theme) => navButtonStyle(theme)}
+            >
+                Community
+            </Button>
+            <Menu anchorEl={anchorEl} open={!!anchorEl} onClose={() => setAnchorEl(null)}>
+                {COMMUNITY_LINKS.map((link) => (
+                    <MenuItem
+                        key={link.href}
+                        component="a"
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => setAnchorEl(null)}
+                    >
+                        {link.label}
+                        <OpenInNewIcon fontSize="small" sx={{marginLeft: 1}}/>
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+};
+
+// Below the `md` breakpoint the inline nav is replaced by a hamburger button
+// that opens this drawer, the conventional mobile navigation pattern.
+const NavDrawer: React.FC<{
+    open: boolean;
+    onClose: () => void;
+    pathname: string;
+    accountLabel: string;
+}> = ({open, onClose, pathname, accountLabel}) => (
+    <Drawer anchor="right" open={open} onClose={onClose} PaperProps={{sx: (theme) => navDrawerPaperStyle(theme)}}>
+        <List sx={{width: 260}} onClick={onClose}>
+            {PRIMARY_LINKS.map((link) => (
+                <ListItemButton
+                    key={link.href}
+                    component={NextLinkComposed}
+                    to={link.href}
+                    selected={isActiveNavLink(pathname, link.href)}
+                >
+                    <ListItemText primary={link.label}/>
+                </ListItemButton>
+            ))}
+            <ListItemButton component={NextLinkComposed} to="/account" selected={isActiveNavLink(pathname, '/account')}>
+                <ListItemText primary={accountLabel}/>
+            </ListItemButton>
+            <Divider sx={{borderColor: 'rgba(255,255,255,0.12)'}}/>
+            <Typography variant="overline" sx={(theme) => navDrawerSectionLabelStyle(theme)} component="div">
+                Community
+            </Typography>
+            {COMMUNITY_LINKS.map((link) => (
+                <ListItemButton key={link.href} component="a" href={link.href} target="_blank" rel="noopener noreferrer">
+                    <ListItemText primary={link.label}/>
+                    <OpenInNewIcon fontSize="small"/>
+                </ListItemButton>
+            ))}
+        </List>
+    </Drawer>
+);
+
 const TopBar: React.FC = () => {
     const colorMode = useContext(ColorModeContext);
     const theme = useTheme();
     const {pathname} = useRouter();
+    const [drawerOpen, setDrawerOpen] = useState(false);
 
     // Reflect the signed-in state in the nav. Read on the client only (after
     // mount) so the server-rendered markup and the first client paint match —
@@ -88,31 +207,40 @@ const TopBar: React.FC = () => {
                 <Box sx={(theme) => flexContainerStyle(theme, {flexWrap: 'wrap'})}>
                     <BrandName/>
 
-                    <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
-                        <NavButton href="/" active={isActiveNavLink(pathname, '/')}>Home</NavButton>
-                        <NavButton href="/news" active={isActiveNavLink(pathname, '/news')}>News</NavButton>
-                        <NavButton href="/guides" active={isActiveNavLink(pathname, '/guides')}>Guides</NavButton>
-                        <NavButton href="/leaderboard" active={isActiveNavLink(pathname, '/leaderboard')}>Leaderboard</NavButton>
-                        <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>
-                        <NavButton href="/roadmap" active={isActiveNavLink(pathname, '/roadmap')}>Road Map</NavButton>
-                        <NavButton href="/commissions" active={isActiveNavLink(pathname, '/commissions')}>Commissions</NavButton>
-                        <NavButton href="/dev" active={isActiveNavLink(pathname, '/dev')}>Dev Portal</NavButton>
+                    {/* Desktop / tablet: inline nav, hidden below the `md` breakpoint. */}
+                    <Box sx={(theme) => ({...flexContainerStyle(theme, {gap: 1}), display: {xs: 'none', md: 'flex'}})}>
+                        {PRIMARY_LINKS.map((link) => (
+                            <NavButton key={link.href} href={link.href} active={isActiveNavLink(pathname, link.href)}>
+                                {link.label}
+                            </NavButton>
+                        ))}
                         <NavButton href="/account" active={isActiveNavLink(pathname, '/account')}>{accountLabel}</NavButton>
-                        <NavButton href="https://discord.gg/xXtuAQ2">Discord</NavButton>
-                        <NavButton href="https://www.patreon.com/danspluginscommunity">Patreon</NavButton>
-                        <NavButton href="https://www.linkedin.com/company/dansplugins">LinkedIn</NavButton>
-                        <NavButton href="https://github.com/RP-Kit/RPKit">RPKit</NavButton>
+                        <CommunityMenu/>
                     </Box>
                 </Box>
 
-                <Box sx={toggleSwitchBoxStyle}>
-                    <ColorModeToggleSwitch
-                        checked={theme.palette.mode === 'dark'}
-                        onChange={colorMode.toggleColorMode}
-                        inputProps={{'aria-label': 'Toggle dark mode'}}
-                    />
+                <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
+                    <Box sx={toggleSwitchBoxStyle}>
+                        <ColorModeToggleSwitch
+                            checked={theme.palette.mode === 'dark'}
+                            onChange={colorMode.toggleColorMode}
+                            inputProps={{'aria-label': 'Toggle dark mode'}}
+                        />
+                    </Box>
+
+                    {/* Mobile: hamburger button, hidden at `md` and above. */}
+                    <IconButton
+                        color="inherit"
+                        aria-label="Open navigation menu"
+                        onClick={() => setDrawerOpen(true)}
+                        sx={{display: {xs: 'inline-flex', md: 'none'}}}
+                    >
+                        <MenuIcon/>
+                    </IconButton>
                 </Box>
             </Toolbar>
+
+            <NavDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} pathname={pathname} accountLabel={accountLabel}/>
         </AppBar>
     );
 }

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -283,6 +283,16 @@ export const navDrawerSectionLabelStyle = (theme: Theme) => ({
 });
 
 /**
+ * Divider between the primary links and the Community section in the mobile
+ * navigation drawer. Always a light line since the drawer surface is the
+ * app bar colour (dark enough in both palette modes) rather than the
+ * default paper background.
+ */
+export const navDrawerDividerStyle = {
+    borderColor: 'rgba(255,255,255,0.12)',
+};
+
+/**
  * Plugin card layout with fixed height
  */
 export const pluginCardStyle = {

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -262,6 +262,27 @@ export const infoCardIconSizeStyle = {
 };
 
 /**
+ * Mobile navigation drawer surface, matching the app bar's colour.
+ */
+export const navDrawerPaperStyle = (theme: Theme) => ({
+    width: 260,
+    backgroundColor: theme.palette.mode === 'dark' ? '#161b22' : theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+});
+
+/**
+ * Section label inside the mobile navigation drawer (e.g. "Community").
+ */
+export const navDrawerSectionLabelStyle = (theme: Theme) => ({
+    paddingX: theme.spacing(2),
+    paddingTop: theme.spacing(2),
+    opacity: 0.7,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    fontSize: '0.75rem',
+});
+
+/**
  * Plugin card layout with fixed height
  */
 export const pluginCardStyle = {


### PR DESCRIPTION
## Summary
- Below the `md` breakpoint, `TopBar` now shows a hamburger `IconButton` that opens a right-hand `Drawer` listing all in-site links plus a "Community" section for the four off-site links, instead of the inline nav row wrapping into a ragged multi-line block.
- At `md` and above, the four off-site community links (Discord, Patreon, LinkedIn, RPKit) are grouped behind a "Community" dropdown `Menu`, so the always-visible desktop nav stays to eight in-site destinations plus Account.
- Adds `navDrawerPaperStyle` / `navDrawerSectionLabelStyle` to `styles/styles.ts` and a `CHANGELOG.md` entry under `[Unreleased]`.

Closes #216

## Test plan
- [x] `git diff` reviewed for correctness (self-review below)
- [ ] CI (`npm run lint`, `npm test`, `npm run build`) — this environment does not have `npm`/Node available locally, so verification relies on CI; please confirm CI passes before merge
- [ ] Manually verify in a browser: nav collapses to a hamburger below `md`, Community menu appears both in the drawer and as a desktop dropdown, active-page underline still works via `isActiveNavLink`

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
