### PR TITLE
fix: wire NEXT_PUBLIC_BASE_URL through Dockerfile/compose.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The lint instructions in `README.md` and `CONTRIBUTING.md` no longer list `npm run lint` twice under separate "Linux:" and "Windows:" headings, which implied a platform difference that does not exist (#247).
 - `USER_GUIDE.md` no longer claims the Guides page opens a plugin's guide "in a new tab" — guides have rendered on-site at `/guides/[id]` since #163; the doc now describes that behavior and the "View on GitHub" fallback link.
+- `NEXT_PUBLIC_BASE_URL` is now passed as a Docker build arg and environment variable in `compose.yml` (matching `NEXT_PUBLIC_API_URL`), so it can actually be set when deploying via `docker compose up --build` as `CONFIG.md` already documented. Previously it had no `Dockerfile`/`compose.yml` wiring at all, so the production build always inlined the `http://localhost:3000` default regardless of what was set, and canonical URLs / `og:url` / shared-link previews would always advertise `localhost` (#251).
 
 ## [0.14.0] – 2026-06-14
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,7 +22,7 @@ NEXT_PUBLIC_API_URL=https://api.dansplugins.com
 
 **Type:** string  
 **Default:** `http://localhost:3000`  
-**Description:** The site's own base URL. It is used for two things: calls the frontend makes to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`), and the absolute canonical URL each page advertises to search engines and link scrapers (`<link rel="canonical">` and `og:url`). Set this to the site's public origin when deploying — otherwise server-side rendering cannot reach its own API routes, and shared links will advertise `localhost` URLs. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend.
+**Description:** The site's own base URL. It is used for two things: calls the frontend makes to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`), and the absolute canonical URL each page advertises to search engines and link scrapers (`<link rel="canonical">` and `og:url`). Set this to the site's public origin when deploying — otherwise server-side rendering cannot reach its own API routes, and shared links will advertise `localhost` URLs. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend. Like all `NEXT_PUBLIC_*` variables, it is inlined at **build time**, not read at runtime — with Docker Compose it must be set when running `docker compose up --build` (see [Docker Compose Configuration](#docker-compose-configuration)), not just on the running container.
 
 **Example:**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ EXPOSE 3000
 # Next.js NEXT_PUBLIC_* vars are inlined at build time
 ARG NEXT_PUBLIC_API_URL=http://localhost:45345
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ARG NEXT_PUBLIC_BASE_URL=http://localhost:3000
+ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
 
 # Build
 RUN npm run build

--- a/compose.yml
+++ b/compose.yml
@@ -5,10 +5,12 @@ services:
       context: .
       args:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:45345}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
     ports:
       - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:45345}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
     volumes:
       - ./node_modules:/app/node_modules
       - ./data:/app/data


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_BASE_URL` is documented in `CONFIG.md` as settable for production deployments, but unlike `NEXT_PUBLIC_API_URL` it had no `Dockerfile` `ARG`/`ENV` or `compose.yml` build-arg wiring.
- Since Next.js inlines `NEXT_PUBLIC_*` vars at **build time**, and `compose.yml`/`up.sh` is this repo's only documented deployment path, the site could never actually pick up a non-default `NEXT_PUBLIC_BASE_URL` in production — canonical URLs, `og:url`, and shared-link previews would always advertise `http://localhost:3000` regardless of what was set in the environment.
- Wired `NEXT_PUBLIC_BASE_URL` through `Dockerfile` (`ARG`/`ENV`, mirroring the existing `NEXT_PUBLIC_API_URL` pattern) and `compose.yml` (`build.args` + `environment` on `dpc-website`).
- Clarified in `CONFIG.md` that the variable is build-time-inlined and must be set at `docker compose up --build` time, not just on the running container.
- Added a `CHANGELOG.md` entry under `[Unreleased] / Fixed`.

Closes #251

## Test plan

- [x] Traced `Dockerfile`/`compose.yml` build-arg wiring by hand against the existing `NEXT_PUBLIC_API_URL` pattern (added in commit `d2db387`, "Make NEXT_PUBLIC_API_URL configurable via compose.yml") — the two variables are now wired identically.
- [ ] CI (`npm run lint`, `npm test`, `npm run build`, and the `dpc-api` Maven build) — this sandbox has no working Linux Node.js toolchain (`node`/`npm` resolve through a broken Windows `cmd.exe` shim with UNC-path errors), so lint/build could not be run locally. Deferring to the GitHub Actions check on this PR's head SHA as the real anchor. The change touches no `.ts`/`.tsx`/Java source, only `Dockerfile`, `compose.yml`, `CONFIG.md`, and `CHANGELOG.md`, so lint/test/build have no relevant surface to exercise either way.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
