### PR TITLE
Serve robots.txt and sitemap.xml; point contributor docs at main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,7 @@ All code:
 
 ## Contribution Workflow
 
-- Branch from `develop` for all changes.
-- Open a pull request against `develop`, not `main`.
+- `main` is the trunk. Branch from `main` for all changes.
+- Open a pull request against `main`. The `develop` branch still exists in the
+  repository's history but is no longer used.
 - Reference the related GitHub issue in every pull request description.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Plugin cards now show each plugin's real branded icon (from `public/icons/`) instead of a generated letter avatar where one is mapped in `plugins.json`; plugins without a mapped icon still fall back to the letter avatar (#214).
 - Pages now emit a canonical URL (`<link rel="canonical">` and `og:url`), built from `NEXT_PUBLIC_BASE_URL`, so query-string and trailing-slash variants of a page are no longer treated as separate resources. The dynamic guide and public-profile routes report their concrete path rather than the bracketed template (#244).
+- The site now serves `/robots.txt` and `/sitemap.xml`, so search engines are told which pages exist instead of discovering them only by following links. The sitemap lists the top-level pages plus every on-site plugin guide (`/guides/[id]`, generated from `pages/data/plugins.json`); `robots.txt` asks crawlers to skip `/account`, `/dev` and `/api/`, and points at the sitemap. Both are routes built from `NEXT_PUBLIC_BASE_URL` rather than hard-coded static files, backed by a tested `utils/sitemap.ts` helper (#257).
 - Shared links now show a branded preview image instead of a text-only card: a 1200×630 social card (`public/social-card.png`) is advertised as `og:image`/`twitter:image`, and `twitter:card` is now `summary_large_image`. Pages can override the image — or opt out of it — via a new `image` prop on `Seo`, backed by a tested `socialImageUrl` helper (#215).
 
 ### Changed
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `USER_GUIDE.md` no longer claims the Guides page opens a plugin's guide "in a new tab" — guides have rendered on-site at `/guides/[id]` since #163; the doc now describes that behavior and the "View on GitHub" fallback link.
 - `NEXT_PUBLIC_BASE_URL` is now passed as a Docker build arg and environment variable in `compose.yml` (matching `NEXT_PUBLIC_API_URL`), so it can actually be set when deploying via `docker compose up --build` as `CONFIG.md` already documented. Previously it had no `Dockerfile`/`compose.yml` wiring at all, so the production build always inlined the `http://localhost:3000` default regardless of what was set, and canonical URLs / `og:url` / shared-link previews would always advertise `localhost` (#251).
 - `CONTRIBUTING.md`'s Testing section now lists `npm test` and `npm run build` alongside `npm run lint`, and adds a backend (`dpc-api/`) testing step — previously it named only `npm run lint`, so a contributor following it exactly could open a PR that fails CI on the `npm test` and `./mvnw verify` gates the guide never mentioned (#254).
+- `CONTRIBUTING.md` and `.github/copilot-instructions.md` now tell contributors to branch from and target `main`, which is where every pull request has actually gone for months. They previously described a `develop`-based workflow, so a contributor following them exactly would branch from a `develop` that has not moved since 0.13.0 and then have to retarget or rebase the pull request (#249).
 
 ## [0.14.0] – 2026-06-14
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -68,7 +68,7 @@ Every page advertises a preview image for shared links (`og:image`, `twitter:ima
 The site serves `/robots.txt` and `/sitemap.xml` so search engines know which pages exist and which routes to leave alone. Both are **routes** (`pages/robots.txt.ts` and `pages/sitemap.xml.ts`), not static files under `public/`, because both need absolute URLs built from `NEXT_PUBLIC_BASE_URL` — a static file would have to hard-code an origin.
 
 - **Set `NEXT_PUBLIC_BASE_URL` before deploying.** Otherwise the sitemap advertises `http://localhost:3000` pages and `robots.txt` points at a `localhost` sitemap, both of which are useless to a crawler.
-- The page list lives in `STATIC_SITEMAP_PATHS` in `utils/sitemap.ts`. Add a new top-level page there when you add one; the per-plugin guide pages (`/guides/[id]`) are generated from `pages/data/plugins.json` and need no maintenance.
+- The page list lives in `STATIC_SITEMAP_PATHS` in `utils/sitemap.ts`. Add a new top-level page there when you add one — a test in `__tests__/sitemap.test.ts` walks `pages/` and fails if an addressable page is neither listed in the sitemap nor disallowed below. The per-plugin guide pages (`/guides/[id]`) are generated from `pages/data/plugins.json` and need no maintenance.
 - `robots.txt` disallows `/account` (signed-in only), `/dev` (the developer console), and `/api/` (JSON, not pages) — the `DISALLOWED_CRAWL_PATHS` list in the same file. Public profiles (`/u/[username]`) stay crawlable but are not listed in the sitemap.
 - Neither document is a substitute for indexing controls on individual pages; `robots.txt` is a request, not an access control. Do not rely on it to keep anything private.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,7 +22,7 @@ NEXT_PUBLIC_API_URL=https://api.dansplugins.com
 
 **Type:** string  
 **Default:** `http://localhost:3000`  
-**Description:** The site's own base URL. It is used for two things: calls the frontend makes to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`), and the absolute URLs each page advertises to search engines and link scrapers — the canonical URL (`<link rel="canonical">` and `og:url`) and the social preview image (`og:image`/`twitter:image`, served from `public/social-card.png`). Set this to the site's public origin when deploying — otherwise server-side rendering cannot reach its own API routes, and shared links will advertise `localhost` URLs whose preview image no one outside your machine can load. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend. Like all `NEXT_PUBLIC_*` variables, it is inlined at **build time**, not read at runtime — with Docker Compose it must be set when running `docker compose up --build` (see [Docker Compose Configuration](#docker-compose-configuration)), not just on the running container.
+**Description:** The site's own base URL. It is used for three things: calls the frontend makes to its internal Next.js API routes (for example, the visit-counter endpoint at `/api/visits`); the absolute URLs each page advertises to search engines and link scrapers — the canonical URL (`<link rel="canonical">` and `og:url`) and the social preview image (`og:image`/`twitter:image`, served from `public/social-card.png`); and the URLs listed in `/sitemap.xml` and `/robots.txt` (see [Crawler Documents](#crawler-documents)). Set this to the site's public origin when deploying — otherwise server-side rendering cannot reach its own API routes, shared links will advertise `localhost` URLs whose preview image no one outside your machine can load, and the sitemap will hand search engines a list of `localhost` pages. Distinct from `NEXT_PUBLIC_API_URL`, which points at the separate DPC API backend. Like all `NEXT_PUBLIC_*` variables, it is inlined at **build time**, not read at runtime — with Docker Compose it must be set when running `docker compose up --build` (see [Docker Compose Configuration](#docker-compose-configuration)), not just on the running container.
 
 **Example:**
 
@@ -62,6 +62,15 @@ Every page advertises a preview image for shared links (`og:image`, `twitter:ima
 - The site-wide card is `public/social-card.png` (1200×630, the size Open Graph consumers expect). Replace that file to rebrand it; keep the dimensions, since `components/Seo.tsx` declares them as `og:image:width`/`og:image:height`. If the new artwork says something different, update `DEFAULT_SOCIAL_IMAGE_ALT` in `components/Seo.tsx` too — it is the `og:image:alt` text describing the card.
 - The URL is made absolute using `NEXT_PUBLIC_BASE_URL`, so that variable must be set to the site's public origin for previews to work anywhere but your own machine.
 - A page can override the image by passing an `image` prop to `Seo` — either a path under `public/` or an absolute URL — or suppress it entirely with `image={null}`. Overrides omit the width/height hints, since only the site card's dimensions are known.
+
+## Crawler Documents
+
+The site serves `/robots.txt` and `/sitemap.xml` so search engines know which pages exist and which routes to leave alone. Both are **routes** (`pages/robots.txt.ts` and `pages/sitemap.xml.ts`), not static files under `public/`, because both need absolute URLs built from `NEXT_PUBLIC_BASE_URL` — a static file would have to hard-code an origin.
+
+- **Set `NEXT_PUBLIC_BASE_URL` before deploying.** Otherwise the sitemap advertises `http://localhost:3000` pages and `robots.txt` points at a `localhost` sitemap, both of which are useless to a crawler.
+- The page list lives in `STATIC_SITEMAP_PATHS` in `utils/sitemap.ts`. Add a new top-level page there when you add one; the per-plugin guide pages (`/guides/[id]`) are generated from `pages/data/plugins.json` and need no maintenance.
+- `robots.txt` disallows `/account` (signed-in only), `/dev` (the developer console), and `/api/` (JSON, not pages) — the `DISALLOWED_CRAWL_PATHS` list in the same file. Public profiles (`/u/[username]`) stay crawlable but are not listed in the sitemap.
+- Neither document is a substitute for indexing controls on individual pages; `robots.txt` is a request, not an access control. Do not rely on it to keep anything private.
 
 ## Editing News Posts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,14 +39,17 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/dansplugins
 
 ## Making Changes
 
+`main` is the trunk: branch from it and open your pull request back against it.
+(A `develop` branch exists in the repository's history but is no longer used.)
+
 1. Make sure an issue exists for the work. If not, create one.
-2. Switch to `develop`: `git checkout develop`
+2. Switch to `main`: `git checkout main`
 3. Create a branch: `git checkout -b <branch-name>`
 4. Make your changes.
 5. Test your changes (see [Testing](#testing)).
 6. Commit: `git commit -m "Description of changes"`
 7. Push: `git push origin <branch-name>`
-8. Open a pull request against `develop`, link the related issue with `#<number>`.
+8. Open a pull request against `main`, link the related issue with `#<number>`.
 9. Address review feedback.
 
 ## Testing

--- a/__tests__/seo.test.ts
+++ b/__tests__/seo.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { absoluteUrl, canonicalPath, socialImageUrl } from '../utils/seo';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { absoluteUrl, canonicalPath, siteBaseUrl, socialImageUrl } from '../utils/seo';
+
+describe('siteBaseUrl', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('uses NEXT_PUBLIC_BASE_URL when it is set', () => {
+        vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://dansplugins.com');
+        expect(siteBaseUrl()).toBe('https://dansplugins.com');
+    });
+
+    it('falls back to the local development origin when it is unset or empty', () => {
+        vi.stubEnv('NEXT_PUBLIC_BASE_URL', '');
+        expect(siteBaseUrl()).toBe('http://localhost:3000');
+    });
+});
 
 describe('canonicalPath', () => {
     it('returns a plain path unchanged', () => {

--- a/__tests__/sitemap.test.ts
+++ b/__tests__/sitemap.test.ts
@@ -1,0 +1,119 @@
+import {describe, expect, it} from 'vitest';
+import {
+    DISALLOWED_CRAWL_PATHS,
+    SITEMAP_ROUTE,
+    STATIC_SITEMAP_PATHS,
+    guideSitemapPaths,
+    robotsTxt,
+    sitemapXml
+} from '../utils/sitemap';
+
+const BASE_URL = 'https://dansplugins.com';
+
+describe('STATIC_SITEMAP_PATHS', () => {
+    it('lists only site-relative paths', () => {
+        const notRelative = STATIC_SITEMAP_PATHS.filter((path) => !path.startsWith('/'));
+        expect(notRelative).toEqual([]);
+    });
+
+    it('contains no dynamic route templates, which have no single canonical URL', () => {
+        const templates = STATIC_SITEMAP_PATHS.filter((path) => path.includes('['));
+        expect(templates).toEqual([]);
+    });
+
+    it('does not offer a route that robots.txt asks crawlers to skip', () => {
+        const contradictions = STATIC_SITEMAP_PATHS.filter((path) =>
+            DISALLOWED_CRAWL_PATHS.some((disallowed) => path.startsWith(disallowed))
+        );
+        expect(contradictions).toEqual([]);
+    });
+});
+
+describe('sitemapXml', () => {
+    it('renders a well-formed urlset with one absolute loc per path', () => {
+        expect(sitemapXml(BASE_URL, ['/', '/about'])).toBe(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+            '    <url>\n        <loc>https://dansplugins.com/</loc>\n    </url>\n' +
+            '    <url>\n        <loc>https://dansplugins.com/about</loc>\n    </url>\n' +
+            '</urlset>\n'
+        );
+    });
+
+    it('does not double up slashes when the base URL has a trailing slash', () => {
+        expect(sitemapXml('https://dansplugins.com/', ['/news'])).toContain(
+            '<loc>https://dansplugins.com/news</loc>'
+        );
+    });
+
+    it('escapes XML-reserved characters in a URL', () => {
+        expect(sitemapXml(BASE_URL, ['/news?a=1&b=2'])).toContain(
+            '<loc>https://dansplugins.com/news?a=1&amp;b=2</loc>'
+        );
+    });
+
+    it('still renders a valid empty urlset when given no paths', () => {
+        expect(sitemapXml(BASE_URL, [])).toBe(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+            '</urlset>\n'
+        );
+    });
+
+    it('lists every static path', () => {
+        const xml = sitemapXml(BASE_URL, STATIC_SITEMAP_PATHS);
+        STATIC_SITEMAP_PATHS.forEach((path) => {
+            expect(xml).toContain(`<loc>${path === '/' ? `${BASE_URL}/` : `${BASE_URL}${path}`}</loc>`);
+        });
+    });
+});
+
+describe('guideSitemapPaths', () => {
+    it('maps plugin ids onto their on-site guide routes', () => {
+        expect(guideSitemapPaths(['medieval-factions', 'fiefs']))
+            .toEqual(['/guides/medieval-factions', '/guides/fiefs']);
+    });
+
+    it('returns nothing when there are no plugins', () => {
+        expect(guideSitemapPaths([])).toEqual([]);
+    });
+});
+
+describe('robotsTxt', () => {
+    it('allows crawling and points at the absolute sitemap URL', () => {
+        expect(robotsTxt(BASE_URL)).toBe(
+            'User-agent: *\n' +
+            'Allow: /\n' +
+            'Disallow: /account\n' +
+            'Disallow: /dev\n' +
+            'Disallow: /api/\n' +
+            '\n' +
+            'Sitemap: https://dansplugins.com/sitemap.xml\n'
+        );
+    });
+
+    it('does not double up slashes when the base URL has a trailing slash', () => {
+        expect(robotsTxt('https://dansplugins.com/')).toContain(
+            'Sitemap: https://dansplugins.com/sitemap.xml'
+        );
+    });
+
+    it('works with the local development default', () => {
+        expect(robotsTxt('http://localhost:3000')).toContain(
+            'Sitemap: http://localhost:3000/sitemap.xml'
+        );
+    });
+
+    it('disallows every route listed as off-limits', () => {
+        const robots = robotsTxt(BASE_URL);
+        DISALLOWED_CRAWL_PATHS.forEach((path) => {
+            expect(robots).toContain(`Disallow: ${path}`);
+        });
+    });
+});
+
+describe('SITEMAP_ROUTE', () => {
+    it('matches the route pages/sitemap.xml.ts is served from', () => {
+        expect(SITEMAP_ROUTE).toBe('/sitemap.xml');
+    });
+});

--- a/__tests__/sitemap.test.ts
+++ b/__tests__/sitemap.test.ts
@@ -1,3 +1,5 @@
+import {readdirSync} from 'node:fs';
+import {join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 import {
     DISALLOWED_CRAWL_PATHS,
@@ -9,6 +11,34 @@ import {
 } from '../utils/sitemap';
 
 const BASE_URL = 'https://dansplugins.com';
+
+// The routes under pages/ that a crawler could ask for, ignoring everything that
+// is not an addressable page: API handlers, Next.js special files (_app,
+// _document), the error pages, dynamic templates (no single URL to list), and the
+// two crawler documents themselves. Used only by the drift guard below, so the
+// path list cannot silently fall behind the pages/ directory.
+const crawlableRoutes = (dir = 'pages', prefix = ''): string[] =>
+    readdirSync(join(process.cwd(), dir), {withFileTypes: true}).flatMap((entry) => {
+        if (entry.isDirectory()) {
+            return entry.name === 'api' ? [] : crawlableRoutes(join(dir, entry.name), `${prefix}/${entry.name}`);
+        }
+        const match = entry.name.match(/^(.*)\.tsx?$/);
+        if (!match) {
+            return [];
+        }
+        const name = match[1];
+        if (
+            name.startsWith('_') ||
+            name === '404' ||
+            name === '500' ||
+            name.includes('[') ||
+            name === 'robots.txt' ||
+            name === 'sitemap.xml'
+        ) {
+            return [];
+        }
+        return [name === 'index' ? prefix || '/' : `${prefix}/${name}`];
+    });
 
 describe('STATIC_SITEMAP_PATHS', () => {
     it('lists only site-relative paths', () => {
@@ -26,6 +56,27 @@ describe('STATIC_SITEMAP_PATHS', () => {
             DISALLOWED_CRAWL_PATHS.some((disallowed) => path.startsWith(disallowed))
         );
         expect(contradictions).toEqual([]);
+    });
+
+    // Drift guard: adding a page under pages/ without deciding what crawlers
+    // should do with it is the failure mode this list has. Every addressable
+    // page must be either offered in the sitemap or explicitly disallowed —
+    // if this fails, add the new route to one of the two lists.
+    it('accounts for every addressable page under pages/', () => {
+        const unaccountedFor = crawlableRoutes().filter(
+            (route) =>
+                !STATIC_SITEMAP_PATHS.includes(route) &&
+                !DISALLOWED_CRAWL_PATHS.some((disallowed) => route.startsWith(disallowed))
+        );
+        expect(unaccountedFor).toEqual([]);
+    });
+
+    it('the drift guard actually finds the site\'s pages', () => {
+        // Guards the guard: a broken directory walk would make the check above
+        // pass vacuously.
+        expect(crawlableRoutes()).toContain('/');
+        expect(crawlableRoutes()).toContain('/news');
+        expect(crawlableRoutes()).toContain('/dev');
     });
 });
 
@@ -76,6 +127,10 @@ describe('guideSitemapPaths', () => {
 
     it('returns nothing when there are no plugins', () => {
         expect(guideSitemapPaths([])).toEqual([]);
+    });
+
+    it('percent-encodes an id so the advertised URL still resolves to the route', () => {
+        expect(guideSitemapPaths(['a b', 'a/b'])).toEqual(['/guides/a%20b', '/guides/a%2Fb']);
     });
 });
 

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import {useRouter} from 'next/router';
 import React from 'react';
-import {absoluteUrl, canonicalPath, socialImageUrl} from '../utils/seo';
+import {absoluteUrl, canonicalPath, siteBaseUrl, socialImageUrl} from '../utils/seo';
 
 // Shared per-page document metadata: title, description, canonical URL, and
 // Open Graph / Twitter card tags so browser tabs, search engines, and shared
@@ -10,11 +10,12 @@ import {absoluteUrl, canonicalPath, socialImageUrl} from '../utils/seo';
 const SITE_NAME = "Dan's Plugins Community";
 const DEFAULT_DESCRIPTION =
     "Free, open-source plugins for Minecraft servers — Medieval Factions and a catalogue of complementary plugins, all developed in the open and free to use.";
-// The site's own origin, shared with services/visitService.ts. Documented in
-// CONFIG.md. Read once at module scope rather than through a getter (as
-// visitService does for stubbing in tests): Next.js inlines NEXT_PUBLIC_* at
-// build time, and the canonical URL never varies within a running build.
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+// The site's own origin, shared with services/visitService.ts and the crawler
+// routes (pages/sitemap.xml.ts, pages/robots.txt.ts). Documented in CONFIG.md.
+// Read once at module scope rather than per render: Next.js inlines
+// NEXT_PUBLIC_* at build time, and the canonical URL never varies within a
+// running build.
+const BASE_URL = siteBaseUrl();
 // Branded 1200x630 card served from public/. Shown as the preview image
 // whenever a dansplugins.com link is shared (Discord above all, which is where
 // the community lives). The dimensions are the size Open Graph consumers

--- a/pages/robots.txt.ts
+++ b/pages/robots.txt.ts
@@ -1,0 +1,21 @@
+import type {GetServerSideProps} from 'next';
+import {siteBaseUrl} from '../utils/seo';
+import {robotsTxt} from '../utils/sitemap';
+
+// Serves /robots.txt. A route rather than a static file under public/ because the
+// `Sitemap:` line has to be an absolute URL and the origin is
+// environment-specific (NEXT_PUBLIC_BASE_URL, documented in CONFIG.md), which a
+// checked-in file would have to hard-code.
+
+export const getServerSideProps: GetServerSideProps = async ({res}) => {
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.write(robotsTxt(siteBaseUrl()));
+    res.end();
+    return {props: {}};
+};
+
+// Next.js requires a default export from every file in pages/. The response is
+// written in getServerSideProps above, so this component never renders.
+const RobotsTxt = () => null;
+
+export default RobotsTxt;

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,0 +1,31 @@
+import type {GetServerSideProps} from 'next';
+import {siteBaseUrl} from '../utils/seo';
+import {STATIC_SITEMAP_PATHS, guideSitemapPaths, sitemapXml} from '../utils/sitemap';
+
+// Serves /sitemap.xml. A route rather than a static file under public/ because
+// the URLs must be absolute and the origin is environment-specific
+// (NEXT_PUBLIC_BASE_URL, documented in CONFIG.md), which a checked-in file would
+// have to hard-code.
+
+interface GuidePlugin {
+    id: string;
+}
+
+const pluginData = require('./data/plugins.json') as { plugins: GuidePlugin[] };
+
+export const getServerSideProps: GetServerSideProps = async ({res}) => {
+    const paths = [
+        ...STATIC_SITEMAP_PATHS,
+        ...guideSitemapPaths(pluginData.plugins.map((plugin) => plugin.id))
+    ];
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.write(sitemapXml(siteBaseUrl(), paths));
+    res.end();
+    return {props: {}};
+};
+
+// Next.js requires a default export from every file in pages/. The response is
+// written in getServerSideProps above, so this component never renders.
+const SitemapXml = () => null;
+
+export default SitemapXml;

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -20,6 +20,14 @@ export const canonicalPath = (path: string): string | null => {
     return withoutTrailingSlash === '' ? '/' : withoutTrailingSlash;
 };
 
+// The site's own public origin. Every absolute URL the site advertises — the
+// canonical URL, og:url, og:image, and the crawler documents in utils/sitemap.ts
+// — is built from this. Documented in CONFIG.md. Read through a function so each
+// caller decides when to read it: components/Seo.tsx reads once at module scope
+// (the canonical URL never varies within a running build), while the sitemap and
+// robots.txt routes read per request.
+export const siteBaseUrl = (): string => process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+
 // Join the site's own origin to a canonical path. `baseUrl` comes from
 // NEXT_PUBLIC_BASE_URL (documented in CONFIG.md) and may or may not carry a
 // trailing slash; `path` is the output of canonicalPath.

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -1,0 +1,79 @@
+// Builders for the two crawler documents the site serves: `/sitemap.xml` (the
+// list of pages worth indexing) and `/robots.txt` (which routes a crawler may
+// visit, plus a pointer at the sitemap). Kept pure and separate from the routes
+// in pages/ — the same split as utils/seo.ts and components/Seo.tsx — so the
+// path list and the generated text can be unit-tested without a request.
+
+import {absoluteUrl} from './seo';
+
+// The route the sitemap is served from, referenced by both the sitemap route
+// itself and the `Sitemap:` line in robots.txt.
+export const SITEMAP_ROUTE = '/sitemap.xml';
+
+// The static pages worth offering to a search engine. Deliberately not derived
+// from the contents of pages/ — that directory also holds error pages, API
+// routes, dynamic templates, and the two signed-in-only pages below, none of
+// which belong in a sitemap. Keep this list in step with the top navigation
+// (components/TopBar.tsx) when a page is added or removed.
+export const STATIC_SITEMAP_PATHS: readonly string[] = [
+    '/',
+    '/about',
+    '/guides',
+    '/leaderboard',
+    '/news',
+    '/roadmap',
+    '/commissions'
+];
+
+// Routes a crawler is asked to skip: `/account` is signed-in-only, `/dev` is the
+// developer console, and `/api/` serves JSON rather than pages. Public profiles
+// (`/u/[username]`) stay crawlable — they are public — but are left out of the
+// sitemap, since the set of usernames is not ours to enumerate.
+export const DISALLOWED_CRAWL_PATHS: readonly string[] = ['/account', '/dev', '/api/'];
+
+// Escape the five characters XML reserves. Today's paths are plain slugs, but a
+// future path carrying a query string or an ampersand would otherwise emit
+// invalid XML that a crawler rejects outright.
+const escapeXml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+
+// Render a sitemap for the given site-relative paths. `baseUrl` comes from
+// NEXT_PUBLIC_BASE_URL (documented in CONFIG.md), so the URLs are absolute as
+// the sitemap protocol requires. No `lastmod`, `changefreq` or `priority`: the
+// pages are server-rendered from live data with no per-page modification date to
+// report honestly, and Google ignores the latter two.
+export const sitemapXml = (baseUrl: string, paths: readonly string[]): string => {
+    const urls = paths.map(
+        (path) => `    <url>\n        <loc>${escapeXml(absoluteUrl(baseUrl, path))}</loc>\n    </url>`
+    );
+    return [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        ...urls,
+        '</urlset>',
+        ''
+    ].join('\n');
+};
+
+// The on-site guide pages (`/guides/[id]`), one per plugin in
+// pages/data/plugins.json. They are reachable from the Guides page, but listing
+// them saves a crawler from having to follow that page's links to find them.
+export const guideSitemapPaths = (pluginIds: readonly string[]): string[] =>
+    pluginIds.map((id) => `/guides/${id}`);
+
+// Render robots.txt: everything is crawlable except the routes above, and the
+// sitemap is advertised as the absolute URL the standard requires.
+export const robotsTxt = (baseUrl: string): string =>
+    [
+        'User-agent: *',
+        'Allow: /',
+        ...DISALLOWED_CRAWL_PATHS.map((path) => `Disallow: ${path}`),
+        '',
+        `Sitemap: ${absoluteUrl(baseUrl, SITEMAP_ROUTE)}`,
+        ''
+    ].join('\n');

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -12,9 +12,11 @@ export const SITEMAP_ROUTE = '/sitemap.xml';
 
 // The static pages worth offering to a search engine. Deliberately not derived
 // from the contents of pages/ — that directory also holds error pages, API
-// routes, dynamic templates, and the two signed-in-only pages below, none of
-// which belong in a sitemap. Keep this list in step with the top navigation
-// (components/TopBar.tsx) when a page is added or removed.
+// routes, dynamic templates, and the routes listed as off-limits below, none of
+// which belong in a sitemap. Add a new top-level page here when you add one.
+// This is the top navigation (components/TopBar.tsx) minus `/dev`: the Dev
+// Portal is linked for humans but renders nothing until its client-side API
+// calls resolve, so there is nothing there for a crawler to index.
 export const STATIC_SITEMAP_PATHS: readonly string[] = [
     '/',
     '/about',
@@ -26,7 +28,8 @@ export const STATIC_SITEMAP_PATHS: readonly string[] = [
 ];
 
 // Routes a crawler is asked to skip: `/account` is signed-in-only, `/dev` is the
-// developer console, and `/api/` serves JSON rather than pages. Public profiles
+// developer console (see above), and `/api/` serves JSON rather than pages. This
+// is a request, not access control — nothing here is private. Public profiles
 // (`/u/[username]`) stay crawlable — they are public — but are left out of the
 // sitemap, since the set of usernames is not ours to enumerate.
 export const DISALLOWED_CRAWL_PATHS: readonly string[] = ['/account', '/dev', '/api/'];

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -65,9 +65,12 @@ export const sitemapXml = (baseUrl: string, paths: readonly string[]): string =>
 
 // The on-site guide pages (`/guides/[id]`), one per plugin in
 // pages/data/plugins.json. They are reachable from the Guides page, but listing
-// them saves a crawler from having to follow that page's links to find them.
+// them saves a crawler from having to follow that page's links to find them. Ids
+// are percent-encoded as a single path segment — every id today is a plain slug,
+// but Next.js hands `params.id` back decoded, so encoding here is what keeps the
+// advertised URL and the route in agreement whatever an id contains.
 export const guideSitemapPaths = (pluginIds: readonly string[]): string[] =>
-    pluginIds.map((id) => `/guides/${id}`);
+    pluginIds.map((id) => `/guides/${encodeURIComponent(id)}`);
 
 // Render robots.txt: everything is crawlable except the routes above, and the
 // sitemap is advertised as the absolute URL the standard requires.


### PR DESCRIPTION
## Summary

- **Crawler documents (#257).** The site now serves `/robots.txt` and `/sitemap.xml`. Both are routes (`pages/robots.txt.ts`, `pages/sitemap.xml.ts`) rather than static files under `public/`, because both need absolute URLs built from `NEXT_PUBLIC_BASE_URL` and a checked-in file would have to hard-code an origin — against the "no hard-coded environment-specific values" rule in `.github/copilot-instructions.md`.
- The URL/text assembly lives in a pure, tested `utils/sitemap.ts` (`sitemapXml`, `robotsTxt`, `guideSitemapPaths`, plus the `STATIC_SITEMAP_PATHS` / `DISALLOWED_CRAWL_PATHS` lists), mirroring how `utils/seo.ts` is split out of `components/Seo.tsx`.
- The `NEXT_PUBLIC_BASE_URL` read moves into a shared `siteBaseUrl()` helper in `utils/seo.ts`, so `components/Seo.tsx` and the two crawler routes resolve the origin the same way instead of repeating the fallback literal. `components/Seo.tsx` still reads it once at module scope.
- Sitemap contents: the seven top-level pages plus every on-site plugin guide (`/guides/[id]`, generated from `pages/data/plugins.json`). No `lastmod`/`changefreq`/`priority` — the pages are server-rendered from live data with no honest per-page modification date, and Google ignores the latter two. Public profiles (`/u/[username]`) stay crawlable but are not enumerated.
- `robots.txt` disallows `/account` (signed-in only), `/dev` (developer console) and `/api/` (JSON, not pages), and advertises the sitemap's absolute URL.
- **Contributor docs (#249).** `CONTRIBUTING.md` and `.github/copilot-instructions.md` now say to branch from and target `main`, which is where every merged PR has actually gone for months, and note that `develop` still exists in history but is unused.
- Docs: new "Crawler Documents" section in `CONFIG.md` (including the reminder that `NEXT_PUBLIC_BASE_URL` must be set before deploying, or the sitemap advertises `localhost` pages), an updated `NEXT_PUBLIC_BASE_URL` description, and `[Unreleased]` entries in `CHANGELOG.md`.

## Notes / deliberate omissions

- Issue #249 offered "either delete `develop` or note in the docs that it is retired". This takes the documentation route only — deleting a remote branch is irreversible, so it is left for a human decision.
- `build.yml` still lists `develop` in its push triggers. Harmless for a branch that never moves, so it is left alone rather than widening this PR's scope.

## Test plan

- [ ] CI: `npm run lint`, `npm test`, `npm run build` (no Node toolchain available in the authoring environment, so CI is the gate).
- [ ] New `__tests__/sitemap.test.ts` covers: XML shape and escaping, the empty-path case, trailing-slash origins, guide-path mapping, the exact `robots.txt` body, and a consistency check that no sitemap path is also disallowed.
- [ ] `__tests__/seo.test.ts` gains coverage of `siteBaseUrl()` (set and empty).
- [ ] Manual: `curl localhost:3000/robots.txt` and `curl localhost:3000/sitemap.xml` return `text/plain` and `application/xml` respectively; with `NEXT_PUBLIC_BASE_URL=https://dansplugins.com` set at build time the URLs are absolute against that origin.

Closes #257
Closes #249

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
