### PR TITLE
Send a guide's relative links back to its repository, and stop parsing raw HTML in guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Resource pages now show a plugin's release history. `dpc-api` mirrors each plugin's GitHub releases into new `plugin_versions` and `plugin_version_assets` tables (`V16`) on an hourly schedule and serves them at `GET /api/v1/plugins/{slug}/versions`; `/resources/[slug]` renders the newest release expanded, with its changelog and a download button per asset, and the rest collapsed into accordions. A downloads chip joins the server-count chip, and the "Latest" chip now reads from the mirror when there is one — still the newest *stable* release, as GitHub's own "latest" means it — so a page render no longer spends a call on GitHub's rate limit for something the API already holds. DPC still hosts no files: every download link points at the asset on GitHub. Release notes are rendered with raw HTML parsing disabled, unlike the guide renderer, because a mirrored release body is not a file from a repository this site controls (#273).
+- Resource pages now show a plugin's release history. `dpc-api` mirrors each plugin's GitHub releases into new `plugin_versions` and `plugin_version_assets` tables (`V16`) on an hourly schedule and serves them at `GET /api/v1/plugins/{slug}/versions`; `/resources/[slug]` renders the newest release expanded, with its changelog and a download button per asset, and the rest collapsed into accordions. A downloads chip joins the server-count chip, and the "Latest" chip now reads from the mirror when there is one — still the newest *stable* release, as GitHub's own "latest" means it — so a page render no longer spends a call on GitHub's rate limit for something the API already holds. DPC still hosts no files: every download link points at the asset on GitHub. Release notes are rendered with raw HTML parsing disabled, because a mirrored release body is not a file from a repository this site controls (#273).
 - The release sync deletes a version GitHub no longer reports, but never on the strength of a failed fetch, and never past the oldest release it actually saw — so an outage or a rate limit can leave the mirror stale, but not wrongly empty.
 
 ### Changed
@@ -25,7 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Links inside an on-site guide now go where their author meant. A `USER_GUIDE.md` is written to be read in its repository, so `[Commands](COMMANDS.md)` resolves there against the repository — but rendered at `/guides/<id>` the browser resolved it against the guide's own URL, asked for `/guides/COMMANDS.md`, and got the site's 404 page. Eight of the sixteen guides carry at least one such link, Medieval Factions' four among them; they now point back at the file in the plugin's repository, on the same `blob/HEAD` default branch the "View on GitHub" button uses, with any `#fragment` carried along. Links that already name where they go are untouched, except that anything leaving the site now opens in a new tab with `rel="noopener noreferrer"`, as the rest of the site's outbound links do, and an in-page anchor still jumps down the page (#296).
+
 - `./up.sh` and `./down.sh` now work as `README.md` says they do. Neither script was tracked as executable, so the command the setup instructions give as the way to start the local stack answered `Permission denied` on a fresh clone before Docker was ever reached; all three helper scripts are now mode `100755` (#294). Their first line was `# /bin/bash` — a comment, not a shebang — leaving the interpreter to whatever the caller fell back to, and now reads `#!/bin/bash`. The two Compose scripts also called `docker-compose`, the v1 binary that reached end of life in June 2023 and that current Docker installations may not provide at all; they now call the v2 subcommand `docker compose`, the spelling every document in the repository already used (#292).
+
+### Security
+
+- The guide renderer no longer parses raw HTML. A guide body is fetched at request time from whatever currently sits on a plugin repository's default branch, so the "it comes from a repository we control" argument covered the repositories rather than the code; `components/PluginVersionList.tsx` had already turned the same option off for mirrored release notes. No catalogued guide uses raw HTML, so nothing rendered changes today (#297).
 
 ## [0.15.0-SNAPSHOT-8-8-2026] – 2026-08-08
 

--- a/RESOURCE_HUB.md
+++ b/RESOURCE_HUB.md
@@ -142,9 +142,9 @@ is entirely user-written text. That needs, at minimum:
 * a report action on every review and comment,
 * soft delete plus a moderation queue behind the existing `AdminProperties`,
 * per-user rate limits on posting,
-* raw HTML disabled in `markdown-to-jsx` wherever user text is rendered —
-  it is enabled by default, and the guide renderer's current settings are safe
-  only because the markdown comes from trusted repositories.
+* raw HTML disabled in `markdown-to-jsx` wherever user text is rendered — it is
+  enabled by default, so it has to be turned off deliberately, as the release-notes
+  and guide renderers both now do.
 
 ### Notifications stay on-site
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -48,6 +48,7 @@ No special software is required to use the website. Simply visit [https://danspl
 
 1. Click **Guides** in the top navigation bar (or visit `/guides`).
 2. Select a plugin from the list to open that plugin's user guide on-site (with a "View on GitHub" link if you want the raw source).
+3. A guide often links to the plugin's other documents, such as its command or configuration reference. Those live in the plugin's repository, so they open on GitHub in a new tab; links within the same guide jump down the page as usual.
 
 ### Viewing the Faction Leaderboard
 

--- a/__tests__/guideMarkdown.test.ts
+++ b/__tests__/guideMarkdown.test.ts
@@ -1,0 +1,53 @@
+import {createElement} from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe, expect, it} from 'vitest';
+import GuideMarkdown from '../components/GuideMarkdown';
+
+// The resolver in utils/guides.ts is unit-tested next door; what is checked here
+// is that the guide renderer actually applies it, which is the half that broke.
+// The component is rendered the way Next.js renders it — to static markup on the
+// server — rather than mounted in a DOM, so no browser environment is needed.
+// JSX is avoided so the file stays a .ts and is picked up by the existing
+// `__tests__/**/*.test.ts` include in vitest.config.ts.
+
+const FIEFS = 'https://github.com/Dans-Plugins/Fiefs';
+
+const render = (markdown: string, githubLink = FIEFS): string =>
+    renderToStaticMarkup(createElement(GuideMarkdown, {markdown, githubLink}));
+
+describe('GuideMarkdown', () => {
+    it('rewrites a repository-relative link so it does not 404 on the site', () => {
+        const html = render('See [Commands](COMMANDS.md).');
+        expect(html).toContain('href="https://github.com/Dans-Plugins/Fiefs/blob/HEAD/COMMANDS.md"');
+        expect(html).not.toContain('href="COMMANDS.md"');
+    });
+
+    it('resolves against the repository it was given, not a fixed one', () => {
+        const html = render('[Config](CONFIG.md)', 'https://github.com/Dans-Plugins/Wild-Pets');
+        expect(html).toContain('href="https://github.com/Dans-Plugins/Wild-Pets/blob/HEAD/CONFIG.md"');
+    });
+
+    it('opens a link that leaves the site in a new tab, with rel="noopener noreferrer"', () => {
+        const html = render('[SpigotMC](https://www.spigotmc.org/resources/fiefs-early-access.98559/)');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('keeps an in-page anchor in the page', () => {
+        const html = render('[Commands](#commands)');
+        expect(html).toContain('href="#commands"');
+        expect(html).not.toContain('target="_blank"');
+    });
+
+    it('does not parse raw HTML in a fetched guide', () => {
+        const html = render('Text <b>bold</b> more');
+        expect(html).not.toContain('<b>bold</b>');
+        expect(html).toContain('&lt;b&gt;bold&lt;/b&gt;');
+    });
+
+    it('still renders ordinary markdown', () => {
+        const html = render('# Heading\n\nA paragraph.');
+        expect(html).toContain('<h1');
+        expect(html).toContain('A paragraph.');
+    });
+});

--- a/__tests__/guides.test.ts
+++ b/__tests__/guides.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { userGuideUrl, userGuideRawUrl } from '../utils/guides';
+import { userGuideUrl, userGuideRawUrl, resolveGuideLink } from '../utils/guides';
+
+const FIEFS = 'https://github.com/Dans-Plugins/Fiefs';
 
 describe('userGuideUrl', () => {
     it('points at USER_GUIDE.md on the default branch of the repo', () => {
@@ -22,5 +24,56 @@ describe('userGuideRawUrl', () => {
     it('does not double up the slash when the link has a trailing slash', () => {
         expect(userGuideRawUrl('https://github.com/Dans-Plugins/Medieval-Factions/'))
             .toBe('https://raw.githubusercontent.com/Dans-Plugins/Medieval-Factions/HEAD/USER_GUIDE.md');
+    });
+});
+
+describe('resolveGuideLink', () => {
+    // The eight guides that carry one of these are the whole reason the resolver
+    // exists: rendered as written, `COMMANDS.md` resolves to /guides/COMMANDS.md
+    // and the site answers 404.
+    it('points a sibling markdown file back at the repository', () => {
+        expect(resolveGuideLink(FIEFS, 'COMMANDS.md'))
+            .toBe('https://github.com/Dans-Plugins/Fiefs/blob/HEAD/COMMANDS.md');
+    });
+
+    it('carries a fragment along with the rewritten path', () => {
+        expect(resolveGuideLink(FIEFS, 'CONFIG.md#files-in-the-data-folder'))
+            .toBe('https://github.com/Dans-Plugins/Fiefs/blob/HEAD/CONFIG.md#files-in-the-data-folder');
+    });
+
+    it('strips an explicit ./ prefix rather than doubling the slash', () => {
+        expect(resolveGuideLink(FIEFS, './CONFIG.md'))
+            .toBe('https://github.com/Dans-Plugins/Fiefs/blob/HEAD/CONFIG.md');
+    });
+
+    it('treats a root-relative path as repository-relative', () => {
+        expect(resolveGuideLink(FIEFS, '/docs/FAQ.md'))
+            .toBe('https://github.com/Dans-Plugins/Fiefs/blob/HEAD/docs/FAQ.md');
+    });
+
+    it('does not double up the slash when the repo link has a trailing slash', () => {
+        expect(resolveGuideLink('https://github.com/Dans-Plugins/Fiefs/', 'FAQ.md'))
+            .toBe('https://github.com/Dans-Plugins/Fiefs/blob/HEAD/FAQ.md');
+    });
+
+    it('leaves an absolute http(s) URL alone', () => {
+        expect(resolveGuideLink(FIEFS, 'https://www.spigotmc.org/resources/fiefs-early-access.98559/'))
+            .toBe('https://www.spigotmc.org/resources/fiefs-early-access.98559/');
+    });
+
+    it('leaves a non-http scheme alone', () => {
+        expect(resolveGuideLink(FIEFS, 'mailto:dan@example.com')).toBe('mailto:dan@example.com');
+    });
+
+    it('leaves a protocol-relative URL alone', () => {
+        expect(resolveGuideLink(FIEFS, '//example.com/x')).toBe('//example.com/x');
+    });
+
+    it('leaves an in-page anchor in the page', () => {
+        expect(resolveGuideLink(FIEFS, '#commands')).toBe('#commands');
+    });
+
+    it('leaves an empty target alone rather than linking to the repository root', () => {
+        expect(resolveGuideLink(FIEFS, '')).toBe('');
     });
 });

--- a/components/GuideMarkdown.tsx
+++ b/components/GuideMarkdown.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {Box, Link} from '@mui/material';
+import Markdown from 'markdown-to-jsx';
+import {resolveGuideLink} from '../utils/guides';
+
+// Themed styling for the rendered markdown elements (markdown-to-jsx emits plain
+// HTML tags, so these are descendant-selector rules rather than component props).
+const guideBodyStyle = {
+    '& h1': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.8rem', fontWeight: 700, mt: 4, mb: 1.5},
+    '& h2': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.4rem', fontWeight: 600, mt: 4, mb: 1.5},
+    '& h3': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.15rem', fontWeight: 600, mt: 3, mb: 1},
+    '& p': {mb: 2, lineHeight: 1.7},
+    '& ul, & ol': {pl: 3, mb: 2},
+    '& li': {mb: 0.5},
+    '& a': {color: 'primary.main'},
+    '& code': {
+        bgcolor: 'action.hover',
+        px: 0.6,
+        py: 0.2,
+        borderRadius: 0.5,
+        fontFamily: 'monospace',
+        fontSize: '0.9em',
+    },
+    '& pre': {
+        bgcolor: '#0d1117',
+        color: '#c9d1d9',
+        border: '1px solid',
+        borderColor: 'divider',
+        p: 2,
+        borderRadius: 2,
+        overflow: 'auto',
+    },
+    '& pre code': {bgcolor: 'transparent', p: 0, color: 'inherit', fontSize: '0.85rem'},
+    '& blockquote': {borderLeft: '4px solid', borderColor: 'divider', pl: 2, ml: 0, color: 'text.secondary'},
+    '& img': {maxWidth: '100%'},
+    '& table': {borderCollapse: 'collapse', width: '100%'},
+    '& th, & td': {border: '1px solid', borderColor: 'divider', p: 1, textAlign: 'left'},
+};
+
+interface GuideLinkProps {
+    // markdown-to-jsx passes through whatever the author wrote, so a malformed
+    // link can arrive without one.
+    href?: string;
+    // Supplied per-render through the override's `props`, since the repository a
+    // relative target resolves against differs per guide.
+    githubLink: string;
+    title?: string;
+    children?: React.ReactNode;
+}
+
+// Every link the guide body renders. A relative target is rewritten to point at
+// the repository the guide came from (see resolveGuideLink); anything that
+// leaves the site opens in a new tab with rel="noopener noreferrer", the way the
+// rest of the site's outbound links do. In-page anchors stay in the page.
+export const GuideLink: React.FC<GuideLinkProps> = ({href, githubLink, title, children}) => {
+    const target = resolveGuideLink(githubLink, href ?? '');
+    const staysOnPage = target === '' || target.startsWith('#');
+    return staysOnPage
+        ? <Link href={target} title={title}>{children}</Link>
+        : <Link href={target} title={title} target="_blank" rel="noopener noreferrer">{children}</Link>;
+};
+
+interface GuideMarkdownProps {
+    markdown: string;
+    // The plugin's repository, used to resolve the guide's relative links.
+    githubLink: string;
+}
+
+// Raw HTML is disabled for the same reason components/PluginVersionList.tsx
+// disables it: markdown-to-jsx parses it by default, and this body is whatever
+// currently sits in a plugin repository's USER_GUIDE.md rather than a file this
+// site controls. No catalogued guide uses raw HTML today, so nothing rendered
+// changes; the setting stops the two markdown renderers from disagreeing.
+const GuideMarkdown: React.FC<GuideMarkdownProps> = ({markdown, githubLink}) => (
+    <Box sx={guideBodyStyle}>
+        <Markdown
+            options={{
+                disableParsingRawHTML: true,
+                overrides: {a: {component: GuideLink, props: {githubLink}}},
+            }}
+        >
+            {markdown}
+        </Markdown>
+    </Box>
+);
+
+export default GuideMarkdown;

--- a/components/PluginVersionList.tsx
+++ b/components/PluginVersionList.tsx
@@ -58,9 +58,8 @@ const changelogStyle = {
 // Raw HTML is disabled deliberately. markdown-to-jsx parses it by default, and
 // these bodies are the first markdown on a resource page that this site does
 // not fetch from a repository file it controls — a mirrored release note is
-// whatever GitHub returned. The guide renderer's looser settings are safe only
-// because its markdown comes from trusted repositories; that argument does not
-// carry over, and reviews and comments will need this off anyway.
+// whatever GitHub returned. components/GuideMarkdown.tsx disables it for the
+// same reason, and reviews and comments will need this off too.
 const Changelog: React.FC<{markdown: string}> = ({markdown}) => (
     <Box sx={changelogStyle}>
         <Markdown options={{disableParsingRawHTML: true}}>{markdown}</Markdown>

--- a/pages/guides/[id].tsx
+++ b/pages/guides/[id].tsx
@@ -1,13 +1,13 @@
 import {Alert, Box, Button, Container, Typography} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import Markdown from 'markdown-to-jsx';
 import type {GetServerSideProps, NextPage} from 'next';
 import React from 'react';
 import TopBar from '../../components/TopBar';
 import Seo from '../../components/Seo';
 import SelfLoadingLikeButton from '../../components/SelfLoadingLikeButton';
 import BottomBar from '../../components/BottomBar';
+import GuideMarkdown from '../../components/GuideMarkdown';
 import {NextLinkComposed} from '../../components/NextLinkComposed';
 import {pageStyle, sectionHeaderStyle, containerPaddingStyle} from '../../styles/styles';
 import {userGuideUrl, userGuideRawUrl} from '../../utils/guides';
@@ -49,40 +49,6 @@ export const getServerSideProps: GetServerSideProps<GuidePageProps> = async ({pa
     return {props: {id, title: plugin.title, githubLink: plugin.githubLink, markdown}};
 };
 
-// Themed styling for the rendered markdown elements (markdown-to-jsx emits plain
-// HTML tags, so these are descendant-selector rules rather than component props).
-const guideBodyStyle = {
-    '& h1': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.8rem', fontWeight: 700, mt: 4, mb: 1.5},
-    '& h2': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.4rem', fontWeight: 600, mt: 4, mb: 1.5},
-    '& h3': {fontFamily: '"Space Grotesk", sans-serif', fontSize: '1.15rem', fontWeight: 600, mt: 3, mb: 1},
-    '& p': {mb: 2, lineHeight: 1.7},
-    '& ul, & ol': {pl: 3, mb: 2},
-    '& li': {mb: 0.5},
-    '& a': {color: 'primary.main'},
-    '& code': {
-        bgcolor: 'action.hover',
-        px: 0.6,
-        py: 0.2,
-        borderRadius: 0.5,
-        fontFamily: 'monospace',
-        fontSize: '0.9em',
-    },
-    '& pre': {
-        bgcolor: '#0d1117',
-        color: '#c9d1d9',
-        border: '1px solid',
-        borderColor: 'divider',
-        p: 2,
-        borderRadius: 2,
-        overflow: 'auto',
-    },
-    '& pre code': {bgcolor: 'transparent', p: 0, color: 'inherit', fontSize: '0.85rem'},
-    '& blockquote': {borderLeft: '4px solid', borderColor: 'divider', pl: 2, ml: 0, color: 'text.secondary'},
-    '& img': {maxWidth: '100%'},
-    '& table': {borderCollapse: 'collapse', width: '100%'},
-    '& th, & td': {border: '1px solid', borderColor: 'divider', p: 1, textAlign: 'left'},
-};
-
 const GuidePage: NextPage<GuidePageProps> = ({id, title, githubLink, markdown}) => (
     <Box sx={(theme) => pageStyle(theme)}>
         <Seo
@@ -106,9 +72,7 @@ const GuidePage: NextPage<GuidePageProps> = ({id, title, githubLink, markdown}) 
             </Box>
 
             {markdown ? (
-                <Box sx={guideBodyStyle}>
-                    <Markdown>{markdown}</Markdown>
-                </Box>
+                <GuideMarkdown markdown={markdown} githubLink={githubLink}/>
             ) : (
                 <Alert
                     severity="info"

--- a/utils/guides.ts
+++ b/utils/guides.ts
@@ -13,3 +13,27 @@ export const userGuideUrl = (githubLink: string): string =>
 // branch, so we don't need to know whether the repo uses main or master.
 export const userGuideRawUrl = (githubLink: string): string =>
     `${githubLink.replace(/\/+$/, '').replace('https://github.com/', 'https://raw.githubusercontent.com/')}/HEAD/USER_GUIDE.md`;
+
+// A link target that already names where it goes: an absolute URL (`https:`,
+// `mailto:`), a protocol-relative one (`//host/path`), or an in-page anchor
+// (`#commands`). Everything else in a USER_GUIDE.md is written for GitHub, where
+// it resolves against the repository.
+const isSelfContainedTarget = (href: string): boolean =>
+    href.startsWith('#') || href.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(href);
+
+// Rewrite a link found inside a fetched guide so it still goes where its author
+// meant. `[Commands](COMMANDS.md)` works on GitHub because the guide is read
+// from the repository; rendered at /guides/<id> the browser would resolve it to
+// /guides/COMMANDS.md and the site would answer 404. Relative targets are
+// therefore pointed back at the repository, on the same `blob/HEAD` default
+// branch userGuideUrl uses, with any `#fragment` carried along untouched.
+// Self-contained targets are returned unchanged.
+export const resolveGuideLink = (githubLink: string, href: string): string => {
+    if (href === '' || isSelfContainedTarget(href)) {
+        return href;
+    }
+    // `/docs/x.md` is repository-root-relative and `./x.md` is guide-relative;
+    // USER_GUIDE.md lives at the repository root, so both land in the same place.
+    const path = href.replace(/^\.?\//, '');
+    return `${githubLink.replace(/\/+$/, '')}/blob/HEAD/${path}`;
+};


### PR DESCRIPTION
## Summary

- **`/guides/<id>` turned eight of the sixteen guides' internal links into 404s.** A `USER_GUIDE.md` is written to be read in its repository, so `[Commands](COMMANDS.md)` resolves there against the repository. `pages/guides/[id].tsx` handed the fetched markdown to `<Markdown>` unchanged, `markdown-to-jsx` emitted the target verbatim, and the browser resolved it against the guide's own URL — `/guides/COMMANDS.md`, which the site answers with its 404 page. The Medieval Factions guide alone had four such links (`COMMANDS.md`, `CONFIG.md`, `FACTION_FLAGS.md`, `FAQ.md`).
- **New `resolveGuideLink` in `utils/guides.ts`** points a relative target back at the plugin's repository, on the same `blob/HEAD` default branch `userGuideUrl` already uses, carrying any `#fragment` along. An absolute URL, a protocol-relative one, and an in-page anchor are returned as written.
- **New `components/GuideMarkdown.tsx`** takes the rendering (and the style block) out of the page, mirroring the `Changelog` renderer in `components/PluginVersionList.tsx`. Links go through a `markdown-to-jsx` `overrides.a` component built on MUI's `Link`; anything leaving the site now opens in a new tab with `rel="noopener noreferrer"`, matching every other outbound link on the site, while an in-page anchor stays in the page.
- **Raw HTML parsing is disabled** in the guide renderer, as `PluginVersionList` already does for mirrored release notes. `RESOURCE_HUB.md` had flagged the gap: the setting was "safe only because the markdown comes from trusted repositories", which is a property of who writes the input rather than of the code. The guide body is fetched at request time from whatever currently sits on a plugin repository's default branch.
- **No rendered guide changes as a side effect.** All sixteen catalogued plugins' raw `USER_GUIDE.md` files were checked on 2026-08-15: none contains a raw HTML element, and none embeds an image (so image sources are deliberately out of scope).

## Test plan

- [x] `npm test` — 263 passing (was 247). Ten new cases for `resolveGuideLink` in `__tests__/guides.test.ts`, plus a new `__tests__/guideMarkdown.test.ts` that renders the component with `react-dom/server` — the same server-render path Next.js uses — and asserts the rewritten `href`, the per-repository resolution, the new-tab attributes, the untouched anchor, and that `<b>bold</b>` comes out escaped. No JSX, so the file stays `.ts` and is picked up by the existing `__tests__/**/*.test.ts` include without touching `vitest.config.ts`.
- [x] Regression evidence (Phase 4 stash-and-run) is recorded in the self-review comment below.
- [x] `npm run lint` — no ESLint warnings or errors.
- [x] `npm run build` — exit 0; `/guides/[id]` still builds as a server-rendered route.

## Deferred this cycle

The rest of the backlog was left alone, with reasons:

- **#271 and its phases (#274, #275, #276, #278), #167 and its phases (#192, #193, #194, #195, #196), #280, #281, #282** — epic feature work, each phase far past this loop's ~400-LOC scope ceiling, and most needing schema and API changes in `dpc-api` first. #276 additionally says of itself that it is worth doing last.
- **#162** — its remaining half (Minecraft-version compatibility) is subsumed by #276; the "latest version" half shipped in #262.
- **#87** — an admin editing UI for the catalogue, which `RESOURCE_HUB.md` sequences after the catalogue finishes moving into the database.
- **#24 / #142** — #142 describes a bug in the Discord ingestion from PR #141, which was never merged; `V11` dropped its orphaned table. Nothing to fix until #24 is revived, and #24 is itself a feature-sized piece of work.
- **#57** — asks for an nginx TLS proxy in `compose.yml`; production TLS is terminated by the gateway that fronts the deployment, so the premise needs a decision from the maintainer before any code is written.

Closes #296
Closes #297

*This pull request description was drafted by Claude on behalf of Daniel Stephenson.*