### PR TITLE
Document the next.config.js options CONFIG.md actually sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CONTRIBUTING.md`'s Testing section now lists `npm test` and `npm run build` alongside `npm run lint`, and adds a backend (`dpc-api/`) testing step — previously it named only `npm run lint`, so a contributor following it exactly could open a PR that fails CI on the `npm test` and `./mvnw verify` gates the guide never mentioned (#254).
 - `CONTRIBUTING.md` and `.github/copilot-instructions.md` now tell contributors to branch from and target `main`, which is where every pull request has actually gone for months. They previously described a `develop`-based workflow, so a contributor following them exactly would branch from a `develop` that has not moved since 0.13.0 and then have to retarget or rebase the pull request (#249).
 - `.github/workflows/build.yml`'s push trigger no longer lists `develop` alongside `main` — #249 already retired the `develop`-based workflow in the contributor docs, but the CI trigger was missed, so it still fired on pushes to a branch every doc says is unused. `pull_request` triggers (which run on real PRs regardless of target) are unchanged.
+- `CONFIG.md`'s `next.config.js` section now names the two options actually set (`reactStrictMode`, `swcMinify`) with their values and rationale, instead of only linking to the upstream Next.js docs. `swcMinify: false` is noted as a restatement of the default under the pinned `next@12.2.2` (not an active opt-out), which should be revisited on a future Next.js major upgrade (#265).
 
 ## [0.14.0] – 2026-06-14
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -118,4 +118,9 @@ Each entry in the `posts` array supports these fields:
 
 ## next.config.js
 
-Additional Next.js configuration is found in `next.config.js` in the project root. Refer to the [Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/introduction) for all available options.
+Additional Next.js configuration is found in `next.config.js` in the project root. The options actually set there are documented below; refer to the [Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/introduction) for everything else.
+
+| Option | Value | Why |
+| --- | --- | --- |
+| `reactStrictMode` | `true` | Opts into React's additional development-mode checks (double-invoked effects, deprecated API warnings) to catch issues early. |
+| `swcMinify` | `false` | `next` is pinned at `12.2.2`, where the SWC minifier defaults to `false`; this line restates that default rather than actively opting out of it. Next.js made `swcMinify` default to `true` starting in v13, so this line should be revisited (and can likely be removed) if/when the `next` dependency is upgraded past v12. |


### PR DESCRIPTION
## Summary

- `CONFIG.md`'s `next.config.js` section previously pointed only at the upstream Next.js docs, unlike every other section of the file, which documents the actual value and rationale for each configurable surface.
- The section has been replaced with a short table naming the two options actually set in `next.config.js` (`reactStrictMode`, `swcMinify`), each with its value and a one-line rationale.
- `swcMinify: false` is noted as a restatement of the default under the pinned `next@12.2.2` (the SWC minifier's default changed to `true` starting in Next.js 13), rather than a deliberate opt-out — so a future Next.js major-version upgrade has a documented basis for deciding whether the line is still needed.
- A `CHANGELOG.md` entry has been added under `[Unreleased] > Fixed` describing the change.

## Test plan

- [x] Diff reviewed against `next.config.js` and `package.json` to confirm both documented values and the pinned Next.js version.
- [ ] `npm run lint` / `npm run build` — **UNVERIFIED-not-applicable**: no Linux-native `node`/`npm` toolchain is reachable in this sandbox (only a Windows `npm` binary is visible via WSL interop, which fails on the environment's UNC working-directory path). The change is documentation-only (`CONFIG.md`, `CHANGELOG.md`); no source files are touched, so lint/build would not have exercised this diff regardless.

Closes #265

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->