### PR TITLE
docs(roadmap): reflect the current state of the issue tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- The road map now reflects the state of the issue tracker. **Resource pages** move to Completed (#272, shipped in 0.15.0), and **on-site guides**, **community profiles and likes** (epic #167 phases 1–2), the **Dev Portal**, and the **search-visibility and link-preview work** (#244, #257, #215) are listed as completed work the page had never mentioned. **Discord announcements in News** (#24) moves from In Progress to Planned — its ingestion was never merged and the retraction problem (#142) is unanswered, so nothing is under way. New Planned items cover the open issues the page omitted: verified reviews and the install reporting they depend on (#278), following and an activity feed (#193), notifications (#196), profiles linked to factions (#195), MCP access tokens (#280, #281), and a knowledge-base section backed by the DPC Zettelkasten (#282). **Minecraft-version compatibility** (#162) and **badges and roles** (#194) are listed as In Progress, each naming the half that shipped and the half that has not.
+
 ## [0.15.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/pages/data/roadmap.json
+++ b/pages/data/roadmap.json
@@ -8,12 +8,32 @@
     },
     {
       "title": "Factions Leaderboard",
-      "description": "A public leaderboard on the website showing community factions synced from participating servers.",
+      "description": "A public leaderboard on the website showing community factions synced from participating servers, each row carrying the server's IP, its Discord, and how recently it last synced.",
       "status": "Completed"
     },
     {
       "title": "Account Management & API Keys",
       "description": "Register an account and manage API keys used by plugins to sync data.",
+      "status": "Completed"
+    },
+    {
+      "title": "Community Profiles & Likes",
+      "description": "One identity for the whole site, provided by the shared UserAuth service: sign in, keep a profile with a display name, avatar and bio, and like plugins and guides. Every profile is public at /u/{username}, likes drive a \"Most Liked\" sort in the catalogue, and a Server Owner badge is derived for anyone whose server syncs with DPC.",
+      "status": "Completed"
+    },
+    {
+      "title": "On-Site Plugin Guides",
+      "description": "Every plugin's user guide rendered on the site at /guides/{plugin}, read from the plugin's own repository, instead of linking visitors out to raw GitHub markdown.",
+      "status": "Completed"
+    },
+    {
+      "title": "Resource Pages",
+      "description": "A page of its own for every plugin at /resources/{plugin}, gathering its description, install count, latest release, guide and links in one place instead of a card on the home page. Bug reports route to the plugin's issue tracker and feature ideas to the Dev Portal, so a resource page never becomes a support queue.",
+      "status": "Completed"
+    },
+    {
+      "title": "Dev Portal",
+      "description": "A public backlog console at /dev mirroring the open issues and pull requests across DPC repositories, where visitors can register interest in an item, claim one to work on, and submit a feature request for a maintainer to convert into a GitHub issue.",
       "status": "Completed"
     },
     {
@@ -23,7 +43,7 @@
     },
     {
       "title": "Automated Test Harness",
-      "description": "A Vitest test suite, run in CI, covering the site's highest-value logic.",
+      "description": "A Vitest test suite, run in CI, covering the site's highest-value logic, alongside the dpc-api backend's own test suite.",
       "status": "Completed"
     },
     {
@@ -38,17 +58,22 @@
     },
     {
       "title": "UX & Accessibility Improvements",
-      "description": "A dark/light theme that persists and follows the operating-system preference, current-page navigation highlighting, consistent new-tab external links, keyboard-accessible cards, and in-place error retry on the leaderboard.",
+      "description": "A dark/light theme that persists and follows the operating-system preference, current-page navigation highlighting, a navigation bar that collapses into a menu on small screens, instant client-side page transitions, consistent new-tab external links, keyboard-accessible cards, per-page headings and landmarks with a skip-to-content link, and in-place error retry on the leaderboard.",
       "status": "Completed"
     },
     {
-      "title": "Discord Announcements in News",
-      "description": "Automatically pull announcements from the community Discord server into the News feed alongside hand-written posts.",
+      "title": "Search Visibility & Link Previews",
+      "description": "Page titles, descriptions and canonical URLs, a robots.txt and a sitemap listing every guide and resource page, and a branded preview image so a shared link shows more than a line of text.",
+      "status": "Completed"
+    },
+    {
+      "title": "Minecraft-Version Compatibility",
+      "description": "Answering a server owner's first question — will this run on my server? — on the card itself. The latest release is now shown per plugin; the supported Minecraft versions still are not, and that half remains open.",
       "status": "In Progress"
     },
     {
-      "title": "Resource Pages",
-      "description": "A page of its own for every plugin, gathering its description, install count, latest release, guide and links in one place instead of a card on the home page.",
+      "title": "Badges & Roles on Profiles",
+      "description": "Recognition on a profile for what someone has done in the community. Server Owner is awarded already, derived from owning an API key; contributor, plugin author and early adopter still need a way to be granted.",
       "status": "In Progress"
     },
     {
@@ -59,6 +84,11 @@
     {
       "title": "Plugin Reviews",
       "description": "Star ratings and written reviews on each plugin, each with a reply from the author, kept separate from bug reports so that a rating is never a support ticket in disguise.",
+      "status": "Planned"
+    },
+    {
+      "title": "Verified Reviews",
+      "description": "A mark on a review showing it comes from someone whose server actually runs the plugin. Nothing reported to the API today identifies which plugins a server runs, so this needs a per-plugin install report from the plugins themselves before the mark can mean anything — which is why reviews ship without it.",
       "status": "Planned"
     },
     {
@@ -78,7 +108,37 @@
     },
     {
       "title": "Editable Plugin Catalogue",
-      "description": "Allow the plugin cards data to be edited from the website instead of by hand, replacing the checked-in catalogue file with the database table the resource pages are built on.",
+      "description": "Allow the plugin cards data to be edited from the website instead of by hand, replacing the checked-in catalogue file with the database table that now holds the same plugins.",
+      "status": "Planned"
+    },
+    {
+      "title": "Following & Activity Feed",
+      "description": "Follow the people whose work you want to keep up with, and a simple feed of what they have been doing.",
+      "status": "Planned"
+    },
+    {
+      "title": "Notifications",
+      "description": "On-site notifications when someone replies to you or likes something you wrote, with an optional Discord webhook and no email.",
+      "status": "Planned"
+    },
+    {
+      "title": "Profiles Linked to Factions",
+      "description": "Connect a profile to the factions its owner belongs to on participating servers, tying the community layer to the faction data the leaderboard already carries.",
+      "status": "Planned"
+    },
+    {
+      "title": "Discord Announcements in News",
+      "description": "Automatically pull announcements from the community Discord server into the News feed alongside hand-written posts. The ingestion has been written but not merged: it never removes a post, so an announcement retracted on Discord would stay on the site forever, and that has to be answered before it lands.",
+      "status": "Planned"
+    },
+    {
+      "title": "MCP Access Tokens",
+      "description": "Long-lived, individually revocable tokens issued from your account for connecting an AI assistant to the DPC MCP server, listed separately from Minecraft server API keys and handed over with a ready-to-paste connection snippet.",
+      "status": "Planned"
+    },
+    {
+      "title": "Knowledge Base",
+      "description": "A section of the site backed by the DPC Zettelkasten — the collection of notes explaining how the plugins work, with every claim traced to a commit — starting with an index of its maps of content and growing into a \"how it works\" block on each plugin's resource page.",
       "status": "Planned"
     },
     {


### PR DESCRIPTION
## What

The Road Map page is driven by `pages/data/roadmap.json`. It had drifted from the issue tracker, so this brings the two back into line. Data only — no changes to `pages/roadmap.tsx`.

### Moved to Completed

- **Resource pages** — #272 closed and shipped in 0.15.0, but the item still read In Progress.
- **On-site plugin guides**, **community profiles and likes** (epic #167 phases 1–2), the **Dev Portal**, and **search visibility and link previews** (#244, #257, #215) — all shipped, none of them mentioned on the page.

### Moved back to Planned

- **Discord announcements in News** (#24) was listed as In Progress. Its ingestion PR was never merged, `V11` dropped the table it created, no code for it exists on `main`, and there is no open PR — so nothing is under way. The description now says so and names the unanswered retraction problem (#142).

### New Planned items, one per open issue the page omitted

Verified reviews and the per-plugin install reporting they depend on (#278), following and an activity feed (#193), notifications (#196), profiles linked to factions (#195), MCP access tokens (#280, #281), and a knowledge-base section backed by the DPC Zettelkasten (#282).

### New In Progress items

- **Minecraft-version compatibility** (#162) — the latest-release chip shipped in 0.15.0; the supported-Minecraft-versions half is still open.
- **Badges and roles** (#194) — the derived Server Owner badge shipped; contributor, plugin author and early adopter still need a grant path.

Descriptions were also refreshed where the feature has grown since it was written (the leaderboard, the UX and accessibility item, the editable-catalogue item now that `V15` exists).

## Coverage

Every open issue is now represented: #271's phases (#273–#276) and #278, epic #167's phase 3 (#192–#196), #162, #142/#24, #87, #57, #280, #281, #282.

## Verification

`roadmap.json` parses and every item validates against the `RoadmapItem` shape the page expects (13 Completed, 2 In Progress, 14 Planned; no duplicate titles). No test references the road-map data and the page component is untouched, so the suite is unaffected; CI will confirm.

*This pull request was drafted by Claude on behalf of Daniel Stephenson.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)