### PR TITLE
docs: fix USER_GUIDE.md guides new-tab claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - The lint instructions in `README.md` and `CONTRIBUTING.md` no longer list `npm run lint` twice under separate "Linux:" and "Windows:" headings, which implied a platform difference that does not exist (#247).
+- `USER_GUIDE.md` no longer claims the Guides page opens a plugin's guide "in a new tab" — guides have rendered on-site at `/guides/[id]` since #163; the doc now describes that behavior and the "View on GitHub" fallback link.
 
 ## [0.14.0] – 2026-06-14
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -28,7 +28,7 @@ No special software is required to use the website. Simply visit [https://danspl
 ### Browsing Plugin Guides
 
 1. Click **Guides** in the top navigation bar (or visit `/guides`).
-2. Select a plugin from the list to open that plugin's user guide in a new tab.
+2. Select a plugin from the list to open that plugin's user guide on-site (with a "View on GitHub" link if you want the raw source).
 
 ### Viewing the Faction Leaderboard
 


### PR DESCRIPTION
## Summary
- `USER_GUIDE.md`'s "Browsing Plugin Guides" section said selecting a plugin "opens that plugin's user guide in a new tab." That was true before #163; since then, guides render on-site at `/guides/[id]` via client-side navigation, with a "View on GitHub" link as a fallback/original-source link. Updated the doc to describe the current behavior.
- Added a matching `CHANGELOG.md` entry under `[Unreleased] > Fixed`.

Found during a repo-wide documentation accuracy sweep (Stage A) of `CHANGELOG.md`, `CONFIG.md`, `README.md`, and `USER_GUIDE.md` against current source — this was the only drift found; the other three files were verified accurate (env vars in `CONFIG.md` match `process.env.NEXT_PUBLIC_*` usage across the codebase; `README.md`'s build/run/test commands match `package.json` scripts and `up.sh`/`down.sh`).

## Out of scope this cycle (recorded for auditability)
The rest of the open backlog was deferred:
- #249 — requires editing `.github/copilot-instructions.md` (agent-loaded config), which needs explicit separate user authorization; not attempted.
- #192, #193, #195, #196 — Phase 3 decompositions of epic #167, each requiring new backend entities/migrations/endpoints; too large for a single polish-sized cycle.
- #162 — would require fabricating per-plugin Minecraft-version compatibility data I can't verify from source.
- #215 — needs a real branded 1200×630 social-preview image asset, which isn't something I can produce.
- #87 — vague/open-ended ("maybe an Admin section"), needs scoping first.
- #57 — assigned to a human (dmccoystephenson); deployment/TLS infra change, leaving for them.
- #24, #142 — already correctly deferred (Discord live-bot ingestion needs real infra to test end-to-end; #142 depends on #24).

## Test plan
- [ ] CI (`build.yml`) — lint + build, since local npm in this sandbox resolves to a broken Windows path and can't run natively here (docs-only change, so this is the real anchor: UNVERIFIED-not-applicable locally, required and expected to be green on CI).
- [x] Manually verified the new doc wording against `pages/guides.tsx` and `pages/guides/[id].tsx` (on-site render + "View on GitHub" fallback link).

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
