### PR TITLE
Document npm test, npm run build, and backend testing in CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `USER_GUIDE.md` no longer tells visitors to "click a plugin card" — plugin cards have never been clickable as a whole; the guide now names the actual controls on a card (Guide, GitHub, SpigotMC, and the like button) and documents the home page's search box and sort toggle, which had gone unmentioned since 0.14.0 (#253).
 - `USER_GUIDE.md` no longer claims the Guides page opens a plugin's guide "in a new tab" — guides have rendered on-site at `/guides/[id]` since #163; the doc now describes that behavior and the "View on GitHub" fallback link.
 - `NEXT_PUBLIC_BASE_URL` is now passed as a Docker build arg and environment variable in `compose.yml` (matching `NEXT_PUBLIC_API_URL`), so it can actually be set when deploying via `docker compose up --build` as `CONFIG.md` already documented. Previously it had no `Dockerfile`/`compose.yml` wiring at all, so the production build always inlined the `http://localhost:3000` default regardless of what was set, and canonical URLs / `og:url` / shared-link previews would always advertise `localhost` (#251).
+- `CONTRIBUTING.md`'s Testing section now lists `npm test` and `npm run build` alongside `npm run lint`, and adds a backend (`dpc-api/`) testing step — previously it named only `npm run lint`, so a contributor following it exactly could open a PR that fails CI on the `npm test` and `./mvnw verify` gates the guide never mentioned (#254).
 
 ## [0.14.0] – 2026-06-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,21 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/dansplugins
 
 ## Testing
 
+CI runs these checks on every pull request, so run them locally before pushing.
+
+### Frontend
+
 Run the linter with:
 
     npm run lint
+
+Run the unit test suite (test files live in `__tests__/`):
+
+    npm test
+
+Make sure the site builds:
+
+    npm run build
 
 For manual testing, start the development server:
 
@@ -62,6 +74,14 @@ For manual testing, start the development server:
 Or use Docker Compose:
 
     docker compose up
+
+### Backend (`dpc-api/`)
+
+If your change touches the Spring Boot backend in `dpc-api/`, run:
+
+    cd dpc-api && ./mvnw verify
+
+See [`dpc-api/README.md`](dpc-api/README.md) for more details.
 
 ## Questions
 


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md`'s Testing section only told contributors to run `npm run lint`, even though CI (`.github/workflows/build.yml`) also gates PRs on `npm test` and `npm run build` for the frontend, and `./mvnw verify` for the `dpc-api/` backend.
- Adds `npm test` and `npm run build` under a "Frontend" subheading, and a new "Backend (`dpc-api/`)" subheading pointing at `cd dpc-api && ./mvnw verify` and `dpc-api/README.md`.
- Adds a `CHANGELOG.md` entry under `[Unreleased] > Fixed`.

Note: issue #249 (docs say to target `develop`, but PRs actually target `main`) was triaged but deferred this cycle — it requires editing `.github/copilot-instructions.md` (agent-loaded config) and is a workflow decision (retire `develop` vs. fast-forward it to `main`), not a mechanical doc fix, so it needs explicit human direction rather than an autonomous change.

## Test plan
- [x] Verified against `package.json` (`test`/`build` scripts), `.github/workflows/build.yml` (CI gates), and `dpc-api/README.md` (exists).
- [ ] `npm run lint` / `npm test` / `npm run build` — could not run locally in this sandbox (npm resolves through a broken WSL→Windows interop path with no Linux node available); this is a docs-only change, so CI on the PR head SHA is the real anchor.

Closes #254

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
