### PR TITLE
SEO: emit a canonical URL and og:url on every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Plugin cards now show each plugin's real branded icon (from `public/icons/`) instead of a generated letter avatar where one is mapped in `plugins.json`; plugins without a mapped icon still fall back to the letter avatar (#214).
+- Pages now emit a canonical URL (`<link rel="canonical">` and `og:url`), built from `NEXT_PUBLIC_BASE_URL`, so query-string and trailing-slash variants of a page are no longer treated as separate resources. The dynamic guide and public-profile routes report their concrete path rather than the bracketed template (#244).
 
 ### Changed
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,7 +22,7 @@ NEXT_PUBLIC_API_URL=https://api.dansplugins.com
 
 **Type:** string  
 **Default:** `http://localhost:3000`  
-**Description:** The site's own base URL, used by the frontend for calls to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`). Set this to the site's public origin when deploying so server-side rendering can reach its own API routes. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend.
+**Description:** The site's own base URL. It is used for two things: calls the frontend makes to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`), and the absolute canonical URL each page advertises to search engines and link scrapers (`<link rel="canonical">` and `og:url`). Set this to the site's public origin when deploying — otherwise server-side rendering cannot reach its own API routes, and shared links will advertise `localhost` URLs. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend.
 
 **Example:**
 

--- a/__tests__/seo.test.ts
+++ b/__tests__/seo.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { absoluteUrl, canonicalPath } from '../utils/seo';
+
+describe('canonicalPath', () => {
+    it('returns a plain path unchanged', () => {
+        expect(canonicalPath('/news')).toBe('/news');
+        expect(canonicalPath('/guides/medievalfactions')).toBe('/guides/medievalfactions');
+    });
+
+    it('keeps the root path as a single slash', () => {
+        expect(canonicalPath('/')).toBe('/');
+    });
+
+    it('drops the query string so tracking parameters are not a separate resource', () => {
+        expect(canonicalPath('/news?utm_source=discord')).toBe('/news');
+        expect(canonicalPath('/?utm_source=discord')).toBe('/');
+    });
+
+    it('drops the fragment', () => {
+        expect(canonicalPath('/about#team')).toBe('/about');
+        expect(canonicalPath('/about?ref=x#team')).toBe('/about');
+    });
+
+    it('drops a trailing slash except on the root', () => {
+        expect(canonicalPath('/news/')).toBe('/news');
+        expect(canonicalPath('/guides/medievalfactions//')).toBe('/guides/medievalfactions');
+    });
+
+    it('adds a missing leading slash', () => {
+        expect(canonicalPath('news')).toBe('/news');
+    });
+
+    it('returns null for an unresolved dynamic route template', () => {
+        expect(canonicalPath('/guides/[id]')).toBeNull();
+        expect(canonicalPath('/u/[username]')).toBeNull();
+    });
+
+    it('returns null for an empty route', () => {
+        expect(canonicalPath('')).toBeNull();
+        expect(canonicalPath('?utm_source=discord')).toBeNull();
+    });
+});
+
+describe('absoluteUrl', () => {
+    it('joins an origin to a path', () => {
+        expect(absoluteUrl('https://dansplugins.com', '/news')).toBe('https://dansplugins.com/news');
+    });
+
+    it('does not double up slashes when the base URL has a trailing slash', () => {
+        expect(absoluteUrl('https://dansplugins.com/', '/news')).toBe('https://dansplugins.com/news');
+        expect(absoluteUrl('https://dansplugins.com//', '/news')).toBe('https://dansplugins.com/news');
+    });
+
+    it('keeps the root path as a trailing slash on the origin', () => {
+        expect(absoluteUrl('https://dansplugins.com', '/')).toBe('https://dansplugins.com/');
+        expect(absoluteUrl('https://dansplugins.com/', '/')).toBe('https://dansplugins.com/');
+    });
+
+    it('works with the local development default', () => {
+        expect(absoluteUrl('http://localhost:3000', '/guides')).toBe('http://localhost:3000/guides');
+    });
+});

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -17,7 +17,8 @@ const version = require('../package.json').version;
  */
 const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({code, title, message}) => (
     <Box sx={(theme) => pageStyle(theme)}>
-        <Seo title={`${code} — ${title}`} description={message}/>
+        {/* No canonical URL: an error page stands in for a URL that is not a real page. */}
+        <Seo title={`${code} — ${title}`} description={message} path={null}/>
         <TopBar/>
         <Container component="main" id="main" maxWidth="sm" sx={{py: 8, textAlign: 'center'}}>
             <Typography variant="h1" color="primary" sx={{fontWeight: 700}}>

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -10,7 +10,10 @@ import {absoluteUrl, canonicalPath} from '../utils/seo';
 const SITE_NAME = "Dan's Plugins Community";
 const DEFAULT_DESCRIPTION =
     "Free, open-source plugins for Minecraft servers — Medieval Factions and a catalogue of complementary plugins, all developed in the open and free to use.";
-// The site's own origin, shared with services/visitService.ts. Documented in CONFIG.md.
+// The site's own origin, shared with services/visitService.ts. Documented in
+// CONFIG.md. Read once at module scope rather than through a getter (as
+// visitService does for stubbing in tests): Next.js inlines NEXT_PUBLIC_* at
+// build time, and the canonical URL never varies within a running build.
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
 
 interface SeoProps {

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,31 +1,47 @@
 import Head from 'next/head';
+import {useRouter} from 'next/router';
 import React from 'react';
+import {absoluteUrl, canonicalPath} from '../utils/seo';
 
-// Shared per-page document metadata: title, description, and Open Graph /
-// Twitter card tags so browser tabs, search engines, and shared links (Discord,
-// social) all show meaningful information. Render once near the top of each page.
+// Shared per-page document metadata: title, description, canonical URL, and
+// Open Graph / Twitter card tags so browser tabs, search engines, and shared
+// links (Discord, social) all show meaningful information. Render once near the
+// top of each page.
 const SITE_NAME = "Dan's Plugins Community";
 const DEFAULT_DESCRIPTION =
     "Free, open-source plugins for Minecraft servers — Medieval Factions and a catalogue of complementary plugins, all developed in the open and free to use.";
+// The site's own origin, shared with services/visitService.ts. Documented in CONFIG.md.
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
 
 interface SeoProps {
     // Page-specific title; the site name is appended automatically. Omit on the
     // home page to use the site name alone.
     title?: string;
     description?: string;
+    // Path the canonical URL and og:url should point at. Defaults to the current
+    // route. Pages that resolve a dynamic segment on the client (for example
+    // /u/[username]) should pass the concrete path once they know it. Pass null
+    // to emit no canonical URL at all — error pages stand in for a URL that is
+    // not a real page, so they must not claim one.
+    path?: string | null;
 }
 
-const Seo: React.FC<SeoProps> = ({title, description}) => {
+const Seo: React.FC<SeoProps> = ({title, description, path}) => {
+    const {asPath} = useRouter();
     const fullTitle = title ? `${title} — ${SITE_NAME}` : SITE_NAME;
     const desc = description ?? DEFAULT_DESCRIPTION;
+    const resolvedPath = path === null ? null : canonicalPath(path ?? asPath);
+    const url = resolvedPath === null ? null : absoluteUrl(BASE_URL, resolvedPath);
     return (
         <Head>
             <title>{fullTitle}</title>
             <meta name="description" content={desc}/>
+            {url ? <link rel="canonical" href={url}/> : null}
             <meta property="og:title" content={fullTitle}/>
             <meta property="og:description" content={desc}/>
             <meta property="og:type" content="website"/>
             <meta property="og:site_name" content={SITE_NAME}/>
+            {url ? <meta property="og:url" content={url}/> : null}
             <meta name="twitter:card" content="summary"/>
             <meta name="twitter:title" content={fullTitle}/>
             <meta name="twitter:description" content={desc}/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dpc-website",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dpc-website",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -88,6 +88,9 @@ const GuidePage: NextPage<GuidePageProps> = ({id, title, githubLink, markdown}) 
         <Seo
             title={`${title} Guide`}
             description={`User guide for the ${title} plugin from Dan's Plugins Community.`}
+            // Unlike /u/[username], the id needs no encoding: getServerSideProps
+            // only serves ids that match an entry in the plugins.json catalogue,
+            // and those are plain slugs.
             path={`/guides/${id}`}
         />
         <TopBar/>

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -85,7 +85,11 @@ const guideBodyStyle = {
 
 const GuidePage: NextPage<GuidePageProps> = ({id, title, githubLink, markdown}) => (
     <Box sx={(theme) => pageStyle(theme)}>
-        <Seo title={`${title} Guide`} description={`User guide for the ${title} plugin from Dan's Plugins Community.`}/>
+        <Seo
+            title={`${title} Guide`}
+            description={`User guide for the ${title} plugin from Dan's Plugins Community.`}
+            path={`/guides/${id}`}
+        />
         <TopBar/>
         <Container maxWidth="md" sx={(theme) => containerPaddingStyle(theme)}>
             <Button component={NextLinkComposed} to="/guides" startIcon={<ArrowBackIcon/>} sx={{mb: 2}}>

--- a/pages/u/[username].tsx
+++ b/pages/u/[username].tsx
@@ -54,7 +54,14 @@ const PublicProfilePage: NextPage = () => {
 
     return (
         <Box sx={(theme) => pageStyle(theme)}>
-            <Seo title={`${heading} — Profile`} description={`The public DPC community profile for ${heading}.`}/>
+            <Seo
+                title={`${heading} — Profile`}
+                description={`The public DPC community profile for ${heading}.`}
+                // The username comes from the router on the client (already
+                // decoded), so the canonical URL is only emitted once it is known,
+                // and the segment is re-encoded to keep the URL well-formed.
+                path={username ? `/u/${encodeURIComponent(username)}` : undefined}
+            />
             <TopBar/>
             <Container component="main" id="main" maxWidth="md" sx={{py: 4}}>
                 {loading ? (

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -1,0 +1,28 @@
+// Helpers for the canonical URL a page advertises to search engines and link
+// scrapers (`<link rel="canonical">` and `og:url`). Kept pure and separate from
+// components/Seo.tsx so the URL-normalisation rules can be unit-tested.
+
+// Normalise a route into the single path a page should claim as canonical:
+// query string and fragment removed (so `?utm_source=discord` is not a separate
+// resource), a leading slash guaranteed, and any trailing slash dropped except
+// on the root. Returns null when there is no honest canonical path to emit —
+// an empty route, or one still containing an unresolved dynamic segment such as
+// `/guides/[id]`, which Next.js reports before the concrete value is known.
+export const canonicalPath = (path: string): string | null => {
+    const withoutFragment = path.split('#')[0];
+    const withoutQuery = withoutFragment.split('?')[0];
+    if (withoutQuery === '' || withoutQuery.includes('[')) {
+        return null;
+    }
+    const withLeadingSlash = withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+    const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, '');
+    return withoutTrailingSlash === '' ? '/' : withoutTrailingSlash;
+};
+
+// Join the site's own origin to a canonical path. `baseUrl` comes from
+// NEXT_PUBLIC_BASE_URL (documented in CONFIG.md) and may or may not carry a
+// trailing slash; `path` is the output of canonicalPath.
+export const absoluteUrl = (baseUrl: string, path: string): string => {
+    const origin = baseUrl.replace(/\/+$/, '');
+    return path === '/' ? `${origin}/` : `${origin}${path}`;
+};


### PR DESCRIPTION
## Summary

- `components/Seo.tsx` now renders `<link rel="canonical">` and `<meta property="og:url">`, built from `NEXT_PUBLIC_BASE_URL`. Without them, a page reached with a tracking query string (`?utm_source=discord`) or a trailing-slash variant looked like a separate resource to search engines and Open Graph scrapers.
- New pure helper `utils/seo.ts` (`canonicalPath`, `absoluteUrl`), unit-tested: strips the query string and fragment, guarantees a leading slash, drops trailing slashes except on the root, and returns `null` for an unresolved dynamic template such as `/guides/[id]` so a page never advertises a bracketed URL.
- `Seo` takes an optional `path` prop that defaults to the current route (`useRouter().asPath`). `/guides/[id]` passes its concrete path from `getServerSideProps`; `/u/[username]` passes `/u/<encoded username>` once the router has resolved it.
- Error pages pass `path={null}` — a 404/500 stands in for a URL that is not a real page, so it must not claim one as canonical.
- `CONFIG.md`: `NEXT_PUBLIC_BASE_URL` now documents both of its uses (internal API-route calls *and* the canonical/`og:url` origin), and notes that leaving it unset makes shared links advertise `localhost`.
- `package-lock.json` was still pinned at `0.12.0` while `package.json` says `0.14.0`; synced so a fresh `npm ci`/`npm install` does not leave a dirty tree.

## Test plan

- [ ] `npm run lint` passes (CI)
- [ ] `npm test` passes, including the new `__tests__/seo.test.ts` (CI)
- [ ] `npm run build` passes (CI)
- [ ] Manual: with `NEXT_PUBLIC_BASE_URL=http://localhost:3000`, view source on `/`, `/news?utm_source=discord`, `/guides/medievalfactions`, and `/u/<someone>` — each should carry exactly one `<link rel="canonical">` and one `og:url` pointing at the clean absolute path
- [ ] Manual: `/404` emits neither tag

> Note: this branch was prepared in an environment without a Node runtime, so lint/test/build were not run locally — CI is the verification gate.

Closes #244

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
