### PR TITLE
Show latest GitHub release version on plugin cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Plugin cards now show a "Latest: vX.Y.Z" chip fetched from each plugin's GitHub releases at render time, so server owners can see the current release without clicking through to GitHub. Plugins with no releases show no chip; the fetch is best-effort and backed by a tested `utils/github.ts` helper (#162).
 - Plugin cards now show each plugin's real branded icon (from `public/icons/`) instead of a generated letter avatar where one is mapped in `plugins.json`; plugins without a mapped icon still fall back to the letter avatar (#214).
 - Pages now emit a canonical URL (`<link rel="canonical">` and `og:url`), built from `NEXT_PUBLIC_BASE_URL`, so query-string and trailing-slash variants of a page are no longer treated as separate resources. The dynamic guide and public-profile routes report their concrete path rather than the bracketed template (#244).
 - The site now serves `/robots.txt` and `/sitemap.xml`, so search engines are told which pages exist instead of discovering them only by following links. The sitemap lists the top-level pages plus every on-site plugin guide (`/guides/[id]`, generated from `pages/data/plugins.json`); `robots.txt` asks crawlers to skip `/account`, `/dev` and `/api/`, and points at the sitemap. Both are routes built from `NEXT_PUBLIC_BASE_URL` rather than hard-coded static files, backed by a tested `utils/sitemap.ts` helper (#257).

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLatestRelease, getLatestReleasesWithRateLimit, parseGithubRepo } from '../utils/github';
+
+const stubFetch = (response: Partial<Response>) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response as Response));
+};
+
+beforeEach(() => {
+    // The implementation logs errors on bad responses; keep test output quiet.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('parseGithubRepo', () => {
+    it('extracts owner/repo from a GitHub URL', () => {
+        expect(parseGithubRepo('https://github.com/Dans-Plugins/Activity-Tracker')).toBe('Dans-Plugins/Activity-Tracker');
+    });
+
+    it('strips a trailing .git suffix', () => {
+        expect(parseGithubRepo('https://github.com/Dans-Plugins/Activity-Tracker.git')).toBe('Dans-Plugins/Activity-Tracker');
+    });
+
+    it('returns undefined for a non-GitHub URL', () => {
+        expect(parseGithubRepo('https://example.com/Dans-Plugins/Activity-Tracker')).toBeUndefined();
+    });
+});
+
+describe('getLatestRelease', () => {
+    it('returns the tag name from a well-formed response', async () => {
+        stubFetch({ ok: true, json: async () => ({ tag_name: 'v1.2.3' }) });
+        expect(await getLatestRelease('https://github.com/Dans-Plugins/Activity-Tracker')).toBe('v1.2.3');
+    });
+
+    it('returns undefined on a 404 (no releases) without logging an error', async () => {
+        stubFetch({ ok: false, status: 404, statusText: 'Not Found' });
+        expect(await getLatestRelease('https://github.com/Dans-Plugins/Activity-Tracker')).toBeUndefined();
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined on a non-ok, non-404 response', async () => {
+        stubFetch({ ok: false, status: 503, statusText: 'Service Unavailable' });
+        expect(await getLatestRelease('https://github.com/Dans-Plugins/Activity-Tracker')).toBeUndefined();
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    it('returns undefined when tag_name is missing', async () => {
+        stubFetch({ ok: true, json: async () => ({ unexpected: 'shape' }) });
+        expect(await getLatestRelease('https://github.com/Dans-Plugins/Activity-Tracker')).toBeUndefined();
+    });
+
+    it('returns undefined when fetch rejects', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+        expect(await getLatestRelease('https://github.com/Dans-Plugins/Activity-Tracker')).toBeUndefined();
+    });
+
+    it('returns undefined for a link that is not a GitHub URL', async () => {
+        vi.stubGlobal('fetch', vi.fn());
+        expect(await getLatestRelease('https://example.com/foo/bar')).toBeUndefined();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});
+
+describe('getLatestReleasesWithRateLimit', () => {
+    it('resolves a tag for every link when batching by the concurrency limit', async () => {
+        const tags: Record<string, string> = { a: 'v1.0.0', b: 'v2.0.0', c: 'v3.0.0', d: 'v4.0.0', e: 'v5.0.0' };
+        vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+            const repo = url.split('/repos/')[1].split('/releases')[0];
+            const id = repo.split('/')[1];
+            return Promise.resolve({ ok: true, json: async () => ({ tag_name: tags[id] }) } as Response);
+        }));
+
+        const links = Object.keys(tags).map((id) => `https://github.com/org/${id}`);
+        const result = await getLatestReleasesWithRateLimit(links, 2);
+
+        expect(result.size).toBe(5);
+        expect(result.get('https://github.com/org/a')).toBe('v1.0.0');
+        expect(result.get('https://github.com/org/e')).toBe('v5.0.0');
+    });
+
+    it('returns an empty map for an empty link list', async () => {
+        vi.stubGlobal('fetch', vi.fn());
+        const result = await getLatestReleasesWithRateLimit([], 5);
+        expect(result.size).toBe(0);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -92,7 +92,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
 
             {(serverCount && serverCount > 0) || latestVersion ? (
                 <Box sx={{px: 2, pb: 1}}>
-                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    <Stack direction="row" spacing={1} sx={{flexWrap: 'wrap', rowGap: 1}}>
                         {serverCount && serverCount > 0 ? (
                             <Chip
                                 size="small"

--- a/components/PluginCard.tsx
+++ b/components/PluginCard.tsx
@@ -3,6 +3,7 @@ import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, 
 import GitHubIcon from '@mui/icons-material/GitHub';
 import DnsIcon from '@mui/icons-material/Dns';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
+import NewReleasesIcon from '@mui/icons-material/NewReleases';
 import LikeButton from './LikeButton';
 import {NextLinkComposed} from './NextLinkComposed';
 import {
@@ -20,6 +21,7 @@ interface PluginCardProps {
     bStatsId?: string;
     icon?: string;
     serverCount?: number | null;
+    latestVersion?: string | null;
     likeCount: number;
     liked: boolean;
     token: string | null;
@@ -46,6 +48,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
     spigotmcLink,
     icon,
     serverCount,
+    latestVersion,
     likeCount,
     liked,
     token
@@ -87,14 +90,26 @@ const PluginCard: React.FC<PluginCardProps> = ({
                 </Typography>
             </CardContent>
 
-            {serverCount && serverCount > 0 ? (
+            {(serverCount && serverCount > 0) || latestVersion ? (
                 <Box sx={{px: 2, pb: 1}}>
-                    <Chip
-                        size="small"
-                        variant="outlined"
-                        icon={<DnsIcon/>}
-                        label={`${serverCount.toLocaleString()} servers`}
-                    />
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        {serverCount && serverCount > 0 ? (
+                            <Chip
+                                size="small"
+                                variant="outlined"
+                                icon={<DnsIcon/>}
+                                label={`${serverCount.toLocaleString()} servers`}
+                            />
+                        ) : null}
+                        {latestVersion ? (
+                            <Chip
+                                size="small"
+                                variant="outlined"
+                                icon={<NewReleasesIcon/>}
+                                label={`Latest: ${latestVersion}`}
+                            />
+                        ) : null}
+                    </Stack>
                 </Box>
             ) : null}
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import BottomBar from '../components/BottomBar'
 import { getVisits, incrementVisits } from '../services/visitService';
 import { getServerCountsWithRateLimit } from '../utils/bstats';
+import { getLatestReleasesWithRateLimit } from '../utils/github';
 import { getLikeCounts, getMyLikes } from '../services/likeService';
 import { sortPlugins, type SortOption } from '../utils/sortPlugins';
 import { EXPERIENCE_CHOSEN_KEY, hasChosenExperience } from '../utils/experience';
@@ -53,6 +54,7 @@ interface Plugin {
 
 interface PluginWithServerCount extends Plugin {
     serverCount?: number | null;
+    latestVersion?: string | null;
 }
 
 interface PluginSectionProps {
@@ -75,6 +77,7 @@ const PluginSection: React.FC<PluginSectionProps> = ({ plugins, likeCounts, like
                     bStatsId={plugin.bStatsId}
                     icon={plugin.icon}
                     serverCount={plugin.serverCount}
+                    latestVersion={plugin.latestVersion}
                     likeCount={likeCounts[plugin.id] || 0}
                     liked={likedSet.has(plugin.id)}
                     token={token}
@@ -215,11 +218,16 @@ export const getServerSideProps = async () => {
         .map(plugin => plugin.bStatsId as string);
     
     const serverCountsMap = await getServerCountsWithRateLimit(bStatsIds, 5);
-    
-    // Create plugins with server counts
+
+    // Fetch latest release tags for all plugins with rate limiting
+    const githubLinks = pluginData.plugins.map(plugin => plugin.githubLink);
+    const latestReleasesMap = await getLatestReleasesWithRateLimit(githubLinks, 5);
+
+    // Create plugins with server counts and latest release versions
     const pluginsWithCounts: PluginWithServerCount[] = pluginData.plugins.map(plugin => ({
         ...plugin,
-        serverCount: (plugin.bStatsId ? serverCountsMap.get(plugin.bStatsId) : undefined) ?? null
+        serverCount: (plugin.bStatsId ? serverCountsMap.get(plugin.bStatsId) : undefined) ?? null,
+        latestVersion: latestReleasesMap.get(plugin.githubLink) ?? null
     }));
 
     return {

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,0 +1,80 @@
+/**
+ * Extracts the `owner/repo` slug from a GitHub repository URL.
+ * @param githubLink e.g. "https://github.com/Dans-Plugins/Activity-Tracker"
+ * @returns "Dans-Plugins/Activity-Tracker" or undefined if the URL doesn't match
+ */
+export function parseGithubRepo(githubLink: string): string | undefined {
+    const match = githubLink.match(/github\.com\/([^/]+)\/([^/#?]+)/i);
+    if (!match) {
+        return undefined;
+    }
+    return `${match[1]}/${match[2].replace(/\.git$/, '')}`;
+}
+
+/**
+ * Fetches the latest release tag for a GitHub repository.
+ * @param githubLink The repository's GitHub URL
+ * @returns The latest release tag name, or undefined if unavailable/error
+ */
+export async function getLatestRelease(githubLink: string): Promise<string | undefined> {
+    const repo = parseGithubRepo(githubLink);
+    if (!repo) {
+        return undefined;
+    }
+
+    try {
+        const response = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+            headers: {Accept: 'application/vnd.github+json'}
+        });
+
+        if (!response.ok) {
+            // 404 just means the repo has no releases yet; not an error worth logging.
+            if (response.status !== 404) {
+                console.error(
+                    `Error fetching latest release for ${repo}: HTTP ${response.status} ${response.statusText}`
+                );
+            }
+            return undefined;
+        }
+
+        const data = await response.json();
+
+        if (typeof data?.tag_name !== 'string' || data.tag_name.length === 0) {
+            return undefined;
+        }
+
+        return data.tag_name;
+    } catch (error) {
+        console.error(`Error fetching latest release for ${repo}:`, error);
+        return undefined;
+    }
+}
+
+/**
+ * Fetches the latest release tag for multiple repositories with rate limiting.
+ * @param githubLinks Array of GitHub repository URLs
+ * @param concurrentLimit Maximum number of concurrent requests (default: 5)
+ * @returns Map of githubLink to latest release tag
+ */
+export async function getLatestReleasesWithRateLimit(
+    githubLinks: string[],
+    concurrentLimit: number = 5
+): Promise<Map<string, string | undefined>> {
+    const results = new Map<string, string | undefined>();
+
+    for (let i = 0; i < githubLinks.length; i += concurrentLimit) {
+        const batch = githubLinks.slice(i, i + concurrentLimit);
+        const batchResults = await Promise.all(
+            batch.map(async (link) => {
+                const tag = await getLatestRelease(link);
+                return {link, tag};
+            })
+        );
+
+        batchResults.forEach(({link, tag}) => {
+            results.set(link, tag);
+        });
+    }
+
+    return results;
+}


### PR DESCRIPTION
## Summary

- Plugin cards give a title, description, server count, and out-links, but nothing about which version is current — server owners had to click through to GitHub to check. This adds a "Latest: vX.Y.Z" chip fetched from each plugin's GitHub Releases API, rendered alongside the existing server-count chip.
- New `utils/github.ts` (`parseGithubRepo`, `getLatestRelease`, `getLatestReleasesWithRateLimit`) mirrors the existing `utils/bstats.ts` pattern (same rate-limited batching, same fail-soft `undefined`-on-error behavior so a GitHub API hiccup never breaks the page).
- `pages/index.tsx`'s `getServerSideProps` fetches latest releases for all 16 plugins the same way it already fetches bStats server counts, and passes `latestVersion` through to `PluginCard`.
- Plugins with no GitHub releases (404) simply show no version chip — no fabricated data.

Partial resolution of #162: this covers "what's the latest version" (fetched live, not hand-entered). "Which Minecraft versions are supported" is intentionally **not** addressed here — filling in per-plugin MC-version compatibility would mean fabricating data not derivable from source, so #162 stays open for that half.

## Test plan
- [x] `__tests__/github.test.ts` — new tests covering `parseGithubRepo`, `getLatestRelease` (happy path, 404, non-404 error, malformed payload, network failure, non-GitHub URL), and `getLatestReleasesWithRateLimit` (batching, empty input), following the sibling `__tests__/bstats.test.ts` conventions.
- [ ] CI (`npm run lint && npm test && npm run build`) — local `node`/`npm` are unavailable in this sandbox (Windows-path `npm` shim, no Linux `node` on `PATH`), so this PR's CI run on GitHub Actions is the real anchor; watching it before merge.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
