### PR TITLE
Dedupe API/site base-URL fallbacks into shared resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The "View the issue" link on a converted feature request now uses MUI's `Link` instead of a bare `<a>`, so it takes the theme's link colour like every other link on the site rather than the browser default (#246).
 - Internal navigation (top nav, the wordmark, plugin/guide links, the account and public-profile pages) now routes through `next/link` instead of plain `<a href>`/`<Button href>`, so moving between pages is an instant client-side transition instead of a full page reload. External links (Discord, GitHub, SpigotMC, etc.) and same-page hash anchors are unchanged (#222).
 - The top navigation now collapses into a hamburger menu (a right-hand `Drawer`) below the `md` breakpoint instead of wrapping twelve links into a ragged multi-line block, and the four off-site community links (Discord, Patreon, LinkedIn, RPKit) are grouped behind a "Community" menu/section on both desktop and mobile so the primary in-site nav stays to eight destinations plus Account (#216).
+- The `NEXT_PUBLIC_API_URL || 'http://localhost:45345'` fallback, previously copy-pasted across seven files, is now a single `getApiBaseUrl()` resolver in `utils/apiBase.ts`; `services/visitService.ts` now shares `utils/seo.ts`'s `siteBaseUrl()` instead of keeping its own copy of the `NEXT_PUBLIC_BASE_URL` fallback. No behaviour change (#258, #260).
 
 ### Fixed
 

--- a/__tests__/apiBase.test.ts
+++ b/__tests__/apiBase.test.ts
@@ -1,0 +1,18 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {DEFAULT_API_BASE_URL, getApiBaseUrl} from '../utils/apiBase';
+
+describe('getApiBaseUrl', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('uses NEXT_PUBLIC_API_URL when it is set', () => {
+        vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.dansplugins.com');
+        expect(getApiBaseUrl()).toBe('https://api.dansplugins.com');
+    });
+
+    it('falls back to the local dev-portal default when it is unset or empty', () => {
+        vi.stubEnv('NEXT_PUBLIC_API_URL', '');
+        expect(getApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+    });
+});

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -30,11 +30,12 @@ import {pageStyle, sectionHeaderStyle} from '../styles/styles'
 import {getMyLikes, type LikedTarget} from '../services/likeService'
 import {resolveLikedItems} from '../utils/likedItems'
 import {badgeLabel} from '../utils/badges'
+import {getApiBaseUrl} from '../utils/apiBase'
 import pluginData from './data/plugins.json'
 
 const version = require('../package.json').version
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345'
+const API_BASE = getApiBaseUrl()
 
 interface ApiKeyInfo {
     id: string

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -29,10 +29,11 @@ import Seo from '../components/Seo'
 import BottomBar from '../components/BottomBar'
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../styles/styles'
 import {relativeTimeFrom} from '../utils/relativeTime'
+import {getApiBaseUrl} from '../utils/apiBase'
 
 const version = require('../package.json').version
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345'
+const API_BASE = getApiBaseUrl()
 
 interface Faction {
     id: string

--- a/services/backlogService.ts
+++ b/services/backlogService.ts
@@ -1,6 +1,8 @@
 // Client-side calls to the dpc-api dev-portal backlog endpoints — a read-only
 // mirror of open GitHub issues/PRs across the Dans-Plugins org.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+import {getApiBaseUrl} from '../utils/apiBase';
+
+const API_BASE = getApiBaseUrl();
 
 export interface BacklogItem {
     repo: string;

--- a/services/claimService.ts
+++ b/services/claimService.ts
@@ -1,6 +1,8 @@
 // Client-side calls to the dpc-api claim endpoints — "I'm working on this" on a
 // backlog issue/PR. A claim is a dpc-api record, not a GitHub assignee.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+import {getApiBaseUrl} from '../utils/apiBase';
+
+const API_BASE = getApiBaseUrl();
 
 export interface Claim {
     repo: string;

--- a/services/featureRequestService.ts
+++ b/services/featureRequestService.ts
@@ -1,7 +1,9 @@
 // Client-side calls to the dpc-api feature-request endpoints — community
 // plugin ideas, upvoted via the existing like mechanism and (admin-only)
 // convertible into a real GitHub issue.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+import {getApiBaseUrl} from '../utils/apiBase';
+
+const API_BASE = getApiBaseUrl();
 
 export interface FeatureRequest {
     id: string;

--- a/services/likeService.ts
+++ b/services/likeService.ts
@@ -1,6 +1,8 @@
 // Client-side calls to the dpc-api likes endpoints. The base URL is the same
 // public API the leaderboard/account pages use.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345';
+import {getApiBaseUrl} from '../utils/apiBase';
+
+const API_BASE = getApiBaseUrl();
 
 export type LikeTargetType = 'plugin' | 'guide' | 'issue' | 'feature_request';
 

--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -1,8 +1,9 @@
 // Client-side calls to the dpc-api public profile endpoint. Same public API the
 // account/leaderboard pages use.
 import type {LikedTarget} from './likeService'
+import {getApiBaseUrl} from '../utils/apiBase'
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:45345'
+const API_BASE = getApiBaseUrl()
 
 /** A user's public profile — no internal id and no API keys (see dpc-api PublicProfileResponse). */
 export interface PublicProfile {

--- a/services/visitService.ts
+++ b/services/visitService.ts
@@ -1,16 +1,16 @@
+import {siteBaseUrl} from '../utils/seo';
+
 interface VisitData {
     visits: number;
     startDate: string;
 }
 
-const getBaseUrl = () => process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
-
 export const incrementVisits = async (): Promise<void> => {
-    await fetch(`${getBaseUrl()}/api/visits`, { method: 'POST' });
+    await fetch(`${siteBaseUrl()}/api/visits`, { method: 'POST' });
 };
 
 export const getVisits = async (): Promise<VisitData> => {
-    const response = await fetch(`${getBaseUrl()}/api/visits`);
+    const response = await fetch(`${siteBaseUrl()}/api/visits`);
     if (!response.ok) {
         throw new Error(`Failed to fetch visits: ${response.status} ${response.statusText}`);
     }

--- a/utils/apiBase.ts
+++ b/utils/apiBase.ts
@@ -1,0 +1,8 @@
+// The default dpc-api dev-portal origin used when NEXT_PUBLIC_API_URL is not
+// set (documented in CONFIG.md).
+export const DEFAULT_API_BASE_URL = 'http://localhost:45345';
+
+// Resolve the dpc-api base URL. A function rather than a module-scope
+// constant so tests can stub NEXT_PUBLIC_API_URL per test — the same reason
+// services/visitService.ts's getBaseUrl() is a getter.
+export const getApiBaseUrl = (): string => process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_BASE_URL;


### PR DESCRIPTION
## Summary
- Extracted the `NEXT_PUBLIC_API_URL || 'http://localhost:45345'` fallback (copy-pasted across 7 files: `pages/account.tsx`, `pages/leaderboard.tsx`, `services/backlogService.ts`, `services/claimService.ts`, `services/featureRequestService.ts`, `services/likeService.ts`, `services/profileService.ts`) into a single `getApiBaseUrl()` resolver in a new `utils/apiBase.ts`.
- Replaced `services/visitService.ts`'s own copy of the `NEXT_PUBLIC_BASE_URL` fallback (`getBaseUrl`) with an import of the existing `siteBaseUrl()` from `utils/seo.ts`.
- Pure refactor: no behavioural change, no new environment variable, no doc changes beyond a `CHANGELOG.md` entry (both vars were already documented in `CONFIG.md`).
- Added `__tests__/apiBase.test.ts` covering the new resolver, following the existing pattern in `__tests__/seo.test.ts`.

Closes #258
Closes #260

## Test plan
- [x] `getApiBaseUrl()` covered by new `__tests__/apiBase.test.ts` (default fallback + `NEXT_PUBLIC_API_URL` override)
- [x] Existing `__tests__/visitService.test.ts` continues to cover `siteBaseUrl()` behaviour end-to-end via `incrementVisits`/`getVisits`
- [ ] `npm run lint && npm test && npm run build` — could not run locally, see note below

**Note on local verification:** this sandbox has no working Linux Node/npm interpreter (only a Windows `npm.cmd` reachable via `/mnt/c`, which fails with a UNC-path error under WSL bash). Local lint/test/build could not be executed as the anchor; deferring to this repo's `Build` GitHub Actions workflow (`npm run lint && npm test && npm run build` on `ubuntu-latest`) as the real anchor for this PR's head SHA.

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
