### PR TITLE
Use MUI Link for the converted-issue link; de-duplicate lint docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- The "View the issue" link on a converted feature request now uses MUI's `Link` instead of a bare `<a>`, so it takes the theme's link colour like every other link on the site rather than the browser default (#246).
 - Internal navigation (top nav, the wordmark, plugin/guide links, the account and public-profile pages) now routes through `next/link` instead of plain `<a href>`/`<Button href>`, so moving between pages is an instant client-side transition instead of a full page reload. External links (Discord, GitHub, SpigotMC, etc.) and same-page hash anchors are unchanged (#222).
 - The top navigation now collapses into a hamburger menu (a right-hand `Drawer`) below the `md` breakpoint instead of wrapping twelve links into a ragged multi-line block, and the four off-site community links (Discord, Patreon, LinkedIn, RPKit) are grouped behind a "Community" menu/section on both desktop and mobile so the primary in-site nav stays to eight destinations plus Account (#216).
+
+### Fixed
+
+- The lint instructions in `README.md` and `CONTRIBUTING.md` no longer list `npm run lint` twice under separate "Linux:" and "Windows:" headings, which implied a platform difference that does not exist (#247).
 
 ## [0.14.0] – 2026-06-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,7 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/dansplugins
 
 Run the linter with:
 
-Linux: `npm run lint`
-Windows: `npm run lint`
+`npm run lint`
 
 For manual testing, start the development server:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/dansplugins
 
 Run the linter with:
 
-`npm run lint`
+    npm run lint
 
 For manual testing, start the development server:
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ Please fill out a bug report [here](https://github.com/Dans-Plugins/dansplugins-
 
 ### Lint
 
-Linux:
-
-    npm run lint
-
-Windows:
-
     npm run lint
 
 If you see no errors, the lint check has passed.

--- a/components/FeatureRequestSection.tsx
+++ b/components/FeatureRequestSection.tsx
@@ -5,6 +5,7 @@ import {
     Card,
     CardContent,
     Chip,
+    Link,
     MenuItem,
     Snackbar,
     Stack,
@@ -171,9 +172,9 @@ const FeatureRequestSection: React.FC<FeatureRequestSectionProps> = ({repos, rep
                                         {request.convertedIssueUrl && (
                                             <>
                                                 {' · '}
-                                                <a href={request.convertedIssueUrl} target="_blank" rel="noopener noreferrer">
+                                                <Link href={request.convertedIssueUrl} target="_blank" rel="noopener noreferrer">
                                                     View the issue
-                                                </a>
+                                                </Link>
                                             </>
                                         )}
                                     </Typography>


### PR DESCRIPTION
## Summary

- **`components/FeatureRequestSection.tsx`** — the "View the issue" link shown on a converted feature request was the only user-facing raw `<a>` in the `.tsx` surface (the sole other hit, `NextLinkComposed.tsx:34`, is the deliberate anchor primitive MUI's `component` prop composes onto). It now uses MUI's `Link`, so it takes the theme's link colour instead of the browser default — which in dark mode rendered as default blue on a dark surface. `Link` inherits the surrounding `Typography` sizing, so the caption layout is unchanged.
- **`README.md` / `CONTRIBUTING.md`** — the lint instructions listed `npm run lint` twice, under separate "Linux:" and "Windows:" headings, implying a platform difference that does not exist (`npm run lint` maps to `next lint` on both). Collapsed to a single block, matching the neighbouring Unit Tests section. The issue named only the README; `CONTRIBUTING.md` had the identical duplication, so both were fixed together.
- **`CHANGELOG.md`** — entries added under `[Unreleased]`.

## Test plan

- [ ] CI (`Build Website`) passes `npm run lint`, `npm test`, and `npm run build`.
- [ ] Dev portal: a feature request with `convertedIssueUrl` set renders "View the issue" in the theme link colour in both light and dark mode, with `target="_blank"` / `rel="noopener noreferrer"` preserved.

**Note on local verification:** this change was authored in a sandboxed environment with no `node`/`npm` on `PATH`, so lint, tests, and build were not run locally — CI is the verification gate for this PR.

Closes #246
Closes #247

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
