### PR TITLE
Add getServerSideProps test coverage for the guide page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Pages now emit a canonical URL (`<link rel="canonical">` and `og:url`), built from `NEXT_PUBLIC_BASE_URL`, so query-string and trailing-slash variants of a page are no longer treated as separate resources. The dynamic guide and public-profile routes report their concrete path rather than the bracketed template (#244).
 - The site now serves `/robots.txt` and `/sitemap.xml`, so search engines are told which pages exist instead of discovering them only by following links. The sitemap lists the top-level pages plus every on-site plugin guide (`/guides/[id]`, generated from `pages/data/plugins.json`); `robots.txt` asks crawlers to skip `/account`, `/dev` and `/api/`, and points at the sitemap. Both are routes built from `NEXT_PUBLIC_BASE_URL` rather than hard-coded static files, backed by a tested `utils/sitemap.ts` helper (#257).
 - Shared links now show a branded preview image instead of a text-only card: a 1200×630 social card (`public/social-card.png`) is advertised as `og:image`/`twitter:image`, and `twitter:card` is now `summary_large_image`. Pages can override the image — or opt out of it — via a new `image` prop on `Seo`, backed by a tested `socialImageUrl` helper (#215).
+- The guide page's (`pages/guides/[id].tsx`) `getServerSideProps` — the not-found, successful-fetch, non-ok-response, and network-failure branches — now has unit test coverage, matching the pattern already used for the home page's `getServerSideProps`. No behaviour change.
 
 ### Changed
 

--- a/__tests__/guideId.getServerSideProps.test.ts
+++ b/__tests__/guideId.getServerSideProps.test.ts
@@ -1,0 +1,73 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {GetServerSidePropsContext} from 'next';
+
+import {getServerSideProps} from '../pages/guides/[id]';
+
+interface GuidePropsShape {
+    props: {
+        id: string;
+        title: string;
+        githubLink: string;
+        markdown: string | null;
+    };
+}
+
+interface NotFoundShape {
+    notFound: true;
+}
+
+// The function only reads context.params, so a minimal object covers every
+// branch without constructing a full GetServerSidePropsContext (req/res/etc).
+const contextWithId = (id?: string): GetServerSidePropsContext =>
+    ({params: id === undefined ? {} : {id}} as GetServerSidePropsContext);
+
+// A real id/githubLink pair from pages/data/plugins.json, so the lookup
+// exercises the actual catalogue rather than a fixture that could drift from it.
+const KNOWN_ID = 'activity-tracker';
+const KNOWN_GITHUB_LINK = 'https://github.com/Dans-Plugins/Activity-Tracker';
+
+beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+});
+
+describe('guide page getServerSideProps', () => {
+    it('returns notFound for an id absent from plugins.json', async () => {
+        const result = await getServerSideProps(contextWithId('not-a-real-plugin')) as NotFoundShape;
+        expect(result).toEqual({notFound: true});
+    });
+
+    it('returns notFound when params.id is missing', async () => {
+        const result = await getServerSideProps(contextWithId()) as NotFoundShape;
+        expect(result).toEqual({notFound: true});
+    });
+
+    it('returns the fetched markdown when the raw USER_GUIDE.md fetch succeeds', async () => {
+        vi.mocked(fetch).mockResolvedValue({ok: true, text: () => Promise.resolve('# Hello')} as Response);
+
+        const result = await getServerSideProps(contextWithId(KNOWN_ID)) as GuidePropsShape;
+
+        expect(result.props).toEqual({
+            id: KNOWN_ID,
+            title: 'Activity Tracker',
+            githubLink: KNOWN_GITHUB_LINK,
+            markdown: '# Hello',
+        });
+    });
+
+    it('falls back to null markdown when the fetch response is not ok', async () => {
+        vi.mocked(fetch).mockResolvedValue({ok: false, text: () => Promise.resolve('')} as Response);
+
+        const result = await getServerSideProps(contextWithId(KNOWN_ID)) as GuidePropsShape;
+
+        expect(result.props.markdown).toBeNull();
+        expect(result.props.id).toBe(KNOWN_ID);
+    });
+
+    it('falls back to null markdown when the fetch throws (network failure)', async () => {
+        vi.mocked(fetch).mockRejectedValue(new Error('network unreachable'));
+
+        const result = await getServerSideProps(contextWithId(KNOWN_ID)) as GuidePropsShape;
+
+        expect(result.props.markdown).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- Backlog triage: all 5 open Phase-3 epic sub-issues (#192-#196) are large multi-file backend+frontend features, well beyond a polish-sized PR. #24, #57, #87, and #142 have each been repeatedly deferred across prior cycles as needing human design/infra decisions (external Discord bot integration, TLS cert strategy, an authenticated admin write path, and a feature blocked on #24 respectively) — nothing new to add there this cycle. A documentation sweep (CONFIG.md, README.md, USER_GUIDE.md, CHANGELOG.md, next.config.js) found no drift; the docs are current with source.
- This cycle is a Stage B (unit-test expansion) cycle instead: `pages/guides/[id].tsx`'s `getServerSideProps` has real branching logic (plugin-not-found, successful markdown fetch, non-ok response, and network-failure fallback) but had no test — unlike the home page's `getServerSideProps`, which already does (`__tests__/index.getServerSideProps.test.ts`).
- Adds `__tests__/guideId.getServerSideProps.test.ts`, covering all four branches, following the existing mocking convention (`vi.stubGlobal('fetch', ...)`) from the sibling home-page test.

No production code changed — test coverage only.

## Test plan
- [x] New tests trace correctly against the source (`pages/guides/[id].tsx`) by hand: not-found for both an unknown id and a missing `params.id`, successful fetch returns the fetched markdown, and both a non-ok response and a thrown fetch both fall back to `markdown: null`.
- [ ] CI (`npm run lint && npm test && npm run build`) — local `node`/`npm` are unavailable in this sandbox (Windows-path `npm` shim, no Linux `node` on `PATH`, same constraint noted in PR #262), so GitHub Actions is the real anchor; watching it before merge.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
