### PR TITLE
chore: release version 0.15.0-SNAPSHOT-8-8-2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.15.0-SNAPSHOT-8-8-2026] – 2026-08-08
+
+### Changed
+- dansplugins-dot-com is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The version bump marks that change in how the project is built — it is not a break in behaviour, configuration or stored data, and existing installations can upgrade in place. Released as `0.15.0-SNAPSHOT-8-8-2026`: the AI-first line has not yet been verified in live operation, and the dated snapshot designation stays until it has.
 
 ### Added
 

--- a/dpc-api/README.md
+++ b/dpc-api/README.md
@@ -324,4 +324,4 @@ cd dpc-api
 ./mvnw clean package -DskipTests
 ```
 
-The runnable JAR is produced at `target/dpc-api-0.1.0-SNAPSHOT.jar`.
+The runnable JAR is produced at `target/dpc-api-0.2.0-SNAPSHOT-8-8-2026.jar`.

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.dansplugins</groupId>
     <artifactId>dpc-api</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT-8-8-2026</version>
     <name>dpc-api</name>
     <description>DPC community data API</description>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dpc-website",
-  "version": "0.14.0",
+  "version": "0.15.0-SNAPSHOT-8-8-2026",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dpc-website",
-      "version": "0.14.0",
+      "version": "0.15.0-SNAPSHOT-8-8-2026",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dpc-website",
-  "version": "0.14.0",
+  "version": "0.15.0-SNAPSHOT-8-8-2026",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Each independently-versioned component has been bumped from its own current
version rather than being levelled to a shared number:

| File | From | To |
|---|---|---|
| `package.json` | `0.14.0` | `0.15.0-SNAPSHOT-8-8-2026` |
| `dpc-api/pom.xml` | `0.1.0-SNAPSHOT` | `0.2.0-SNAPSHOT-8-8-2026` |

The bump marks dansplugins-dot-com moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata and the documentation that cites it has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
